### PR TITLE
Manual hash deletion

### DIFF
--- a/include/session/config/base.h
+++ b/include/session/config/base.h
@@ -180,6 +180,18 @@ LIBSESSION_EXPORT config_push_data* config_push(config_object* conf);
 LIBSESSION_EXPORT void config_confirm_pushed(
         config_object* conf, seqno_t seqno, const char* msg_hash);
 
+/// API: base/config_confirm_deleted
+///
+/// Reports that hashes obtained from `config_push` or `old_hashes` have been successfully deleted
+/// on the server.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to config_object object
+/// - `msg_hash` -- [in] Array of null-terminated C strings for the hashes that were deleted
+/// - `msg_hash_len` -- [in] Number of values provided in `msg_hash`
+LIBSESSION_EXPORT void config_confirm_deleted(
+        config_object* conf, const char** msg_hash, size_t msg_hash_len);
+
 /// API: base/config_dump
 ///
 /// Returns a binary dump of the current state of the config object.  This dump can be used to

--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -1084,6 +1084,17 @@ class ConfigBase : public ConfigSig {
     /// - `msg_hash` -- message hash that was pushed
     virtual void confirm_pushed(seqno_t seqno, std::string msg_hash);
 
+    /// API: base/ConfigBase::confirm_deleted
+    ///
+    /// Should be called after the obsolete hash deletion is confirmed by the storage server swarm
+    /// to let the object know it can stop tracking those old hashes.
+    ///
+    /// NB: If `needs_push` is `true` then _old_hashes will contain the hash of the current config message on the swarm so the deletion should only be triggered after a successful push request.
+    ///
+    /// Inputs:
+    /// - `hashes` -- message hashes that were deleted
+    virtual void confirm_deleted(const std::vector<std::string> hashes);
+
     /// API: base/ConfigBase::dump
     ///
     /// Returns a dump of the current state for storage in the database; this value would get passed

--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -290,11 +290,8 @@ std::vector<std::string> ConfigBase::current_hashes() const {
 
 std::vector<std::string> ConfigBase::old_hashes() {
     std::vector<std::string> hashes;
-    if (!is_dirty()) {
-        for (auto& old : _old_hashes)
-            hashes.push_back(std::move(old));
-        _old_hashes.clear();
-    }
+    for (auto& old : _old_hashes)
+        hashes.push_back(std::move(old));
 
     return hashes;
 }
@@ -346,7 +343,6 @@ std::tuple<seqno_t, ustring, std::vector<std::string>> ConfigBase::push() {
     if (!is_readonly())
         for (auto& old : _old_hashes)
             obs.push_back(std::move(old));
-    _old_hashes.clear();
 
     return ret;
 }
@@ -358,6 +354,12 @@ void ConfigBase::confirm_pushed(seqno_t seqno, std::string msg_hash) {
         set_state(ConfigState::Clean);
         _curr_hash = std::move(msg_hash);
     }
+}
+
+void ConfigBase::confirm_deleted(const std::vector<std::string> hashes) {
+    for (auto& old : hashes)
+        if (auto it = _old_hashes.find(old); it != _old_hashes.end())
+            _old_hashes.erase(it);
 }
 
 ustring ConfigBase::dump() {
@@ -730,6 +732,17 @@ LIBSESSION_EXPORT config_push_data* config_push(config_object* conf) {
 LIBSESSION_EXPORT void config_confirm_pushed(
         config_object* conf, seqno_t seqno, const char* msg_hash) {
     unbox(conf)->confirm_pushed(seqno, msg_hash);
+}
+
+LIBSESSION_EXPORT void config_confirm_deleted(
+        config_object* conf, const char** msg_hash, size_t msh_hash_len) {
+    std::vector<std::string> hashes;
+    hashes.reserve(msh_hash_len);
+
+    for (auto i = 0; i < msh_hash_len; ++i)
+        hashes.push_back(msg_hash[i]);
+
+    unbox(conf)->confirm_deleted(hashes);
 }
 
 LIBSESSION_EXPORT bool config_dump(config_object* conf, unsigned char** out, size_t* outlen) {

--- a/tests/test_bugs.cpp
+++ b/tests/test_bugs.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Dirty/Mutable test case", "[config][dirty]") {
     auto [seqno, data, obsolete] = c1.push();
     CHECK(obsolete == std::vector<std::string>{});
     c1.confirm_pushed(seqno, "fakehash1");
+    CHECK(c1.current_hashes() == std::vector{{"fakehash1"s}});
 
     session::config::Contacts c2{ustring_view{seed}, c1.dump()};
     session::config::Contacts c3{ustring_view{seed}, c1.dump()};
@@ -68,4 +69,12 @@ TEST_CASE("Dirty/Mutable test case", "[config][dirty]") {
 
     CHECK(seqno4 == 3);  // The merge *and* change should go into the same message update/seqno
     CHECK(as_set(obs4) == make_set("fakehash1"s, "fakehash2"s, "fakehash3"s));
+
+    c1.confirm_pushed(seqno4, "fakehash4");
+    auto obs5 = c1.old_hashes();
+    CHECK(!c1.is_dirty());
+    CHECK(c1.is_clean());
+    CHECK(as_set(obs5) == make_set("fakehash1"s, "fakehash2"s, "fakehash3"s));
+    c1.confirm_deleted({"fakehash1"s, "fakehash2"s, "fakehash3"s});
+    CHECK(c1.old_hashes().empty());
 }

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -130,6 +130,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     merge_configs.emplace_back("fakehash2", to_push);
     contacts.merge(merge_configs);
     contacts2.confirm_pushed(seqno, "fakehash2");
+    CHECK(as_set(contacts2.old_hashes()) == make_set("fakehash1"s));
 
     CHECK_FALSE(contacts.needs_push());
     CHECK(std::get<seqno_t>(contacts.push()) == seqno);
@@ -179,11 +180,19 @@ TEST_CASE("Contacts", "[config][contacts]") {
 
     CHECK(seqno == seqno2);
     CHECK(to_push != to_push2);
-    CHECK(as_set(obs) == make_set("fakehash2"s));
-    CHECK(as_set(obs2) == make_set("fakehash2"s));
+    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2"s));
+    CHECK(as_set(obs2) == make_set("fakehash1"s, "fakehash2"s));
+    CHECK(contacts.current_hashes().empty());
+    CHECK(contacts2.current_hashes().empty());
 
     contacts.confirm_pushed(seqno, "fakehash3a");
     contacts2.confirm_pushed(seqno2, "fakehash3b");
+    CHECK(as_set(contacts.old_hashes()) == make_set("fakehash1"s, "fakehash2"s));
+    CHECK(as_set(contacts2.old_hashes()) == make_set("fakehash1"s, "fakehash2"s));
+    contacts.confirm_deleted({"fakehash1"s, "fakehash2"s});
+    contacts2.confirm_deleted({"fakehash1"s, "fakehash2"s});
+    CHECK(contacts.old_hashes().empty());
+    CHECK(contacts2.old_hashes().empty());
 
     merge_configs.clear();
     merge_configs.emplace_back("fakehash3b", to_push2);
@@ -362,6 +371,12 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK(to_push->obsolete_len == 1);
     CHECK(to_push->obsolete[0] == "fakehash1"sv);
     free(to_push);
+
+    const char* removed_hash[1];
+    removed_hash[0] = "fakehash1";
+    config_confirm_deleted(conf2, removed_hash, 1);
+    auto old_hashes2 = config_old_hashes(conf2);
+    CHECK(old_hashes2->len == 0);
 
     // Iterate through and make sure we got everything we expected
     std::vector<std::string> session_ids;

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -305,7 +305,7 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(seqno == 2);
     g2.confirm_pushed(seqno, "fakehash2");
     CHECK(g2.current_hashes() == std::vector{{"fakehash2"s}});
-    CHECK(as_set(obs) == make_set("fakehash1"s));
+    CHECK(as_set(g2.old_hashes()) == make_set("fakehash1"s));
     g2.dump();
 
     CHECK_FALSE(g2.needs_push());
@@ -348,12 +348,15 @@ TEST_CASE("User Groups", "[config][groups]") {
     g2.erase_community("http://exAMple.ORG:5678/", "sudokuROOM");
 
     std::tie(seqno, to_push, obs) = g2.push();
+    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2"s));
     g2.confirm_pushed(seqno, "fakehash3");
     auto to_push3 = to_push;
 
     CHECK(seqno == 3);
-    CHECK(as_set(obs) == make_set("fakehash2"s));
+    CHECK(as_set(g2.old_hashes()) == make_set("fakehash1"s, "fakehash2"s));
     CHECK(g2.current_hashes() == std::vector{{"fakehash3"s}});
+    g2.confirm_deleted({"fakehash1"s, "fakehash2"s});
+    CHECK(g2.old_hashes().empty());
 
     to_merge.clear();
     to_merge.emplace_back("fakehash3", to_push);
@@ -378,9 +381,13 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(groups.size_groups() == 1);
 
     std::tie(seqno, to_push, obs) = groups.push();
+    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2"s, "fakehash3"s));  // haven't confirmed
     groups.confirm_pushed(seqno, "fakehash4");
     CHECK(seqno == 4);
-    CHECK(as_set(obs) == make_set("fakehash1"s, "fakehash2", "fakehash3"));
+    CHECK(as_set(groups.old_hashes()) ==
+          make_set("fakehash1"s, "fakehash2"s, "fakehash3"s));  // push confirmed
+    groups.confirm_deleted({"fakehash1"s, "fakehash2"s, "fakehash3"s});
+    CHECK(groups.old_hashes().empty());
 
     to_merge.clear();
     // Load some obsolete ones in just to check that they get immediately obsoleted


### PR DESCRIPTION
This PR removes the auto-clear logic of `_old_hashes` requiring clients to confirm the deletion (or absence) of hashes from the swarm. The main reason for this change is to allow clients to better handle situations where network requests fail.

This also makes it easier for clients to add new logic where they delete `old_hashes` when `needs_push` is `false` (resulting in the swarm being cleaned up correctly).

**Note:** If `needs_push` is `true` then `_old_hashes` will contain the hash of the current config message on the swarm so the deletion should **only** be triggered after a successful `push` request.

**Note:** We should tag a `v1.2.1` release after #31 but before this gets merged (as we want to delay the client-side changes for this PR until a subsequent client release)