### PR TITLE
Fixed documentation strings so the docs site can build

### DIFF
--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -655,7 +655,7 @@ class ConfigBase : public ConfigSig {
         /// - `value` -- replaces current value with given string view
         void operator=(std::string_view value) { *this = std::string{value}; }
 
-        /// API: base/ConfigBase::DictFieldProxy::operator=(std::span<const unsigned char>)
+        /// API: base/ConfigBase::DictFieldProxy::operator
         ///
         /// Replaces the current value with the given std::span<const unsigned char>.  This also
         /// auto-vivifies any intermediate dicts needed to reach the given key, including replacing
@@ -1263,6 +1263,9 @@ class ConfigBase : public ConfigSig {
     ///
     /// Note that only *incomplete* partial sets are affected by this (and stored); we also
     /// separately retain metadata about *completed* multipart sets (see MULTIPART_MAX_REMEMBER).
+    ///
+    /// Inputs: None
+    ///
     std::chrono::milliseconds MULTIPART_MAX_WAIT = 7 * 24h;
 
     /// API: base/ConfigBase::MULTIPART_MAX_REMEMBER
@@ -1272,6 +1275,9 @@ class ConfigBase : public ConfigSig {
     ///
     /// Unlike MULTIPART_MAX_WAIT, such storage does not include the data itself, but merely the
     /// (final) config hash and timestamp of the recombined parts needed for deduplication.
+    ///
+    /// Inputs: None
+    ///
     std::chrono::milliseconds MULTIPART_MAX_REMEMBER = 14 * 24h;
 
     /// API: base/ConfigBase::add_key

--- a/include/session/config/encrypt.hpp
+++ b/include/session/config/encrypt.hpp
@@ -62,6 +62,9 @@ void encrypt_inplace(
 ///
 /// That is, for some message `m`, encrypt_overhead() is the difference between m.size() and
 /// encrypt(m).size().
+///
+/// Inputs: None
+///
 constexpr size_t ENCRYPT_DATA_OVERHEAD = 40;  // ABYTES + NPUBBYTES
 
 /// Thrown if decrypt() fails.


### PR DESCRIPTION
- When we have a `constexpr` the documentation builder still expects the docstring to have `Inputs: None`. We should probably update the script

```
// Fails

/// API: encrypt/ENCRYPT_DATA_OVERHEAD
///
/// This value contains the constant amount of extra bytes required for encryption as performed by
/// `encrypt()`/`decrypt()`/`encrypt_inplace()`/`decrypt_inplace()`.
///
/// That is, for some message `m`, encrypt_overhead() is the difference between m.size() and
/// encrypt(m).size().
constexpr size_t ENCRYPT_DATA_OVERHEAD = 40;  // ABYTES + NPUBBYTES

// Passes

/// API: encrypt/ENCRYPT_DATA_OVERHEAD
///
/// This value contains the constant amount of extra bytes required for encryption as performed by
/// `encrypt()`/`decrypt()`/`encrypt_inplace()`/`decrypt_inplace()`.
///
/// That is, for some message `m`, encrypt_overhead() is the difference between m.size() and
/// encrypt(m).size().
///
/// Inputs: None
///
constexpr size_t ENCRYPT_DATA_OVERHEAD = 40;  // ABYTES + NPUBBYTES
```

- When we write a function docstring we don't account for more complex typings such as `<const unsigned char>`. The regex for `RPC_START` in the build script does not account for spaces. I tried tweaking it but it broke other things. So this is the current solution which I have seen elsewhere in the code base.

```
// Fails

/// API: base/ConfigBase::DictFieldProxy::operator=(std::span<const unsigned char>)

// Passes

/// API: base/ConfigBase::DictFieldProxy::operator
```