### PR TITLE
Keep clang format happy

### DIFF
--- a/tests/test_configdata.cpp
+++ b/tests/test_configdata.cpp
@@ -902,7 +902,8 @@ const auto m126_expected =
 // clang-format on
 
 TEST_CASE("config message example 3 - simple conflict", "[config][example][conflict]") {
-    /// This is the "Simple conflict resolution" example described in docs/api/docs/config-merge-logic.md
+    /// This is the "Simple conflict resolution" example described in docs/api/
+    /// docs/config-merge-logic.md
     MutableConfigMessage m124{m123_expected};
     REQUIRE(m124.seqno() == 124);
 


### PR DESCRIPTION
Line limit is 100 char and we had 101. Will fix drone lint test