### PR TITLE
Split set_invited func, renamed some constants, renamed some functions

### DIFF
--- a/include/session/config/groups/members.h
+++ b/include/session/config/groups/members.h
@@ -8,7 +8,7 @@ extern "C" {
 #include "../profile_pic.h"
 #include "../util.h"
 
-enum groups_members_invite_status { INVITE_SENT = 1, INVITE_FAILED = 2, INVITE_NOT_SENT = 3 };
+enum groups_members_status { STATUS_SENT = 1, STATUS_FAILED = 2, STATUS_NOT_SENT = 3 };
 enum groups_members_remove_status { REMOVED_MEMBER = 1, REMOVED_MEMBER_AND_MESSAGES = 2 };
 
 /// A convenience status enum for the group member, this enum is returned by a function which
@@ -38,8 +38,8 @@ typedef struct config_group_member {
     user_profile_pic profile_pic;
 
     bool admin;
-    int invited;   // 0 == unset, INVITE_SENT = invited, INVITED_FAILED = invite failed to send,
-                   // INVITE_NOT_SENT = invite hasn't been sent yet
+    int invited;   // 0 == unset, STATUS_SENT = invited, STATUS_FAILED = invite failed to send,
+                   // STATUS_NOT_SENT = invite hasn't been sent yet
     int promoted;  // same value as `invited`, but for promotion-to-admin
     int removed;   // 0 == unset, REMOVED_MEMBER = removed, REMOVED_MEMBER_AND_MESSAGES = remove
                    // member and their messages

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -226,8 +226,7 @@ struct member {
         else if (removed_status > 0)
             return Status::removed_unknown;
 
-        // If the member is promoted then we assume they had accepted the invite and return the
-        // relevant promoted status
+        // If the member is promoted then we return the relevant promoted status
         if (admin) {
             if (promotion_status == STATUS_NOT_SENT)
                 return Status::promotion_not_sent;

--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -215,11 +215,11 @@ struct group_info : base_group_info {
     void into(struct ugroups_group_info& c) const;   // Into c struct
 
     /// Marks the group as kicked and clears auth_data & secret_key
-    void markKicked();
+    void mark_kicked();
 
-    /// Marks the group as reinvited (i.e. revert a `markKicked` call)
+    /// Marks the group as reinvited (i.e. revert a `mark_kicked` call)
     /// Note: this only works when the group was not permanently deleted.
-    void markInvited();
+    void mark_invited();
 
     /// Returns true if we don't have room access, i.e. we were kicked and both secretkey and
     /// auth_data are empty.
@@ -227,10 +227,10 @@ struct group_info : base_group_info {
 
     /// Mark the group as permanently destroyed and clears auth_data & secret_key. This cannot be
     /// unset once set.
-    void markDestroyed();
+    void mark_destroyed();
 
     /// Returns true if the group was destroyed by one of the admin.
-    bool isDestroyed() const;
+    bool is_destroyed() const;
 
   private:
     friend class UserGroups;

--- a/src/config/groups/members.cpp
+++ b/src/config/groups/members.cpp
@@ -144,11 +144,11 @@ member::member(const config_group_member& m) : session_id{m.session_id, 66} {
     }
     admin = m.admin;
     invite_status =
-            (m.invited == INVITE_SENT || m.invited == INVITE_FAILED || m.invited == INVITE_NOT_SENT)
+            (m.invited == STATUS_SENT || m.invited == STATUS_FAILED || m.invited == STATUS_NOT_SENT)
                     ? m.invited
                     : 0;
-    promotion_status = (m.promoted == INVITE_SENT || m.promoted == INVITE_FAILED ||
-                        m.invited == INVITE_NOT_SENT)
+    promotion_status = (m.promoted == STATUS_SENT || m.promoted == STATUS_FAILED ||
+                        m.invited == STATUS_NOT_SENT)
                              ? m.promoted
                              : 0;
     removed_status = (m.removed == REMOVED_MEMBER || m.removed == REMOVED_MEMBER_AND_MESSAGES)
@@ -167,9 +167,9 @@ void member::into(config_group_member& m) const {
         copy_c_str(m.profile_pic.url, "");
     }
     m.admin = admin;
-    static_assert(groups::INVITE_SENT == ::INVITE_SENT);
-    static_assert(groups::INVITE_FAILED == ::INVITE_FAILED);
-    static_assert(groups::INVITE_NOT_SENT == ::INVITE_NOT_SENT);
+    static_assert(groups::STATUS_SENT == ::STATUS_SENT);
+    static_assert(groups::STATUS_FAILED == ::STATUS_FAILED);
+    static_assert(groups::STATUS_NOT_SENT == ::STATUS_NOT_SENT);
     static_assert(
             static_cast<int>(groups::member::Status::invite_unknown) ==
             ::GROUP_MEMBER_STATUS_INVITE_UNKNOWN);
@@ -284,7 +284,7 @@ LIBSESSION_C_API GROUP_MEMBER_STATUS group_member_status(const config_group_memb
 LIBSESSION_C_API bool groups_members_set_invite_sent(config_object* conf, const char* session_id) {
     try {
         if (auto m = unbox<groups::Members>(conf)->get(session_id)) {
-            m->set_invited();
+            m->set_invite_sent();
             unbox<groups::Members>(conf)->set(*m);
             return true;
         }
@@ -298,7 +298,7 @@ LIBSESSION_C_API bool groups_members_set_invite_failed(
         config_object* conf, const char* session_id) {
     try {
         if (auto m = unbox<groups::Members>(conf)->get(session_id)) {
-            m->set_invited(/*failed*/ true);
+            m->set_invite_failed();
             unbox<groups::Members>(conf)->set(*m);
             return true;
         }
@@ -312,7 +312,7 @@ LIBSESSION_C_API bool groups_members_set_invite_accepted(
         config_object* conf, const char* session_id) {
     try {
         if (auto m = unbox<groups::Members>(conf)->get(session_id)) {
-            m->set_accepted();
+            m->set_invite_accepted();
             unbox<groups::Members>(conf)->set(*m);
             return true;
         }

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -249,7 +249,7 @@ void group_info::load(const dict& info_dict) {
     removed_status = maybe_int(info_dict, "r").value_or(0);
 }
 
-void group_info::markKicked() {
+void group_info::mark_kicked() {
     secretkey.clear();
     auth_data.clear();
     if (removed_status != GROUP_DESTROYED) {
@@ -257,7 +257,7 @@ void group_info::markKicked() {
     }
 }
 
-void group_info::markInvited() {
+void group_info::mark_invited() {
     if (removed_status == KICKED_FROM_GROUP) {
         removed_status = NOT_REMOVED;
     }
@@ -267,13 +267,13 @@ bool group_info::kicked() const {
     return removed_status == KICKED_FROM_GROUP;
 }
 
-void group_info::markDestroyed() {
+void group_info::mark_destroyed() {
     secretkey.clear();
     auth_data.clear();
     removed_status = GROUP_DESTROYED;
 }
 
-bool group_info::isDestroyed() const {
+bool group_info::is_destroyed() const {
     return removed_status == GROUP_DESTROYED;
 }
 

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -542,17 +542,17 @@ TEST_CASE("User Groups -- (non-legacy) groups", "[config][groups][new]") {
     c3b->auth_data.resize(100);
     CHECK_FALSE(c3b->kicked());
     // mark ourselves as kicked
-    c3b->markKicked();
+    c3b->mark_kicked();
     CHECK(c3b->kicked());
     CHECK(c3b->secretkey.empty());
     CHECK(c3b->auth_data.empty());
     // add a non empty auth_data, and reset the removed_status: we shouldn't be kicked anymore
     c3b->auth_data.resize(100);
-    c3b->markInvited();
+    c3b->mark_invited();
     CHECK_FALSE(c3b->kicked());
     // we are not kicked, mark the group as destroyed
-    c3b->markDestroyed();
-    CHECK(c3b->isDestroyed());
+    c3b->mark_destroyed();
+    CHECK(c3b->is_destroyed());
     // the group was destroyed, so we are not `kicked` from it.
     // We keep the states separate as `kicked` is not permanent but `destroyed` is.
     CHECK_FALSE(c3b->kicked());
@@ -562,14 +562,14 @@ TEST_CASE("User Groups -- (non-legacy) groups", "[config][groups][new]") {
     c3b->removed_status = 0;
     CHECK_FALSE(c3b->kicked());
     // kicked->destroyed works
-    c3b->markKicked();
+    c3b->mark_kicked();
     CHECK(c3b->kicked());
-    c3b->markDestroyed();
-    CHECK(c3b->isDestroyed());
+    c3b->mark_destroyed();
+    CHECK(c3b->is_destroyed());
     // destroyed->kicked doesn't work
-    c3b->markKicked();
+    c3b->mark_kicked();
     CHECK_FALSE(c3b->kicked());
-    CHECK(c3b->isDestroyed());
+    CHECK(c3b->is_destroyed());
 
     auto gg = groups.get_or_construct_group(
             "030303030303030303030303030303030303030303030303030303030303030303");

--- a/tests/test_group_keys.cpp
+++ b/tests/test_group_keys.cpp
@@ -358,7 +358,7 @@ TEST_CASE("Group Keys - C++ API", "[config][groups][keys][cpp]") {
         auto& m = members.emplace_back(member_seeds[4 + i], false, group_pk.data(), std::nullopt);
 
         auto memb = admin1.members.get_or_construct(m.session_id);
-        memb.set_invited();
+        memb.set_invite_sent();
         memb.supplement = true;
         memb.name = i == 0 ? "fred" : "JOHN";
         admin1.members.set(memb);

--- a/tests/test_group_members.cpp
+++ b/tests/test_group_members.cpp
@@ -152,14 +152,14 @@ TEST_CASE("Group Members", "[config][groups][members]") {
     }
     for (int i = 50; i < 55; i++) {
         auto m = gmem2.get_or_construct(sids[i]);
-        m.set_invited();  // failed invite
+        m.set_invite_sent();
         if (i % 2)
             m.supplement = true;
         gmem2.set(m);
     }
     for (int i = 55; i < 58; i++) {
         auto m = gmem2.get_or_construct(sids[i]);
-        m.set_invited(true);
+        m.set_invite_failed();
         if (i % 2)
             m.supplement = true;
         gmem2.set(m);
@@ -231,9 +231,9 @@ TEST_CASE("Group Members", "[config][groups][members]") {
         else if (i >= 50 && i <= 56) {
             auto m = gmem1.get(sids[i]).value();
             if (i >= 55)
-                m.set_invited();
+                m.set_invite_sent();
             else
-                m.set_accepted();
+                m.set_invite_accepted();
             gmem1.set(m);
         } else if (i == 58) {
             auto m = gmem1.get(sids[i]).value();


### PR DESCRIPTION
- Split the `set_invited` function into `set_invite_sent` and `set_invite_failed` to be clearer and more consistent with the promotion functions
- Renamed the `INVITE_{status}` constants to be `STATUS_{status}` as they are used for both invite and promotion statuses
- Renamed some UserGroups functions to be snake case