### PR TITLE
Fixed a bug where profile_updated would update when no data changed

### DIFF
--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -27,6 +27,11 @@ std::optional<std::string_view> UserProfile::get_name() const {
 void UserProfile::set_name(std::string_view new_name) {
     if (new_name.size() > contact_info::MAX_NAME_LENGTH)
         throw std::invalid_argument{"Invalid profile name: exceeds maximum length"};
+
+    auto current_name = get_name();
+    if (current_name && *current_name == new_name)
+        return;
+
     set_nonempty_str(data["n"], new_name);
 
     const auto target_timestamp = (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
@@ -53,6 +58,17 @@ profile_pic UserProfile::get_profile_pic() const {
 }
 
 void UserProfile::set_profile_pic(std::string_view url, std::span<const unsigned char> key) {
+    auto current_url = data["p"].string_view_or("");
+    auto current_key_str = data["q"].string_view_or("");
+    std::span<const unsigned char> current_key{
+            reinterpret_cast<const unsigned char*>(current_key_str.data()), current_key_str.size()};
+
+    bool changed = (current_url != url) || (current_key.size() != key.size()) ||
+                   !std::equal(current_key.begin(), current_key.end(), key.begin());
+
+    if (!changed)
+        return;
+
     set_pair_if(!url.empty() && key.size() == 32, data["p"], url, data["q"], key);
 
     // If the profile was removed then we should remove the "reupload" version as well
@@ -68,6 +84,17 @@ void UserProfile::set_profile_pic(profile_pic pic) {
 
 void UserProfile::set_reupload_profile_pic(
         std::string_view url, std::span<const unsigned char> key) {
+    auto current_url = data["P"].string_view_or("");
+    auto current_key_str = data["Q"].string_view_or("");
+    std::span<const unsigned char> current_key{
+            reinterpret_cast<const unsigned char*>(current_key_str.data()), current_key_str.size()};
+
+    bool changed = (current_url != url) || (current_key.size() != key.size()) ||
+                   !std::equal(current_key.begin(), current_key.end(), key.begin());
+
+    if (!changed)
+        return;
+
     set_pair_if(!url.empty() && key.size() == 32, data["P"], url, data["Q"], key);
     data["T"] = ts_now();
 }
@@ -95,6 +122,13 @@ std::optional<std::chrono::seconds> UserProfile::get_nts_expiry() const {
 }
 
 void UserProfile::set_blinded_msgreqs(std::optional<bool> value) {
+    auto current_value = data["M"].exists()
+                               ? std::optional<bool>{static_cast<bool>(data["M"].integer_or(0))}
+                               : std::nullopt;
+
+    if (current_value == value)
+        return;
+
     if (!value)
         data["M"].erase();
     else

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -60,11 +60,8 @@ profile_pic UserProfile::get_profile_pic() const {
 void UserProfile::set_profile_pic(std::string_view url, std::span<const unsigned char> key) {
     auto current_url = data["p"].string_view_or("");
     auto current_key_str = data["q"].string_view_or("");
-    std::span<const unsigned char> current_key{
-            reinterpret_cast<const unsigned char*>(current_key_str.data()), current_key_str.size()};
-
-    bool changed = (current_url != url) || (current_key.size() != key.size()) ||
-                   !std::equal(current_key.begin(), current_key.end(), key.begin());
+    std::string_view new_key_str{reinterpret_cast<const char*>(key.data()), key.size()};
+    bool changed = (current_url != url) || (current_key_str != new_key_str);
 
     if (!changed)
         return;
@@ -86,11 +83,8 @@ void UserProfile::set_reupload_profile_pic(
         std::string_view url, std::span<const unsigned char> key) {
     auto current_url = data["P"].string_view_or("");
     auto current_key_str = data["Q"].string_view_or("");
-    std::span<const unsigned char> current_key{
-            reinterpret_cast<const unsigned char*>(current_key_str.data()), current_key_str.size()};
-
-    bool changed = (current_url != url) || (current_key.size() != key.size()) ||
-                   !std::equal(current_key.begin(), current_key.end(), key.begin());
+    std::string_view new_key_str{reinterpret_cast<const char*>(key.data()), key.size()};
+    bool changed = (current_url != url) || (current_key_str != new_key_str);
 
     if (!changed)
         return;
@@ -122,9 +116,9 @@ std::optional<std::chrono::seconds> UserProfile::get_nts_expiry() const {
 }
 
 void UserProfile::set_blinded_msgreqs(std::optional<bool> value) {
-    auto current_value = data["M"].exists()
-                               ? std::optional<bool>{static_cast<bool>(data["M"].integer_or(0))}
-                               : std::nullopt;
+    std::optional<bool> current_value;
+    if (data["M"].exists())
+        current_value = static_cast<bool>(data["M"].integer_or(0));
 
     if (current_value == value)
         return;

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -504,20 +504,22 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
     UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{0s});
 
+    strcpy(p.url, "http://example.org/omg-pic-124.bmp");  // NB: length must be < sizeof(p.url)!
     CHECK(0 == user_profile_set_pic(conf, p));
     UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{123s});
-    user_profile_set_blinded_msgreqs(conf, 1);
+    user_profile_set_blinded_msgreqs(conf, 0);
     CHECK(UserProfileTester::get_profile_updated_value(conf).time_since_epoch().count() != 123);
     UserProfileTester::set_profile_updated(conf, std::chrono::sys_seconds{0s});
 
     UserProfileTester::set_reupload_profile_updated(conf, std::chrono::sys_seconds{124s});
     CHECK(0 == user_profile_set_reupload_pic(conf, p));
-    user_profile_set_blinded_msgreqs(conf, 2);
+    user_profile_set_blinded_msgreqs(conf, 1);
     CHECK(UserProfileTester::get_reupload_profile_updated_value(conf).time_since_epoch().count() !=
           124);
 
     // Ensure the timestamp is stored in seconds seconds (was incorrectly stored as microseconds)
     auto time_before_call = std::chrono::system_clock::now();
+    strcpy(p.url, "http://example.org/omg-pic-125.bmp");  // NB: length must be < sizeof(p.url)!
     CHECK(0 == user_profile_set_pic(conf, p));
     auto time_after_call = std::chrono::system_clock::now();
     auto before_seconds =
@@ -531,4 +533,30 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     INFO("Checking if raw_value " << raw_value << " is within the range [" << before_seconds << ", "
                                   << after_seconds << "]");
     CHECK((raw_value >= before_seconds && raw_value <= after_seconds));
+}
+
+TEST_CASE("user profile timestamp update bug", "[config][user_profile]") {
+
+    const auto seed = "0123456789abcdef0123456789abcdef00000000000000000000000000000000"_hexbytes;
+
+    session::config::UserProfile profile{std::span<const unsigned char>{seed}, std::nullopt};
+
+    // Initially the code would update `profile_updated` even if the data hadn't changed, this test
+    // verifies that no longer happens
+    std::vector<unsigned char> key = "qwerty78901234567890123456789012"_bytes;
+    std::string url = "http://example.com/huge.bmp";
+    profile.set_name("Nibbler");
+    profile.set_blinded_msgreqs(true);
+    profile.set_profile_pic(url, key);
+    auto seconds_before_call = profile.get_profile_updated();
+    std::this_thread::sleep_for(2s);
+    profile.set_name("Nibbler");
+    profile.set_blinded_msgreqs(true);
+    profile.set_profile_pic(url, key);
+    auto seconds_after_call = profile.get_profile_updated();
+    CHECK(profile.get_profile_updated() == seconds_before_call);
+
+    // Also make sure it does change
+    profile.set_name("Nibbler1");
+    CHECK(profile.get_profile_updated() != seconds_before_call);
 }


### PR DESCRIPTION
Currently if you call `set_name`/`set_blinded_msgreqs`/`set_profile_pic`/`set_reupload_profile_pic` with the _current_ data one of the `profile_updated` timestamps is being updated - this doesn't really align with the existing behaviour of `libSession` where it only changes when data changes.

This PR changes the behaviour so the `profile_updated` timestamps only get updated if the data has changed