### PR TITLE
Disabled the "profile_updated" timestamp updating logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(libsession-util
-    VERSION 1.5.5
+    VERSION 1.5.6
     DESCRIPTION "Session client utility library"
     LANGUAGES ${LANGS})
 

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -29,8 +29,8 @@ void UserProfile::set_name(std::string_view new_name) {
         throw std::invalid_argument{"Invalid profile name: exceeds maximum length"};
     set_nonempty_str(data["n"], new_name);
 
-    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
-    // data[target_timestamp] = ts_now();
+    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" :
+    // "T"); data[target_timestamp] = ts_now();
 }
 void UserProfile::set_name_truncated(std::string new_name) {
     set_name(utf8_truncate(std::move(new_name), contact_info::MAX_NAME_LENGTH));
@@ -100,8 +100,8 @@ void UserProfile::set_blinded_msgreqs(std::optional<bool> value) {
     else
         data["M"] = static_cast<int>(*value);
 
-    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
-    // data[target_timestamp] = ts_now();
+    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" :
+    // "T"); data[target_timestamp] = ts_now();
 }
 
 std::optional<bool> UserProfile::get_blinded_msgreqs() const {

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -29,8 +29,8 @@ void UserProfile::set_name(std::string_view new_name) {
         throw std::invalid_argument{"Invalid profile name: exceeds maximum length"};
     set_nonempty_str(data["n"], new_name);
 
-    const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
-    data[target_timestamp] = ts_now();
+    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
+    // data[target_timestamp] = ts_now();
 }
 void UserProfile::set_name_truncated(std::string new_name) {
     set_name(utf8_truncate(std::move(new_name), contact_info::MAX_NAME_LENGTH));
@@ -59,7 +59,7 @@ void UserProfile::set_profile_pic(std::string_view url, std::span<const unsigned
     if (url.empty() || key.size() != 32)
         set_reupload_profile_pic({});
 
-    data["t"] = ts_now();
+    // data["t"] = ts_now();
 }
 
 void UserProfile::set_profile_pic(profile_pic pic) {
@@ -69,7 +69,7 @@ void UserProfile::set_profile_pic(profile_pic pic) {
 void UserProfile::set_reupload_profile_pic(
         std::string_view url, std::span<const unsigned char> key) {
     set_pair_if(!url.empty() && key.size() == 32, data["P"], url, data["Q"], key);
-    data["T"] = ts_now();
+    // data["T"] = ts_now();
 }
 
 void UserProfile::set_reupload_profile_pic(profile_pic pic) {
@@ -100,8 +100,8 @@ void UserProfile::set_blinded_msgreqs(std::optional<bool> value) {
     else
         data["M"] = static_cast<int>(*value);
 
-    const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
-    data[target_timestamp] = ts_now();
+    // const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
+    // data[target_timestamp] = ts_now();
 }
 
 std::optional<bool> UserProfile::get_blinded_msgreqs() const {
@@ -111,11 +111,11 @@ std::optional<bool> UserProfile::get_blinded_msgreqs() const {
 }
 
 std::chrono::sys_seconds UserProfile::get_profile_updated() const {
-    if (auto t = data["t"].sys_seconds()) {
-        if (auto T = data["T"].sys_seconds(); T && *T > *t)
-            return *T;
-        return *t;
-    }
+    // if (auto t = data["t"].sys_seconds()) {
+    //     if (auto T = data["T"].sys_seconds(); T && *T > *t)
+    //         return *T;
+    //     return *t;
+    // }
     return std::chrono::sys_seconds{};
 }
 

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -460,75 +460,84 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
           "qwert\0yuio1234567890123456789012"_bytes);
 
-    // Reupload the "current" pic and confirm it gets returned
+    // Ensure the timestamp doesn't get updated
     strcpy(p.url, "testUrl");
     memcpy(p.key, "secret78901234567890123456789000", 32);
     CHECK(0 == user_profile_set_reupload_pic(conf, p));
-
-    pic = user_profile_get_pic(conf);
-    REQUIRE(pic.url != ""s);
-    REQUIRE(pic.key != session::to_vector("").data());
-    CHECK(pic.url == "testUrl"sv);
-    CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
-          "secret78901234567890123456789000"_bytes);
-
-    // Upload a "new" pic and it now gets returned
-    strcpy(p.url, "testNewUrl");
-    memcpy(p.key, "secret78901234567890123456789111", 32);
     CHECK(0 == user_profile_set_pic(conf, p));
-    pic = user_profile_get_pic(conf);
-    REQUIRE(pic.url != ""s);
-    REQUIRE(pic.key != session::to_vector("").data());
-    CHECK(pic.url == "testNewUrl"sv);
-    CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
-          "secret78901234567890123456789111"_bytes);
-
-    // Ensure the timestamp for the last modified pic gets updated correctly when the name gets set
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    CHECK(0 == user_profile_set_pic(conf, p));
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
-    user_profile_set_name(conf, "test1");
-    CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
-    CHECK(0 == user_profile_set_reupload_pic(conf, p));
-    user_profile_set_name(conf, "test2");
-    CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
-          124);
-
-    // Ensure the timestamp for the last modified pic gets updated correctly when the blinded msgreq
-    // is set
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    CHECK(0 == user_profile_set_pic(conf, p));
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
+    CHECK(0 == user_profile_set_name(conf, "Test"));
     user_profile_set_blinded_msgreqs(conf, 1);
-    CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
-    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+    CHECK(user_profile_get_profile_updated(conf) == 0);
 
-    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
-    CHECK(0 == user_profile_set_reupload_pic(conf, p));
-    user_profile_set_blinded_msgreqs(conf, 2);
-    CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
-          124);
+    // // Reupload the "current" pic and confirm it gets returned
+    // strcpy(p.url, "testUrl");
+    // memcpy(p.key, "secret78901234567890123456789000", 32);
+    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
 
-    // Ensure the timestamp is stored in seconds seconds (was incorrectly stored as microseconds)
-    auto time_before_call = std::chrono::system_clock::now();
-    CHECK(0 == user_profile_set_pic(conf, p));
-    auto time_after_call = std::chrono::system_clock::now();
-    auto before_seconds =
-            std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
-                    .count();
-    auto after_seconds =
-            std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
-                    .count();
+    // pic = user_profile_get_pic(conf);
+    // REQUIRE(pic.url != ""s);
+    // REQUIRE(pic.key != session::to_vector("").data());
+    // CHECK(pic.url == "testUrl"sv);
+    // CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
+    //       "secret78901234567890123456789000"_bytes);
 
-    auto raw_value = UserProfileTester::get_raw_profile_updated_value(conf);
-    INFO("Checking if raw_value " << raw_value << " is within the range [" << before_seconds << ", "
-                                  << after_seconds << "]");
-    CHECK((raw_value >= before_seconds && raw_value <= after_seconds));
+    // // Upload a "new" pic and it now gets returned
+    // strcpy(p.url, "testNewUrl");
+    // memcpy(p.key, "secret78901234567890123456789111", 32);
+    // CHECK(0 == user_profile_set_pic(conf, p));
+    // pic = user_profile_get_pic(conf);
+    // REQUIRE(pic.url != ""s);
+    // REQUIRE(pic.key != session::to_vector("").data());
+    // CHECK(pic.url == "testNewUrl"sv);
+    // CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
+    //       "secret78901234567890123456789111"_bytes);
+
+    // // Ensure the timestamp for the last modified pic gets updated correctly when the name gets set
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    // CHECK(0 == user_profile_set_pic(conf, p));
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
+    // user_profile_set_name(conf, "test1");
+    // CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
+    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
+    // user_profile_set_name(conf, "test2");
+    // CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
+    //       124);
+
+    // // Ensure the timestamp for the last modified pic gets updated correctly when the blinded msgreq
+    // // is set
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    // CHECK(0 == user_profile_set_pic(conf, p));
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
+    // user_profile_set_blinded_msgreqs(conf, 1);
+    // CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
+    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
+    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
+    // user_profile_set_blinded_msgreqs(conf, 2);
+    // CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
+    //       124);
+
+    // // Ensure the timestamp is stored in seconds seconds (was incorrectly stored as microseconds)
+    // auto time_before_call = std::chrono::system_clock::now();
+    // CHECK(0 == user_profile_set_pic(conf, p));
+    // auto time_after_call = std::chrono::system_clock::now();
+    // auto before_seconds =
+    //         std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
+    //                 .count();
+    // auto after_seconds =
+    //         std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
+    //                 .count();
+
+    // auto raw_value = UserProfileTester::get_raw_profile_updated_value(conf);
+    // INFO("Checking if raw_value " << raw_value << " is within the range [" << before_seconds << ", "
+    //                               << after_seconds << "]");
+    // CHECK((raw_value >= before_seconds && raw_value <= after_seconds));
 }

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -460,6 +460,79 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
           "qwert\0yuio1234567890123456789012"_bytes);
 
