### PR TITLE
Add implicit group pubkey to group signature

### DIFF
--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1205,19 +1205,35 @@ ustring Keys::encrypt_message(ustring_view plaintext, bool compress, size_t padd
             compress = false;
         }
     }
+    // `plaintext` is now pointing at either the original input data, or at `_compressed` local
+    // variable containing the compressed form of that data.
 
     oxenc::bt_dict_producer dict{};
-    dict.append(
-            "", 1);  // encoded data version (bump this if something changes in an incompatible way)
-    dict.append("a", std::string_view{from_unsigned(user_ed25519_sk.data()) + 32, 32});
 
-    std::array<unsigned char, 64> signature;
-    crypto_sign_ed25519_detached(
-            signature.data(), nullptr, plaintext.data(), plaintext.size(), user_ed25519_sk.data());
+    // encoded data version (bump this if something changes in an incompatible way)
+    dict.append("", 1);
+
+    // Sender ed pubkey, by which the message can be validated.  Note that there are *two*
+    // components to this validation: first the regular signature validation of the "s" signature we
+    // add below, but then also validation that this Ed25519 converts to the Session ID of the
+    // claimed sender of the message inside the encoded message data.
+    dict.append("a", std::string_view{from_unsigned(user_ed25519_sk.data()) + 32, 32});
 
     if (!compress)
         dict.append("d", from_unsigned_sv(plaintext));
 
+    // We sign `plaintext || group_ed25519_pubkey` rather than just `plaintext` so that if this
+    // encrypted data will not validate if cross-posted to any other group.  We don't actually
+    // include the pubkey alongside, because that is implicitly known by the group members that
+    // receive it.
+    assert(_sign_pk);
+    std::vector<unsigned char> to_sign(plaintext.size() + _sign_pk->size());
+    std::memcpy(to_sign.data(), plaintext.data(), plaintext.size());
+    std::memcpy(to_sign.data() + plaintext.size(), _sign_pk->data(), _sign_pk->size());
+
+    std::array<unsigned char, 64> signature;
+    crypto_sign_ed25519_detached(
+            signature.data(), nullptr, to_sign.data(), to_sign.size(), user_ed25519_sk.data());
     dict.append("s", from_unsigned_sv(signature));
 
     if (compress)
@@ -1350,8 +1366,14 @@ std::pair<std::string, ustring> Keys::decrypt_message(ustring_view ciphertext) c
     } else if (raw_data.empty())
         throw std::runtime_error{"message must contain compressed (z) or uncompressed (d) data"};
 
+    // The value we verify is the raw data *followed by* the group Ed25519 pubkey.  (See the comment
+    // in encrypt_message).
+    assert(_sign_pk);
+    std::vector<unsigned char> to_verify(raw_data.size() + _sign_pk->size());
+    std::memcpy(to_verify.data(), raw_data.data(), raw_data.size());
+    std::memcpy(to_verify.data() + raw_data.size(), _sign_pk->data(), _sign_pk->size());
     if (0 != crypto_sign_ed25519_verify_detached(
-                     ed_sig.data(), raw_data.data(), raw_data.size(), ed_pk.data()))
+                     ed_sig.data(), to_verify.data(), to_verify.size(), ed_pk.data()))
         throw std::runtime_error{"message signature failed validation"};
 
     if (compressed) {

--- a/src/session_encrypt.cpp
+++ b/src/session_encrypt.cpp
@@ -49,7 +49,7 @@ ustring sign_for_recipient(
     ustring buf;
     buf.reserve(message.size() + 96);  // 32+32 now, but 32+64 when we reuse it for the sealed box
     buf += message;
-    buf += ed25519_privkey.substr(32);
+    buf += ed25519_privkey.substr(32);  // [32:] of a libsodium full seed value is the *pubkey*
     buf += recipient_pubkey;
 
     uc64 sig;


### PR DESCRIPTION
A group message doesn't explicitly contain the group that the message was written for, which allows cross-posting of messages.  This appends the group pubkey to the signature and verification to eliminate this possibility.

(It is worth noting that this same implicit recipient pubkey is already present in 1-1 message signatures, and that the update here conceptually matches the solution that has been long used in 1-1 messages to prevent any similar replay of DMs).

The idea here is that if A and B are each in groups G and H, and A sends a message M to group G then B could take M, decrypt it, leave the signature intact, and then reencrypt it for group H and send it to group H.  Members of group H would then see a message that is accepted as coming from A, even though A did not send such a message to H.

This commit solves it by reworking our group message encryption to include the implicit pubkey in the signature.  That is, we were previously signing/verifying just `plaintext` (the blob of data containing the encoded message data), but now we sign/verify `plaintext || group_ed25519_pubkey`.

It is "implicit" in that we don't include that group pubkey as part of the message, because any legitimate recipient of the message already knows the group it was received it, and so if they receive it in a different group the value they verify `plaintext || different_pubkey` isn't the value that was signed, `plaintext || original_pubkey`, and so will fail verification of any clients that receive it in the wrong group.

(@mpretty-cyro - this commit will cherry-pick cleanly into the libquic branch for iOS)