### PR TITLE
Feature/split mobile desktop notif settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(libsession-util
-    VERSION 1.5.0
+    VERSION 1.5.1
     DESCRIPTION "Session client utility library"
     LANGUAGES ${LANGS})
 

--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -26,8 +26,10 @@ typedef struct contacts_contact {
     bool blocked;
 
     int priority;
-    CONVO_NOTIFY_MODE notifications;
-    int64_t mute_until;
+    CONVO_NOTIFY_MODE mobile_notifications;
+    CONVO_NOTIFY_MODE desktop_notifications;
+    int64_t mobile_mute_until;
+    int64_t desktop_mute_until;
 
     CONVO_EXPIRATION_MODE exp_mode;
     int exp_seconds;

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -32,9 +32,14 @@ namespace session::config {
 ///     a - 1 if approved, omitted otherwise (int)
 ///     A - 1 if remote has approved me, omitted otherwise (int)
 ///     b - 1 if contact is blocked, omitted otherwise
-///     @ - notification setting (int).  Omitted = use default setting; 1 = all; 2 = disabled.
-///     ! - mute timestamp: if this is set then notifications are to be muted until the given unix
-///         timestamp (seconds, not milliseconds).
+///     @ - mobile notification setting (int).  Omitted = use default setting; 1 = all; 2 =
+///         disabled.
+///     % - desktop notification setting (int).  Omitted = use default setting; 1 = all; 2
+///         = disabled.
+///     ! - mobile mute timestamp: if this is set then notifications are to be muted
+///         until the given unix timestamp (seconds, not milliseconds).
+///     ^ - desktop mute timestamp: if this is set then notifications are to be muted until the
+///         given unix timestamp (seconds, not milliseconds).
 ///     + - the conversation priority; -1 means hidden; omitted means not pinned; otherwise an
 ///         integer value >0, where a higher priority means the conversation is meant to appear
 ///         earlier in the pinned conversation list.
@@ -60,10 +65,14 @@ struct contact_info {
                        // (i.e. pinned earlier in the pinned list).  If negative then this
                        // conversation is hidden.  Otherwise (0) this is a regular, unpinned
                        // conversation.
-    notify_mode notifications = notify_mode::defaulted;
-    int64_t mute_until = 0;  // If non-zero, disable notifications until the given unix timestamp
-                             // (seconds, overriding whatever the current `notifications` value is
-                             // until the timestamp expires).
+    notify_mode mobile_notifications = notify_mode::defaulted;
+    notify_mode desktop_notifications = notify_mode::defaulted;
+    int64_t mobile_mute_until = 0;   // If non-zero, disable mobile notifications until the given
+                                     // unix timestamp (seconds, overriding whatever the current
+                                     // `notifications` value is until the timestamp expires).
+    int64_t desktop_mute_until = 0;  // If non-zero, disable desktop notifications until the given
+                                     // unix timestamp (seconds, overriding whatever the current
+                                     // `notifications` value is until the timestamp expires).
     expiration_mode exp_mode = expiration_mode::none;  // The expiry time; none if not expiring.
     std::chrono::seconds exp_timer{0};                 // The expiration timer (in seconds)
     int64_t created = 0;  // Unix timestamp (seconds) when this contact was added
@@ -271,15 +280,25 @@ class Contacts : public ConfigBase {
     /// - `priority` -- numerical value on the contacts priority (pinned, normal, hidden etc)
     void set_priority(std::string_view session_id, int priority);
 
-    /// API: contacts/contacts::set_notifications
+    /// API: contacts/contacts::set_mobile_notifications
     ///
     /// Alternative to `set()` for setting a single field.  (If setting multiple fields at once you
     /// should use `set()` instead).
     ///
     /// Inputs:
     /// - `session_id` -- hex string of the session id
-    /// - `notifications` -- detail on notifications
-    void set_notifications(std::string_view session_id, notify_mode notifications);
+    /// - `notifications` -- detail on mobile notifications
+    void set_mobile_notifications(std::string_view session_id, notify_mode notifications);
+
+    /// API: contacts/contacts::set_desktop_notifications
+    ///
+    /// Alternative to `set()` for setting a single field.  (If setting multiple fields at once you
+    /// should use `set()` instead).
+    ///
+    /// Inputs:
+    /// - `session_id` -- hex string of the session id
+    /// - `notifications` -- detail on desktop notifications
+    void set_desktop_notifications(std::string_view session_id, notify_mode notifications);
 
     /// API: contacts/contacts::set_expiry
     ///

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -31,9 +31,12 @@ typedef struct ugroups_legacy_group_info {
     int priority;       // pinned conversation priority; 0 = unpinned, negative = hidden, positive =
                         // pinned (with higher meaning pinned higher).
     int64_t joined_at;  // unix timestamp (seconds) when joined (or re-joined)
-    CONVO_NOTIFY_MODE notifications;  // When the user wants notifications
-    int64_t mute_until;               // Mute notifications until this timestamp (seconds, overrides
-                                      // `notifications` setting until the timestamp)
+    CONVO_NOTIFY_MODE mobile_notifications;   // When the user wants mobile notifications
+    CONVO_NOTIFY_MODE desktop_notifications;  // When the user wants desktop notifications
+    int64_t mobile_mute_until;   // Mute mobile notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
+    int64_t desktop_mute_until;  // Mute desktop notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
 
     bool invited;  // True if this is in the invite-but-not-accepted state.
 
@@ -61,9 +64,12 @@ typedef struct ugroups_group_info {
     int priority;       // pinned conversation priority; 0 = unpinned, negative = hidden, positive =
                         // pinned (with higher meaning pinned higher).
     int64_t joined_at;  // unix timestamp (seconds) when joined (or re-joined)
-    CONVO_NOTIFY_MODE notifications;  // When the user wants notifications
-    int64_t mute_until;               // Mute notifications until this timestamp (seconds, overrides
-                                      // `notifications` setting until the timestamp)
+    CONVO_NOTIFY_MODE mobile_notifications;   // When the user wants mobile notifications
+    CONVO_NOTIFY_MODE desktop_notifications;  // When the user wants desktop notifications
+    int64_t mobile_mute_until;   // Mute mobile notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
+    int64_t desktop_mute_until;  // Mute desktop notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
 
     bool invited;  // True if this is in the invite-but-not-accepted state.
 
@@ -82,9 +88,12 @@ typedef struct ugroups_community_info {
     int priority;       // pinned conversation priority; 0 = unpinned, negative = hidden, positive =
                         // pinned (with higher meaning pinned higher).
     int64_t joined_at;  // unix timestamp (seconds) when joined (or re-joined)
-    CONVO_NOTIFY_MODE notifications;  // When the user wants notifications
-    int64_t mute_until;               // Mute notifications until this timestamp (seconds, overrides
-                                      // `notifications` setting until the timestamp)
+    CONVO_NOTIFY_MODE mobile_notifications;   // When the user wants mobile notifications
+    CONVO_NOTIFY_MODE desktop_notifications;  // When the user wants desktop notifications
+    int64_t mobile_mute_until;   // Mute mobile notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
+    int64_t desktop_mute_until;  // Mute desktop notifications until this timestamp (seconds,
+                                 // overrides `notifications` setting until the timestamp)
 
     bool invited;  // True if this is in the invite-but-not-accepted state.
 

--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -23,11 +23,16 @@ namespace session::config {
 ///
 /// *Within* the group dicts (i.e. not at the top level), we use these common values:
 ///
-///     @ - notification setting (int).  Omitted = use default setting; 1 = all, 2 = disabled, 3 =
-///         mentions-only.
-///     ! - mute timestamp: if set then don't show notifications for this contact's messages until
-///         this unix timestamp (i.e.  overriding the current notification setting until the given
-///         time).
+///     @ - mobile notification setting (int).  Omitted = use default setting; 1 = all, 2 =
+///         disabled, 3 = mentions-only.
+///     % - desktop notification setting (int).  Omitted = use default setting; 1 = all, 2 =
+///         disabled, 3 = mentions-only.
+///     ! - mobile mute timestamp: if set then don't show notifications for this contact's messages
+///         until this unix timestamp (i.e.  overriding the current notification setting until the
+///         given time).
+///     ^ - desktop mute timestamp: if set then don't show notifications for this contact's messages
+///         until this unix timestamp (i.e.  overriding the current notification setting until the
+///         given time).
 ///     + - the conversation priority, for pinning/hiding this group in the conversation list.
 ///         Integer.  Omitted means not pinned; -1 means hidden, and a positive value is a pinned
 ///         message for which higher priority values means the conversation is meant to appear
@@ -51,7 +56,7 @@ namespace session::config {
 ///     n - the room name, from a the group invitation; this is intended to be removed once the
 ///         invitation has been accepted, as the name contained in the group info supercedes this).
 ///     r - removed_status, tracks why we were removed from the group.
-///     @, !, +, i, j -- see common values, above.
+///     @, %, !, ^, +, i, j -- see common values, above.
 ///
 /// o - dict of communities (AKA open groups); within this dict (which deliberately has the same
 ///     layout as convo_info_volatile) each key is the SOGS base URL (in canonical form), and value
@@ -63,7 +68,7 @@ namespace session::config {
 ///             appropriate).  For instance, a room name SudokuSolvers would be "sudokusolvers" in
 ///             the outer key, with the capitalization variation in use ("SudokuSolvers") in this
 ///             key.  This key is *always* present (to keep the room dict non-empty).
-///         @, !, +, i, j - see common values, above.
+///         @, %, !, ^, +, i, j -- see common values, above.
 ///
 /// C - dict of legacy groups; within this dict each key is the group pubkey (binary, 33 bytes) and
 /// value is a dict containing keys:
@@ -76,7 +81,7 @@ namespace session::config {
 ///     a - set of admin session ids (each 33 bytes).
 ///     E - disappearing messages duration, in seconds, > 0.  Omitted if disappearing messages is
 ///         disabled.  (Note that legacy groups only support expire after-read)
-///     @, !, +, i, j - see common values, above.
+///     @, %, !, ^, +, i, j -- see common values, above.
 
 /// Common base type with fields shared by all the groups
 struct base_group_info {
@@ -85,8 +90,14 @@ struct base_group_info {
     int priority = 0;       // The priority; 0 means unpinned, -1 means hidden, positive means
                             // pinned higher (i.e.  higher priority conversations come first).
     int64_t joined_at = 0;  // unix timestamp (seconds) when the group was joined (or re-joined)
-    notify_mode notifications = notify_mode::defaulted;  // When the user wants notifications
-    int64_t mute_until = 0;  // unix timestamp (seconds) until which notifications are disabled
+    notify_mode mobile_notifications =
+            notify_mode::defaulted;  // When the user wants mobile notifications
+    notify_mode desktop_notifications =
+            notify_mode::defaulted;  // When the user wants desktop notifications
+    int64_t mobile_mute_until =
+            0;  // unix timestamp (seconds) until which mobile notifications are disabled
+    int64_t desktop_mute_until =
+            0;  // unix timestamp (seconds) until which desktop notifications are disabled
 
     std::string name;  // human-readable; always set for a legacy closed group, only used before
                        // joining a new closed group (after joining the group info provide the name)

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -144,8 +144,10 @@ void contact_info::into(contacts_contact& c) const {
     c.approved_me = approved_me;
     c.blocked = blocked;
     c.priority = priority;
-    c.notifications = static_cast<CONVO_NOTIFY_MODE>(mobile_notifications);
-    c.mute_until = to_epoch_seconds(mobile_mute_until);
+    c.mobile_notifications = static_cast<CONVO_NOTIFY_MODE>(mobile_notifications);
+    c.desktop_notifications = static_cast<CONVO_NOTIFY_MODE>(desktop_notifications);
+    c.mobile_mute_until = to_epoch_seconds(mobile_mute_until);
+    c.desktop_mute_until = to_epoch_seconds(desktop_mute_until);
     c.exp_mode = static_cast<CONVO_EXPIRATION_MODE>(exp_mode);
     c.exp_seconds = exp_timer.count();
     if (c.exp_seconds <= 0 && c.exp_mode != CONVO_EXPIRATION_NONE)
@@ -167,8 +169,10 @@ contact_info::contact_info(const contacts_contact& c) : session_id{c.session_id,
     approved_me = c.approved_me;
     blocked = c.blocked;
     priority = c.priority;
-    mobile_notifications = static_cast<notify_mode>(c.notifications);
-    mobile_mute_until = to_epoch_seconds(c.mute_until);
+    mobile_notifications = static_cast<notify_mode>(c.mobile_notifications);
+    desktop_notifications = static_cast<notify_mode>(c.desktop_notifications);
+    mobile_mute_until = to_epoch_seconds(c.mobile_mute_until);
+    desktop_mute_until = to_epoch_seconds(c.desktop_mute_until);
     exp_mode = static_cast<expiration_mode>(c.exp_mode);
     exp_timer = exp_mode == expiration_mode::none ? 0s : std::chrono::seconds{c.exp_seconds};
     if (exp_timer <= 0s && exp_mode != expiration_mode::none)

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -89,15 +89,24 @@ void contact_info::load(const dict& info_dict) {
 
     priority = maybe_int(info_dict, "+").value_or(0);
 
-    int notify = maybe_int(info_dict, "@").value_or(0);
-    if (notify >= 0 && notify <= 3) {
-        notifications = static_cast<notify_mode>(notify);
-        if (notifications == notify_mode::mentions_only)
-            notifications = notify_mode::all;
+    int notify_mobile = maybe_int(info_dict, "@").value_or(0);
+    if (notify_mobile >= 0 && notify_mobile <= 3) {
+        mobile_notifications = static_cast<notify_mode>(notify_mobile);
+        if (mobile_notifications == notify_mode::mentions_only)
+            mobile_notifications = notify_mode::all;
     } else {
-        notifications = notify_mode::defaulted;
+        mobile_notifications = notify_mode::defaulted;
     }
-    mute_until = to_epoch_seconds(maybe_int(info_dict, "!").value_or(0));
+    int notify_desktop = maybe_int(info_dict, "%").value_or(0);
+    if (notify_desktop >= 0 && notify_desktop <= 3) {
+        desktop_notifications = static_cast<notify_mode>(notify_desktop);
+        if (desktop_notifications == notify_mode::mentions_only)
+            desktop_notifications = notify_mode::all;
+    } else {
+        desktop_notifications = notify_mode::defaulted;
+    }
+    mobile_mute_until = to_epoch_seconds(maybe_int(info_dict, "!").value_or(0));
+    desktop_mute_until = to_epoch_seconds(maybe_int(info_dict, "^").value_or(0));
 
     int exp_mode_ = maybe_int(info_dict, "e").value_or(0);
     if (exp_mode_ >= static_cast<int>(expiration_mode::none) &&
@@ -135,8 +144,8 @@ void contact_info::into(contacts_contact& c) const {
     c.approved_me = approved_me;
     c.blocked = blocked;
     c.priority = priority;
-    c.notifications = static_cast<CONVO_NOTIFY_MODE>(notifications);
-    c.mute_until = to_epoch_seconds(mute_until);
+    c.notifications = static_cast<CONVO_NOTIFY_MODE>(mobile_notifications);
+    c.mute_until = to_epoch_seconds(mobile_mute_until);
     c.exp_mode = static_cast<CONVO_EXPIRATION_MODE>(exp_mode);
     c.exp_seconds = exp_timer.count();
     if (c.exp_seconds <= 0 && c.exp_mode != CONVO_EXPIRATION_NONE)
@@ -158,8 +167,8 @@ contact_info::contact_info(const contacts_contact& c) : session_id{c.session_id,
     approved_me = c.approved_me;
     blocked = c.blocked;
     priority = c.priority;
-    notifications = static_cast<notify_mode>(c.notifications);
-    mute_until = to_epoch_seconds(c.mute_until);
+    mobile_notifications = static_cast<notify_mode>(c.notifications);
+    mobile_mute_until = to_epoch_seconds(c.mute_until);
     exp_mode = static_cast<expiration_mode>(c.exp_mode);
     exp_timer = exp_mode == expiration_mode::none ? 0s : std::chrono::seconds{c.exp_seconds};
     if (exp_timer <= 0s && exp_mode != expiration_mode::none)
@@ -233,11 +242,16 @@ void Contacts::set(const contact_info& contact) {
 
     set_nonzero_int(info["+"], contact.priority);
 
-    auto notify = contact.notifications;
-    if (notify == notify_mode::mentions_only)
-        notify = notify_mode::all;
-    set_positive_int(info["@"], static_cast<int>(notify));
-    set_positive_int(info["!"], to_epoch_seconds(contact.mute_until));
+    auto notify_mobile = contact.mobile_notifications;
+    if (notify_mobile == notify_mode::mentions_only)
+        notify_mobile = notify_mode::all;
+    auto notify_desktop = contact.desktop_notifications;
+    if (notify_desktop == notify_mode::mentions_only)
+        notify_desktop = notify_mode::all;
+    set_positive_int(info["@"], static_cast<int>(notify_mobile));
+    set_positive_int(info["%"], static_cast<int>(notify_desktop));
+    set_positive_int(info["!"], to_epoch_seconds(contact.mobile_mute_until));
+    set_positive_int(info["^"], to_epoch_seconds(contact.desktop_mute_until));
 
     set_pair_if(
             contact.exp_mode != expiration_mode::none && contact.exp_timer > 0s,
@@ -301,9 +315,15 @@ void Contacts::set_priority(std::string_view session_id, int priority) {
     set(c);
 }
 
-void Contacts::set_notifications(std::string_view session_id, notify_mode notifications) {
+void Contacts::set_mobile_notifications(std::string_view session_id, notify_mode notifications) {
     auto c = get_or_construct(session_id);
-    c.notifications = notifications;
+    c.mobile_notifications = notifications;
+    set(c);
+}
+
+void Contacts::set_desktop_notifications(std::string_view session_id, notify_mode notifications) {
+    auto c = get_or_construct(session_id);
+    c.desktop_notifications = notifications;
     set(c);
 }
 

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -35,8 +35,8 @@ template <typename T>
 static void base_into(const base_group_info& self, T& c) {
     c.priority = self.priority;
     c.joined_at = to_epoch_seconds(self.joined_at);
-    c.notifications = static_cast<CONVO_NOTIFY_MODE>(self.notifications);
-    c.mute_until = to_epoch_seconds(self.mute_until);
+    c.notifications = static_cast<CONVO_NOTIFY_MODE>(self.mobile_notifications);
+    c.mute_until = to_epoch_seconds(self.mobile_mute_until);
     c.invited = self.invited;
 }
 
@@ -44,8 +44,8 @@ template <typename T>
 static void base_from(base_group_info& self, const T& c) {
     self.priority = c.priority;
     self.joined_at = to_epoch_seconds(c.joined_at);
-    self.notifications = static_cast<notify_mode>(c.notifications);
-    self.mute_until = to_epoch_seconds(c.mute_until);
+    self.mobile_notifications = static_cast<notify_mode>(c.notifications);
+    self.mobile_mute_until = to_epoch_seconds(c.mute_until);
     self.invited = c.invited;
 }
 
@@ -129,13 +129,20 @@ void base_group_info::load(const dict& info_dict) {
     priority = maybe_int(info_dict, "+").value_or(0);
     joined_at = to_epoch_seconds(std::max<int64_t>(0, maybe_int(info_dict, "j").value_or(0)));
 
-    int notify = maybe_int(info_dict, "@").value_or(0);
-    if (notify >= 0 && notify <= 3)
-        notifications = static_cast<notify_mode>(notify);
+    int notify_mobile = maybe_int(info_dict, "@").value_or(0);
+    if (notify_mobile >= 0 && notify_mobile <= 3)
+        mobile_notifications = static_cast<notify_mode>(notify_mobile);
     else
-        notifications = notify_mode::defaulted;
+        mobile_notifications = notify_mode::defaulted;
 
-    mute_until = to_epoch_seconds(maybe_int(info_dict, "!").value_or(0));
+    int notify_dekstop = maybe_int(info_dict, "%").value_or(0);
+    if (notify_dekstop >= 0 && notify_dekstop <= 3)
+        desktop_notifications = static_cast<notify_mode>(notify_dekstop);
+    else
+        desktop_notifications = notify_mode::defaulted;
+
+    mobile_mute_until = to_epoch_seconds(maybe_int(info_dict, "!").value_or(0));
+    desktop_mute_until = to_epoch_seconds(maybe_int(info_dict, "^").value_or(0));
 
     invited = maybe_int(info_dict, "i").value_or(0);
 }
@@ -410,8 +417,10 @@ void UserGroups::set(const community_info& c) {
 void UserGroups::set_base(const base_group_info& bg, DictFieldProxy& info) const {
     set_nonzero_int(info["+"], bg.priority);
     set_positive_int(info["j"], to_epoch_seconds(bg.joined_at));
-    set_positive_int(info["@"], static_cast<int>(bg.notifications));
-    set_positive_int(info["!"], to_epoch_seconds(bg.mute_until));
+    set_positive_int(info["@"], static_cast<int>(bg.mobile_notifications));
+    set_positive_int(info["%"], static_cast<int>(bg.desktop_notifications));
+    set_positive_int(info["!"], to_epoch_seconds(bg.mobile_mute_until));
+    set_positive_int(info["^"], to_epoch_seconds(bg.desktop_mute_until));
     set_flag(info["i"], bg.invited);
     // We don't set n here because it's subtly different in the three group types
 }

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -35,8 +35,10 @@ template <typename T>
 static void base_into(const base_group_info& self, T& c) {
     c.priority = self.priority;
     c.joined_at = to_epoch_seconds(self.joined_at);
-    c.notifications = static_cast<CONVO_NOTIFY_MODE>(self.mobile_notifications);
-    c.mute_until = to_epoch_seconds(self.mobile_mute_until);
+    c.mobile_notifications = static_cast<CONVO_NOTIFY_MODE>(self.mobile_notifications);
+    c.desktop_notifications = static_cast<CONVO_NOTIFY_MODE>(self.desktop_notifications);
+    c.mobile_mute_until = to_epoch_seconds(self.mobile_mute_until);
+    c.desktop_mute_until = to_epoch_seconds(self.desktop_mute_until);
     c.invited = self.invited;
 }
 
@@ -44,8 +46,10 @@ template <typename T>
 static void base_from(base_group_info& self, const T& c) {
     self.priority = c.priority;
     self.joined_at = to_epoch_seconds(c.joined_at);
-    self.mobile_notifications = static_cast<notify_mode>(c.notifications);
-    self.mobile_mute_until = to_epoch_seconds(c.mute_until);
+    self.mobile_notifications = static_cast<notify_mode>(c.mobile_notifications);
+    self.desktop_notifications = static_cast<notify_mode>(c.desktop_notifications);
+    self.mobile_mute_until = to_epoch_seconds(c.mobile_mute_until);
+    self.desktop_mute_until = to_epoch_seconds(c.desktop_mute_until);
     self.invited = c.invited;
 }
 

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -53,8 +53,10 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK_FALSE(c.blocked);
     CHECK_FALSE(c.profile_picture);
     CHECK(c.created == 0);
-    CHECK(c.notifications == session::config::notify_mode::defaulted);
-    CHECK(c.mute_until == 0);
+    CHECK(c.mobile_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.desktop_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.mobile_mute_until == 0);
+    CHECK(c.desktop_mute_until == 0);
 
     CHECK_FALSE(contacts.needs_push());
     CHECK_FALSE(contacts.needs_dump());
@@ -65,8 +67,10 @@ TEST_CASE("Contacts", "[config][contacts]") {
     c.approved = true;
     c.approved_me = true;
     c.created = created_ts * 1'000;
-    c.notifications = session::config::notify_mode::all;
-    c.mute_until = (now + 1800) * 1'000'000;
+    c.mobile_notifications = session::config::notify_mode::all;
+    c.desktop_notifications = session::config::notify_mode::disabled;
+    c.mobile_mute_until = (now + 1800) * 1'000'000;
+    c.desktop_mute_until = (now + 1900) * 1'000'000;
 
     contacts.set(c);
 
@@ -111,8 +115,10 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK_FALSE(x->profile_picture);
     CHECK_FALSE(x->blocked);
     CHECK(x->created == created_ts);
-    CHECK(x->notifications == session::config::notify_mode::all);
-    CHECK(x->mute_until == now + 1800);
+    CHECK(x->mobile_notifications == session::config::notify_mode::all);
+    CHECK(x->desktop_notifications == session::config::notify_mode::disabled);
+    CHECK(x->mobile_mute_until == now + 1800);
+    CHECK(x->desktop_mute_until == now + 1900);
 
     auto another_id = "051111111111111111111111111111111111111111111111111111111111111111"sv;
     auto c2 = contacts2.get_or_construct(another_id);

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -118,8 +118,10 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(c.name == "");
     CHECK(c.members().empty());
     CHECK(c.joined_at == 0);
-    CHECK(c.notifications == session::config::notify_mode::defaulted);
-    CHECK(c.mute_until == 0);
+    CHECK(c.mobile_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.desktop_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.mobile_mute_until == 0);
+    CHECK(c.desktop_mute_until == 0);
 
     CHECK_FALSE(groups.needs_push());
     CHECK_FALSE(groups.needs_dump());
@@ -137,8 +139,10 @@ TEST_CASE("User Groups", "[config][groups]") {
     c.name = "Englishmen";
     c.disappearing_timer = 60min;
     c.joined_at = created_ts * 1000;  // milliseconds
-    c.notifications = session::config::notify_mode::mentions_only;
-    c.mute_until = now + 3600;
+    c.mobile_notifications = session::config::notify_mode::mentions_only;
+    c.desktop_notifications = session::config::notify_mode::all;
+    c.mobile_mute_until = now + 3600;
+    c.desktop_mute_until = now + 3700;
     CHECK(c.insert(users[0], false));
     CHECK(c.insert(users[1], true));
     CHECK(c.insert(users[2], false));
@@ -244,8 +248,10 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(c1.members() == expected_members);
     CHECK(c1.name == "Englishmen");
     CHECK(c1.joined_at == created_ts);
-    CHECK(c1.notifications == session::config::notify_mode::mentions_only);
-    CHECK(c1.mute_until == now + 3600);
+    CHECK(c1.mobile_notifications == session::config::notify_mode::mentions_only);
+    CHECK(c1.desktop_notifications == session::config::notify_mode::all);
+    CHECK(c1.mobile_mute_until == now + 3600);
+    CHECK(c1.desktop_mute_until == now + 3700);
 
     CHECK_FALSE(g2.needs_push());
     CHECK_FALSE(g2.needs_dump());
@@ -458,8 +464,10 @@ TEST_CASE("User Groups -- (non-legacy) groups", "[config][groups][new]") {
     CHECK(c.id == definitely_real_id);
     CHECK(c.priority == 0);
     CHECK(c.joined_at == 0);
-    CHECK(c.notifications == session::config::notify_mode::defaulted);
-    CHECK(c.mute_until == 0);
+    CHECK(c.mobile_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.desktop_notifications == session::config::notify_mode::defaulted);
+    CHECK(c.mobile_mute_until == 0);
+    CHECK(c.desktop_mute_until == 0);
 
     c.secretkey = session::to_vector(ed_sk);  // This *isn't* the right secret key for the group, so
                                               // won't propagate, and so auth data will:
@@ -486,15 +494,19 @@ TEST_CASE("User Groups -- (non-legacy) groups", "[config][groups][new]") {
     CHECK(c2->id == definitely_real_id);
     CHECK(c2->priority == 0);
     CHECK(c2->joined_at == 0);
-    CHECK(c2->notifications == session::config::notify_mode::defaulted);
-    CHECK(c2->mute_until == 0);
+    CHECK(c2->mobile_notifications == session::config::notify_mode::defaulted);
+    CHECK(c2->desktop_notifications == session::config::notify_mode::defaulted);
+    CHECK(c2->mobile_mute_until == 0);
+    CHECK(c2->desktop_mute_until == 0);
     CHECK_FALSE(c2->invited);
     CHECK(c2->name == "");
 
     c2->priority = 123;
     c2->joined_at = (int64_t)1'234'567'890 * 1'000;
-    c2->notifications = session::config::notify_mode::mentions_only;
-    c2->mute_until = (int64_t)456'789'012 * 1'000'000;
+    c2->mobile_notifications = session::config::notify_mode::mentions_only;
+    c2->desktop_notifications = session::config::notify_mode::all;
+    c2->mobile_mute_until = (int64_t)456'789'012 * 1'000'000;
+    c2->desktop_mute_until = (int64_t)456'789'013 * 1'000'000;
     c2->invited = true;
     c2->name = "Magic Special Room";
 
@@ -527,8 +539,10 @@ TEST_CASE("User Groups -- (non-legacy) groups", "[config][groups][new]") {
     CHECK(c3->id == definitely_real_id);
     CHECK(c3->priority == 123);
     CHECK(c3->joined_at == 1234567890);
-    CHECK(c3->notifications == session::config::notify_mode::mentions_only);
-    CHECK(c3->mute_until == 456789012);
+    CHECK(c3->mobile_notifications == session::config::notify_mode::mentions_only);
+    CHECK(c3->desktop_notifications == session::config::notify_mode::all);
+    CHECK(c3->mobile_mute_until == 456789012);
+    CHECK(c3->desktop_mute_until == 456789013);
     CHECK(c3->invited);
     CHECK(c3->name == "Magic Special Room");
 
@@ -844,14 +858,19 @@ TEST_CASE("User groups mute_until & joined_at are always seconds", "[config][gro
         auto lg = c.get_or_construct_legacy_group(
                 "051234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
         int64_t joined_at = get_timestamp_us();
-        int64_t mute_until = get_timestamp_s();
+        int64_t mobile_mute_until = get_timestamp_s();
+        int64_t desktop_mute_until = get_timestamp_s() + 10;
         lg.joined_at = joined_at;
-        lg.mute_until = mute_until;
+        lg.mobile_mute_until = mobile_mute_until;
+        lg.desktop_mute_until = desktop_mute_until;
         c.set(lg);
         auto lg2 = c.get_or_construct_legacy_group(
                 "051234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
         CHECK(lg2.joined_at == joined_at / 1'000'000);  // joined_at was given in microseconds
-        CHECK(lg2.mute_until == mute_until);            // mute_until was given in seconds
+        CHECK(lg2.mobile_mute_until ==
+              mobile_mute_until);  // mobile_mute_until was given in seconds
+        CHECK(lg2.desktop_mute_until ==
+              desktop_mute_until);  // desktop_mute_until was given in seconds
         c.erase_legacy_group("051234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
     }
 
@@ -859,14 +878,19 @@ TEST_CASE("User groups mute_until & joined_at are always seconds", "[config][gro
         auto gr = c.get_or_construct_group(
                 "031234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
         int64_t joined_at = get_timestamp_ms();
-        int64_t mute_until = get_timestamp_us();
+        int64_t mobile_mute_until = get_timestamp_us();
+        int64_t desktop_mute_until = get_timestamp_us() + 10;
         gr.joined_at = joined_at;
-        gr.mute_until = mute_until;
+        gr.mobile_mute_until = mobile_mute_until;
+        gr.desktop_mute_until = desktop_mute_until;
         c.set(gr);
         auto gr2 = c.get_or_construct_group(
                 "031234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
-        CHECK(gr2.joined_at == joined_at / 1'000);        // joined_at was given in milliseconds
-        CHECK(gr2.mute_until == mute_until / 1'000'000);  // mute_until was given in microseconds
+        CHECK(gr2.joined_at == joined_at / 1'000);  // joined_at was given in milliseconds
+        CHECK(gr2.mobile_mute_until ==
+              mobile_mute_until / 1'000'000);  // mobile_mute_until was given in microseconds
+        CHECK(gr2.desktop_mute_until ==
+              desktop_mute_until / 1'000'000);  // desktop_mute_until was given in microseconds
         c.erase_group("031234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
     }
 
@@ -877,19 +901,24 @@ TEST_CASE("User groups mute_until & joined_at are always seconds", "[config][gro
         const auto room = "sudoku_room";
         auto comm = c.get_or_construct_community(url, room, open_group_pubkey);
         int64_t joined_at = get_timestamp_ms();
-        int64_t mute_until = get_timestamp_ms();
+        int64_t mobile_mute_until = get_timestamp_ms();
+        int64_t desktop_mute_until = get_timestamp_ms() + 10;
         comm.joined_at = joined_at;
-        comm.mute_until = mute_until;
+        comm.mobile_mute_until = mobile_mute_until;
+        comm.desktop_mute_until = desktop_mute_until;
         c.set(comm);
         auto comm2 = c.get_or_construct_community(url, room, open_group_pubkey);
-        CHECK(comm2.joined_at == joined_at / 1'000);    // joined_at was given in milliseconds
-        CHECK(comm2.mute_until == mute_until / 1'000);  // mute_until was given in milliseconds
+        CHECK(comm2.joined_at == joined_at / 1'000);  // joined_at was given in milliseconds
+        CHECK(comm2.mobile_mute_until ==
+              mobile_mute_until / 1'000);  // mobile_mute_until was given in milliseconds
+        CHECK(comm2.desktop_mute_until ==
+              desktop_mute_until / 1'000);  // mobile_mute_until was given in milliseconds
         c.erase_community(url, room);
     }
     {
         // this dump has:
         // - an invalid joined_at (1'733'979'503'520) and
-        // - an invalid mute_until (1'733'979'503'520'780) values
+        // - an invalid mobile_mute_until (1'733'979'503'520'780) values
         const auto dump_with_not_seconds =
                 "64313a21693165313a243231303a64313a23693165313a2664313a676433333a031234567890abcdef"
                 "1234"
@@ -908,7 +937,7 @@ TEST_CASE("User groups mute_until & joined_at are always seconds", "[config][gro
                 "031234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
 
         CHECK(gr.joined_at == 1'733'979'503'520 / 1'000);
-        CHECK(gr.mute_until == 1'733'979'503'520'780 / 1'000'000);
+        CHECK(gr.mobile_mute_until == 1'733'979'503'520'780 / 1'000'000);
     }
 }
 


### PR DESCRIPTION
Updated the code to have separate settings for mobile and desktop notification settings (so they will be remembered against the account but the user can have different settings across mobile and desktop)