+#if 0
+    // Reupload the "current" pic and confirm it gets returned
+    strcpy(p.url, "testUrl");
+    memcpy(p.key, "secret78901234567890123456789000", 32);
+    CHECK(0 == user_profile_set_reupload_pic(conf, p));
+
+    pic = user_profile_get_pic(conf);
+    REQUIRE(pic.url != ""s);
+    REQUIRE(pic.key != session::to_vector("").data());
+    CHECK(pic.url == "testUrl"sv);
+    CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
+          "secret78901234567890123456789000"_bytes);
+
+    // Upload a "new" pic and it now gets returned
+    strcpy(p.url, "testNewUrl");
+    memcpy(p.key, "secret78901234567890123456789111", 32);
+    CHECK(0 == user_profile_set_pic(conf, p));
+    pic = user_profile_get_pic(conf);
+    REQUIRE(pic.url != ""s);
+    REQUIRE(pic.key != session::to_vector("").data());
+    CHECK(pic.url == "testNewUrl"sv);
+    CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
+          "secret78901234567890123456789111"_bytes);
+
+    // Ensure the timestamp for the last modified pic gets updated correctly when the name gets set
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    CHECK(0 == user_profile_set_pic(conf, p));
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
+    user_profile_set_name(conf, "test1");
+    CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
+    CHECK(0 == user_profile_set_reupload_pic(conf, p));
+    user_profile_set_name(conf, "test2");
+    CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
+          124);
+
+    // Ensure the timestamp for the last modified pic gets updated correctly when the blinded msgreq
+    // is set
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    CHECK(0 == user_profile_set_pic(conf, p));
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
+    user_profile_set_blinded_msgreqs(conf, 1);
+    CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
+    UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
+
+    UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
+    CHECK(0 == user_profile_set_reupload_pic(conf, p));
+    user_profile_set_blinded_msgreqs(conf, 2);
+    CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
+          124);
+
+    // Ensure the timestamp is stored in seconds seconds (was incorrectly stored as microseconds)
+    auto time_before_call = std::chrono::system_clock::now();
+    CHECK(0 == user_profile_set_pic(conf, p));
+    auto time_after_call = std::chrono::system_clock::now();
+    auto before_seconds =
+            std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
+                    .count();
+    auto after_seconds =
+            std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
+                    .count();
+
+    auto raw_value = UserProfileTester::get_raw_profile_updated_value(conf);
+    INFO("Checking if raw_value " << raw_value << " is within the range [" << before_seconds << ", "
+                                  << after_seconds << "]");
+    CHECK((raw_value >= before_seconds && raw_value <= after_seconds));
+#else
     // Ensure the timestamp doesn't get updated
     strcpy(p.url, "testUrl");
     memcpy(p.key, "secret78901234567890123456789000", 32);
