### PR TITLE
Tweaked the behaviour of curr_hash to always represent the swarm config

### DIFF
--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -157,9 +157,8 @@ class ConfigBase : public ConfigSig {
     using Key = std::array<unsigned char, KEY_SIZE>;
     sodium_vector<Key> _keys;
 
-    // Contains the current active message hash, as fed into us in `confirm_pushed()`.  Empty if we
-    // don't know it yet.  When we dirty the config this value gets moved into `old_hashes_` to be
-    // removed by the next push.
+    // Contains the current active message hash, as fed into us in `confirm_pushed()` or after a
+    // merge results in a clean state.  Empty if we don't know it yet.
     std::string _curr_hash;
 
     // Contains obsolete known message hashes that are obsoleted by the most recent merge or push;

--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -34,10 +34,6 @@ void ConfigBase::set_state(ConfigState s) {
     if (s == ConfigState::Dirty && is_readonly())
         throw std::runtime_error{"Unable to make changes to a read-only config object"};
 
-    if (_state == ConfigState::Clean && !_curr_hash.empty()) {
-        _old_hashes.insert(std::move(_curr_hash));
-        _curr_hash.clear();
-    }
     _state = s;
     _needs_dump = true;
 }
@@ -234,12 +230,12 @@ std::vector<std::string> ConfigBase::_merge(
     // - confs that failed to parse (we can't understand them, so leave them behind as they may be
     //   some future message).
     std::optional<size_t> superconf = new_conf->unmerged_index();  // nullopt if we had to merge
-    std::string_view superconf_hash =
-            superconf && *superconf < all_hashes.size() ? all_hashes[*superconf] : "";
+    std::string_view updated_curr_hash =
+            superconf && *superconf < all_hashes.size() ? all_hashes[*superconf] : _curr_hash;
 
     for (size_t i = 0; i < all_hashes.size(); i++) {
         if (i != superconf && !bad_confs.count(i) && !all_hashes[i].empty() &&
-            superconf_hash != all_hashes[i])
+            updated_curr_hash != all_hashes[i])
             _old_hashes.emplace(all_hashes[i]);
     }
 
@@ -356,6 +352,11 @@ void ConfigBase::confirm_pushed(seqno_t seqno, std::string msg_hash) {
     // caller got the last data to push, and so we don't care about this confirmation.
     if (_state == ConfigState::Waiting && seqno == _config->seqno()) {
         set_state(ConfigState::Clean);
+
+        if (!_curr_hash.empty() && _curr_hash != msg_hash) {
+            _old_hashes.insert(std::move(_curr_hash));
+        }
+
         _curr_hash = std::move(msg_hash);
     }
 }

--- a/tests/test_bugs.cpp
+++ b/tests/test_bugs.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Dirty/Mutable test case", "[config][dirty]") {
     auto [seqno, data, obsolete] = c1.push();
     CHECK(obsolete == std::vector<std::string>{});
     c1.confirm_pushed(seqno, "fakehash1");
+    CHECK(c1.current_hashes() == std::vector{{"fakehash1"s}});
 
     session::config::Contacts c2{ustring_view{seed}, c1.dump()};
     session::config::Contacts c3{ustring_view{seed}, c1.dump()};
@@ -46,13 +47,14 @@ TEST_CASE("Dirty/Mutable test case", "[config][dirty]") {
     auto [seqno3, data3, obs3] = c3.push();
 
     REQUIRE(seqno2 == 2);
-    CHECK(obs2 == std::vector{"fakehash1"s});
+    CHECK(obs2.empty());
     REQUIRE(seqno3 == 2);
-    CHECK(obs2 == std::vector{"fakehash1"s});
+    CHECK(obs3.empty());
 
     auto r = c1.merge(std::vector<std::pair<std::string, ustring_view>>{
             {{"fakehash2", data2}, {"fakehash3", data3}}});
     CHECK(r == std::vector{{"fakehash2"s, "fakehash3"s}});
+    CHECK(c1.current_hashes() == std::vector{{"fakehash1"s}});
     CHECK(c1.needs_dump());
     CHECK(c1.needs_push());  // because we have the merge conflict to push
     CHECK(c1.is_dirty());
@@ -67,5 +69,12 @@ TEST_CASE("Dirty/Mutable test case", "[config][dirty]") {
     CHECK(!c1.is_clean());  // not clean yet because we haven't confirmed
 
     CHECK(seqno4 == 3);  // The merge *and* change should go into the same message update/seqno
-    CHECK(as_set(obs4) == make_set("fakehash1"s, "fakehash2"s, "fakehash3"s));
+    CHECK(c1.current_hashes() == std::vector{{"fakehash1"s}});  // because haven't confirmed yet
+    CHECK(as_set(obs4) == make_set("fakehash2"s, "fakehash3"s));
+
+    c1.confirm_pushed(seqno4, "fakehash4");
+    auto obs5 = c1.old_hashes();
+    CHECK(!c1.is_dirty());
+    CHECK(c1.is_clean());
+    CHECK(as_set(obs5) == make_set("fakehash1"s));
 }

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -129,7 +129,9 @@ TEST_CASE("Contacts", "[config][contacts]") {
     std::vector<std::pair<std::string, ustring_view>> merge_configs;
     merge_configs.emplace_back("fakehash2", to_push);
     contacts.merge(merge_configs);
+    CHECK(obs.empty());  // not confirmed yet
     contacts2.confirm_pushed(seqno, "fakehash2");
+    CHECK(as_set(contacts2.old_hashes()) == make_set("fakehash1"s));
 
     CHECK_FALSE(contacts.needs_push());
     CHECK(std::get<seqno_t>(contacts.push()) == seqno);
@@ -179,11 +181,15 @@ TEST_CASE("Contacts", "[config][contacts]") {
 
     CHECK(seqno == seqno2);
     CHECK(to_push != to_push2);
-    CHECK(as_set(obs) == make_set("fakehash2"s));
-    CHECK(as_set(obs2) == make_set("fakehash2"s));
+    CHECK(obs.empty());   // not confirmed yet
+    CHECK(obs2.empty());  // not confirmed yet
+    CHECK(as_set(contacts.current_hashes()) == make_set("fakehash2"s));
+    CHECK(as_set(contacts2.current_hashes()) == make_set("fakehash2"s));
 
     contacts.confirm_pushed(seqno, "fakehash3a");
     contacts2.confirm_pushed(seqno2, "fakehash3b");
+    CHECK(as_set(contacts.old_hashes()) == make_set("fakehash2"s));   // confirmed
+    CHECK(as_set(contacts2.old_hashes()) == make_set("fakehash2"s));  // confirmed
 
     merge_configs.clear();
     merge_configs.emplace_back("fakehash3b", to_push2);
@@ -203,11 +209,13 @@ TEST_CASE("Contacts", "[config][contacts]") {
     // encryption in the middle of the protobuf wrapping).
     // TODO: reenable once protobuf isn't always-on.
     // CHECK(printable(to_push) == printable(to_push2));
-    CHECK(as_set(obs) == make_set("fakehash3a"s, "fakehash3b"));
-    CHECK(as_set(obs2) == make_set("fakehash3a"s, "fakehash3b"));
+    CHECK(as_set(obs) == make_set("fakehash3b"s));   // not confirmed yet
+    CHECK(as_set(obs2) == make_set("fakehash3a"s));  // not confirmed yet
 
     contacts.confirm_pushed(seqno, "fakehash4");
     contacts2.confirm_pushed(seqno2, "fakehash4");
+    CHECK(as_set(contacts.old_hashes()) == make_set("fakehash3a"s));
+    CHECK(as_set(contacts2.old_hashes()) == make_set("fakehash3b"s));
 
     CHECK_FALSE(contacts.needs_push());
     CHECK_FALSE(contacts2.needs_push());
@@ -356,11 +364,13 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK(accepted->value[0] == "fakehash2"sv);
     free(accepted);
 
+    CHECK(to_push->obsolete_len == 0);
     config_confirm_pushed(conf2, to_push->seqno, "fakehash2");
 
-    REQUIRE(to_push->obsolete_len > 0);
-    CHECK(to_push->obsolete_len == 1);
-    CHECK(to_push->obsolete[0] == "fakehash1"sv);
+    auto old_hashes = config_old_hashes(conf2);
+    REQUIRE(old_hashes->len > 0);
+    CHECK(old_hashes->len == 1);
+    CHECK(old_hashes->value[0] == "fakehash1"sv);
     free(to_push);
 
     // Iterate through and make sure we got everything we expected

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -298,14 +298,15 @@ TEST_CASE("User Groups", "[config][groups]") {
 
     CHECK(g2.needs_push());
     CHECK(g2.needs_dump());
-    CHECK(g2.current_hashes().empty());
+    CHECK(g2.current_hashes() == std::vector{"fakehash1"s});
     std::tie(seqno, to_push, obs) = g2.push();
-    CHECK(g2.current_hashes().empty());
+    CHECK(obs.empty());
+    CHECK(g2.current_hashes() == std::vector{"fakehash1"s});
     auto to_push2 = to_push;
     CHECK(seqno == 2);
     g2.confirm_pushed(seqno, "fakehash2");
     CHECK(g2.current_hashes() == std::vector{{"fakehash2"s}});
-    CHECK(as_set(obs) == make_set("fakehash1"s));
+    CHECK(as_set(g2.old_hashes()) == make_set("fakehash1"s));
     g2.dump();
 
     CHECK_FALSE(g2.needs_push());
@@ -348,11 +349,12 @@ TEST_CASE("User Groups", "[config][groups]") {
     g2.erase_community("http://exAMple.ORG:5678/", "sudokuROOM");
 
     std::tie(seqno, to_push, obs) = g2.push();
+    CHECK(obs.empty());
     g2.confirm_pushed(seqno, "fakehash3");
     auto to_push3 = to_push;
 
     CHECK(seqno == 3);
-    CHECK(as_set(obs) == make_set("fakehash2"s));
+    CHECK(as_set(g2.old_hashes()) == make_set("fakehash2"s));
     CHECK(g2.current_hashes() == std::vector{{"fakehash3"s}});
 
     to_merge.clear();
@@ -378,9 +380,10 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(groups.size_groups() == 1);
 
     std::tie(seqno, to_push, obs) = groups.push();
+    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2"));  // haven't confirmed
     groups.confirm_pushed(seqno, "fakehash4");
     CHECK(seqno == 4);
-    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2", "fakehash3"));
+    CHECK(as_set(groups.old_hashes()) == make_set("fakehash3"s));  // push confirmed
 
     to_merge.clear();
     // Load some obsolete ones in just to check that they get immediately obsoleted

--- a/tests/test_group_info.cpp
+++ b/tests/test_group_info.cpp
@@ -83,9 +83,10 @@ TEST_CASE("Group Info settings", "[config][groups][info]") {
     auto [s2, p2, o2] = ginfo2.push();
     CHECK(s2 == 2);
     CHECK(p2.size() == 512);
-    CHECK(o2 == std::vector{"fakehash1"s});
+    CHECK(o2.empty());
 
     ginfo2.confirm_pushed(s2, "fakehash2");
+    CHECK(ginfo2.old_hashes() == std::vector{"fakehash1"s});
 
     ginfo1.set_name("Better name!");
 
@@ -352,7 +353,10 @@ TEST_CASE("Verify-only Group Info", "[config][groups][verify-only]") {
     auto [s7, t7, o7] = ginfo_rw3.push();
     CHECK(s7 == s6 + 1);
     CHECK(t7 != t6);
-    CHECK(o7 == std::vector{{"fakehash23"s}});
+    CHECK(o7.empty());
+
+    ginfo_rw3.confirm_pushed(s7, "fakehash24");
+    CHECK(ginfo_rw3.old_hashes() == std::vector{{"fakehash23"s}});
 
     merge_configs.clear();
     merge_configs.emplace_back("fakehash7", t7);


### PR DESCRIPTION
Changing the behaviour of `_curr_hash` slightly to represent the hash of the config message which is on the swarm instead of representing the "latest config hash" (which would automatically be cleared when in a "Dirty" state)

This change prevents a situation where updating a config locally into the same state that a config on the swarm is in results in the `_curr_hash` being added to `_old_hashes` (this would happen because `dirty()` gets called when making a local change which clears the `_curr_hash` value, then when merging we wouldn't be able to prevent adding `_curr_hash` from `_old_hashes` because we no longer knew what it was)

**Note:**
This change has a negative side effect where we will no longer delete the old `_curr_hash` from the swarm after a merge that results in a config change (resulting in both the "current" and "last" config messages remaining on the swarm)

There will be a separate PR to tweak the behaviour of `_old_hashes` (to prevent remove it's auto-clear logic) which adds the ability for clients to confirm the deletion (or absence) of hashes from the swarm. The main reason for this change is to help minimise the effect of clients misusing the functions, increase the chance clients properly clean up their swarms, and allow clients to better handle situations where network requests fail.

The assumption is that clients will add new logic where they delete `old_hashes` even when `needs_push` is `false` (resulting in the swarm being cleaned up correctly, but an extra network request than what we originally needed)

Have opened #30 for the manual hash deletion logic