@@ -468,76 +541,5 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     CHECK(0 == user_profile_set_name(conf, "Test"));
     user_profile_set_blinded_msgreqs(conf, 1);
     CHECK(user_profile_get_profile_updated(conf) == 0);
-
-    // // Reupload the "current" pic and confirm it gets returned
-    // strcpy(p.url, "testUrl");
-    // memcpy(p.key, "secret78901234567890123456789000", 32);
-    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
-
-    // pic = user_profile_get_pic(conf);
-    // REQUIRE(pic.url != ""s);
-    // REQUIRE(pic.key != session::to_vector("").data());
-    // CHECK(pic.url == "testUrl"sv);
-    // CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
-    //       "secret78901234567890123456789000"_bytes);
-
-    // // Upload a "new" pic and it now gets returned
-    // strcpy(p.url, "testNewUrl");
-    // memcpy(p.key, "secret78901234567890123456789111", 32);
-    // CHECK(0 == user_profile_set_pic(conf, p));
-    // pic = user_profile_get_pic(conf);
-    // REQUIRE(pic.url != ""s);
-    // REQUIRE(pic.key != session::to_vector("").data());
-    // CHECK(pic.url == "testNewUrl"sv);
-    // CHECK(session::to_vector(std::span<const unsigned char>{pic.key, 32}) ==
-    //       "secret78901234567890123456789111"_bytes);
-
-    // // Ensure the timestamp for the last modified pic gets updated correctly when the name gets set
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    // CHECK(0 == user_profile_set_pic(conf, p));
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
-    // user_profile_set_name(conf, "test1");
-    // CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
-    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
-    // user_profile_set_name(conf, "test2");
-    // CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
-    //       124);
-
-    // // Ensure the timestamp for the last modified pic gets updated correctly when the blinded msgreq
-    // // is set
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    // CHECK(0 == user_profile_set_pic(conf, p));
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
-    // user_profile_set_blinded_msgreqs(conf, 1);
-    // CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
-    // UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
-
-    // UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
-    // CHECK(0 == user_profile_set_reupload_pic(conf, p));
-    // user_profile_set_blinded_msgreqs(conf, 2);
-    // CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
-    //       124);
-
-    // // Ensure the timestamp is stored in seconds seconds (was incorrectly stored as microseconds)
-    // auto time_before_call = std::chrono::system_clock::now();
-    // CHECK(0 == user_profile_set_pic(conf, p));
-    // auto time_after_call = std::chrono::system_clock::now();
-    // auto before_seconds =
-    //         std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
-    //                 .count();
-    // auto after_seconds =
-    //         std::chrono::duration_cast<std::chrono::seconds>(time_before_call.time_since_epoch())
-    //                 .count();
-
-    // auto raw_value = UserProfileTester::get_raw_profile_updated_value(conf);
-    // INFO("Checking if raw_value " << raw_value << " is within the range [" << before_seconds << ", "
-    //                               << after_seconds << "]");
-    // CHECK((raw_value >= before_seconds && raw_value <= after_seconds));
+#endif
 }


### PR DESCRIPTION
We want to do a client release which doesn't yet set the `profile_updated` timestamp and it's less work to disable it on the `libSession` side than to rollback changes to the clients

The plan would be to revert this change in a subsequent release