### PR TITLE
Sync the ProConfig to swarms rather than extra data

### DIFF
--- a/include/session/config/pro.hpp
+++ b/include/session/config/pro.hpp
@@ -15,13 +15,13 @@ namespace session::config {
 ///   |     +-- @ - version
 ///   |     +-- e - expiry unix timestamp (in milliseconds)
 ///   |     +-- g - gen_index_hash
-///   |     +-- r - rotating ed25519 pubkey
 ///   |     +-- s - proof signature, signed by the Session Pro Backend's ed25519 key
 ///   |
-///   +-- r - rotating ed25519 privkey
+///   +-- r - rotating ed25519 seed (32b)
 class ProConfig {
   public:
-    /// Private key for the public key key specified in the proof.
+    /// Rotating private key for the public key specified in the proof. On the wire we store the
+    /// seed. At runtime we derive the full key for convenience.
     cleared_uc64 rotating_privkey;
 
     /// A cryptographic proof for entitling an Ed25519 key to Session Pro

--- a/include/session/config/pro.hpp
+++ b/include/session/config/pro.hpp
@@ -15,10 +15,10 @@ namespace session::config {
 ///   |     +-- @ - version
 ///   |     +-- e - expiry unix timestamp (in milliseconds)
 ///   |     +-- g - gen_index_hash
-///   |     +-- r - rotating ed25519 privkey
+///   |     +-- r - rotating ed25519 pubkey
 ///   |     +-- s - proof signature, signed by the Session Pro Backend's ed25519 key
 ///   |
-///   +-- r - rotating ed25519 pubkey
+///   +-- r - rotating ed25519 privkey
 class ProConfig {
   public:
     /// Private key for the public key key specified in the proof.
@@ -27,7 +27,7 @@ class ProConfig {
     /// A cryptographic proof for entitling an Ed25519 key to Session Pro
     ProProof proof;
 
-    bool load(bt_dict_consumer& root);
+    bool load(const dict& root);
 
     bool operator==(const ProConfig& other) const {
         return rotating_privkey == other.rotating_privkey && proof == other.proof;

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -28,17 +28,13 @@ using namespace std::literals;
 /// t - The unix timestamp (seconds) that the user last explicitly updated their profile information
 ///     (automatically updates when changing `name`, `profile_pic` or `set_blinded_msgreqs`).
 /// E - user pro access expiry unix timestamp (in milliseconds). Note: This can be different from
-/// the pro proof expiry which can be sooner. P - user profile url after re-uploading (should take
-/// precedence over `p` when `T > t`). Q - user profile decryption key (binary) after re-uploading
-/// (should take precedence over `q`
+///     the pro proof expiry which can be sooner.
+/// P - user profile url after re-uploading (should take precedence over `p` when `T > t`).
+/// Q - user profile decryption key (binary) after re-uploading (should take precedence over `q`
 ///     when `T > t`).
 /// T - The unix timestamp (seconds) that the user last re-uploaded their profile information
 ///    (automatically updates when calling `set_reupload_profile_pic`).
 class UserProfile : public ConfigBase {
-
-  private:
-    std::optional<ProConfig> pro_config;
-
   public:
     friend class UserProfileTester;
 
@@ -274,8 +270,7 @@ class UserProfile : public ConfigBase {
     /// Inputs: None
     ///
     /// Outputs:
-    /// - `bool` - A flag indicating whether the config had Session Pro components which were
-    /// removed.
+    /// - `bool` - Flag indicating whether the config had Session Pro config removed or not.
     bool remove_pro_config();
 
     /// API: user_profile/UserProfile::get_pro_features
@@ -333,10 +328,6 @@ class UserProfile : public ConfigBase {
     /// nullopt to remove the value.
     void set_pro_access_expiry(
             std::optional<std::chrono::sys_time<std::chrono::milliseconds>> access_expiry_ts_ms);
-
-  protected:
-    void extra_data(oxenc::bt_dict_producer&& extra) const override;
-    void load_extra_data(oxenc::bt_dict_consumer&& extra) override;
 };
 
 }  // namespace session::config

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -21,15 +21,14 @@ bool ProConfig::load(const dict& root) {
     if (!p)
         return false;
 
-    std::optional<std::vector<unsigned char>> maybe_rotating_privkey = maybe_vector(root, "r");
-    if (!maybe_rotating_privkey || maybe_rotating_privkey->size() != rotating_privkey.max_size())
+    std::optional<std::vector<unsigned char>> maybe_rotating_seed = maybe_vector(root, "r");
+    if (!maybe_rotating_seed || maybe_rotating_seed->size() != crypto_sign_ed25519_SEEDBYTES)
         return false;
 
     // NOTE: Load into the proof object
     {
         std::optional<uint8_t> version = maybe_int(*p, "@");
         std::optional<std::vector<unsigned char>> maybe_gen_index_hash = maybe_vector(*p, "g");
-        std::optional<std::vector<unsigned char>> maybe_rotating_pubkey = maybe_vector(*p, "r");
         std::optional<std::chrono::sys_time<std::chrono::milliseconds>> maybe_expiry_unix_ts_ms =
                 maybe_ts_ms(*p, "e");
         std::optional<std::vector<unsigned char>> maybe_sig = maybe_vector(*p, "s");
@@ -37,9 +36,6 @@ bool ProConfig::load(const dict& root) {
         if (!version)
             return false;
         if (!maybe_gen_index_hash || maybe_gen_index_hash->size() != proof.gen_index_hash.size())
-            return false;
-        if (!maybe_rotating_pubkey ||
-            maybe_rotating_pubkey->size() != proof.rotating_pubkey.max_size())
             return false;
         if (!maybe_sig || maybe_sig->size() != proof.sig.max_size())
             return false;
@@ -51,15 +47,14 @@ bool ProConfig::load(const dict& root) {
                 proof.gen_index_hash.data(),
                 maybe_gen_index_hash->data(),
                 proof.gen_index_hash.size());
-        std::memcpy(
-                proof.rotating_pubkey.data(),
-                maybe_rotating_pubkey->data(),
-                proof.rotating_pubkey.size());
         proof.expiry_unix_ts = *maybe_expiry_unix_ts_ms;
         std::memcpy(proof.sig.data(), maybe_sig->data(), proof.sig.size());
     }
 
-    std::memcpy(rotating_privkey.data(), maybe_rotating_privkey->data(), rotating_privkey.size());
+    // Derive the rotating public key from the seed and populate the proof's pubkey and the outer
+    // private key
+    crypto_sign_ed25519_seed_keypair(
+            proof.rotating_pubkey.data(), rotating_privkey.data(), maybe_rotating_seed->data());
     return true;
 }
 

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -10,64 +10,56 @@
 
 namespace session::config {
 
-bool ProConfig::load(bt_dict_consumer& root) {
+bool ProConfig::load(const dict& root) {
     // Get proof fields from session pro data sitting in the 'p' (proof) dictionary
-    if (!root.skip_until("p"))
+    auto p_it = root.find("p");
+    if (p_it == root.end())
         return false;
 
     // Lookup and get 'p'
-    auto pd = root.consume_dict_consumer();
-
-    if (!root.skip_until("r"))
+    const config::dict* p = std::get_if<config::dict>(&p_it->second);
+    if (!p)
         return false;
 
-    auto rotating_privkey_ = root.consume_string_view();
-
-    if (rotating_privkey_.size() != rotating_privkey.max_size())
+    std::optional<std::vector<unsigned char>> maybe_rotating_privkey = maybe_vector(root, "r");
+    if (!maybe_rotating_privkey || maybe_rotating_privkey->size() != rotating_privkey.max_size())
         return false;
 
     // NOTE: Load into the proof object
     {
-        if (!pd.skip_until("@"))
+        std::optional<uint8_t> version = maybe_int(*p, "@");
+        std::optional<std::vector<unsigned char>> maybe_gen_index_hash = maybe_vector(*p, "g");
+        std::optional<std::vector<unsigned char>> maybe_rotating_pubkey = maybe_vector(*p, "r");
+        std::optional<std::chrono::sys_time<std::chrono::milliseconds>> maybe_expiry_unix_ts_ms =
+                maybe_ts_ms(*p, "e");
+        std::optional<std::vector<unsigned char>> maybe_sig = maybe_vector(*p, "s");
+
+        if (!version)
+            return false;
+        if (!maybe_gen_index_hash || maybe_gen_index_hash->size() != proof.gen_index_hash.size())
+            return false;
+        if (!maybe_rotating_pubkey ||
+            maybe_rotating_pubkey->size() != proof.rotating_pubkey.max_size())
+            return false;
+        if (!maybe_sig || maybe_sig->size() != proof.sig.max_size())
+            return false;
+        if (!maybe_expiry_unix_ts_ms)
             return false;
 
-        proof.version = pd.consume_integer<uint8_t>();
-
-        if (!pd.skip_until("e"))
-            return false;
-
-        proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(pd.consume_integer<uint64_t>()));
-
-        if (!pd.skip_until("g"))
-            return false;
-
-        auto gen_index_hash = pd.consume_string_view();
-        if (gen_index_hash.size() != proof.gen_index_hash.size())
-            return false;
-
-        if (!pd.skip_until("r"))
-            return false;
-
-        auto rotating_pubkey = pd.consume_string_view();
-        if (rotating_pubkey.size() != proof.rotating_pubkey.max_size())
-            return false;
-
-        if (!pd.skip_until("s"))
-            return false;
-
-        auto sig = pd.consume_string_view();
-        if (sig.size() != proof.sig.max_size())
-            return false;
-
+        proof.version = *version;
         std::memcpy(
-                proof.gen_index_hash.data(), gen_index_hash.data(), proof.gen_index_hash.size());
+                proof.gen_index_hash.data(),
+                maybe_gen_index_hash->data(),
+                proof.gen_index_hash.size());
         std::memcpy(
-                proof.rotating_pubkey.data(), rotating_pubkey.data(), proof.rotating_pubkey.size());
-        std::memcpy(proof.sig.data(), sig.data(), proof.sig.size());
+                proof.rotating_pubkey.data(),
+                maybe_rotating_pubkey->data(),
+                proof.rotating_pubkey.size());
+        proof.expiry_unix_ts = *maybe_expiry_unix_ts_ms;
+        std::memcpy(proof.sig.data(), maybe_sig->data(), proof.sig.size());
     }
 
-    std::memcpy(rotating_privkey.data(), rotating_privkey_.data(), rotating_privkey.size());
+    std::memcpy(rotating_privkey.data(), maybe_rotating_privkey->data(), rotating_privkey.size());
     return true;
 }
 

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -20,33 +20,6 @@ UserProfile::UserProfile(
     load_key(ed25519_secretkey);
 }
 
-void UserProfile::extra_data(oxenc::bt_dict_producer&& extra) const {
-    if (pro_config) {
-        auto root = extra.append_dict("pro_config");
-
-        const ProProof& pro_proof = pro_config->proof;
-        {
-            auto proof_dict = root.append_dict("p");
-            proof_dict.append("@", pro_proof.version);
-            proof_dict.append("e", pro_proof.expiry_unix_ts.time_since_epoch().count());
-            proof_dict.append("g", pro_proof.gen_index_hash);
-            proof_dict.append("r", pro_proof.rotating_pubkey);
-            proof_dict.append("s", pro_proof.sig);
-        }
-
-        root.append("r", pro_config->rotating_privkey);
-    }
-}
-
-void UserProfile::load_extra_data(oxenc::bt_dict_consumer&& extra) {
-    if (extra.skip_until("pro_config")) {
-        auto pd = extra.consume_dict_consumer();
-        ProConfig pro = {};
-        if (pro.load(pd))
-            pro_config = std::move(pro);
-    }
-}
-
 std::optional<std::string_view> UserProfile::get_name() const {
     if (auto* s = data["n"].string(); s && !s->empty())
         return *s;
@@ -177,13 +150,29 @@ std::chrono::sys_seconds UserProfile::get_profile_updated() const {
 }
 
 std::optional<ProConfig> UserProfile::get_pro_config() const {
-    return pro_config;
+    std::optional<ProConfig> result = {};
+    if (const config::dict* s = data["s"].dict(); s) {
+        ProConfig pro = {};
+        if (pro.load(*s))
+            result = std::move(pro);
+    }
+    return result;
 }
 
-void UserProfile::set_pro_config(ProConfig const& pro) {
-    if (pro_config != pro) {
-        pro_config = pro;
-        _needs_dump = true;
+void UserProfile::set_pro_config(const ProConfig& pro) {
+    const std::optional<ProConfig>& curr = get_pro_config();
+    if (!curr || *curr != pro) {
+        auto root = data["s"];
+        root["r"] = pro.rotating_privkey;
+
+        const ProProof& pro_proof = pro.proof;
+        auto proof_dict = root["p"];
+        proof_dict["@"] = pro_proof.version;
+        proof_dict["g"] = pro_proof.gen_index_hash;
+        proof_dict["r"] = pro_proof.rotating_pubkey;
+        proof_dict["e"] = pro_proof.expiry_unix_ts.time_since_epoch().count();
+        proof_dict["s"] = pro_proof.sig;
+
         const auto target_timestamp =
                 (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");
         data[target_timestamp] = ts_now();
@@ -191,13 +180,9 @@ void UserProfile::set_pro_config(ProConfig const& pro) {
 }
 
 bool UserProfile::remove_pro_config() {
-    if (pro_config) {
-        pro_config = std::nullopt;
-        _needs_dump = true;
-        return true;
-    }
-
-    return false;
+    bool result = data["s"].exists();
+    data["s"].erase();
+    return result;
 }
 
 session::ProProfileBitset UserProfile::get_profile_bitset() const {

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -1,6 +1,7 @@
 #include "session/config/user_profile.h"
 
 #include <sodium/crypto_generichash_blake2b.h>
+#include <sodium/crypto_sign_ed25519.h>
 
 #include "internal.hpp"
 #include "session/config/contacts.hpp"
@@ -163,12 +164,12 @@ void UserProfile::set_pro_config(const ProConfig& pro) {
     std::optional<ProConfig> curr = get_pro_config();
     if (!curr || *curr != pro) {
         auto root = data["s"];
-        root["r"] = pro.rotating_privkey;
+        root["r"] = std::span<const unsigned char>(
+                pro.rotating_privkey.data(), crypto_sign_ed25519_SEEDBYTES);
 
         auto proof_dict = root["p"];
         proof_dict["@"] = pro.proof.version;
         proof_dict["g"] = pro.proof.gen_index_hash;
-        proof_dict["r"] = pro.proof.rotating_pubkey;
         proof_dict["e"] = pro.proof.expiry_unix_ts.time_since_epoch().count();
         proof_dict["s"] = pro.proof.sig;
 

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -151,7 +151,7 @@ std::chrono::sys_seconds UserProfile::get_profile_updated() const {
 
 std::optional<ProConfig> UserProfile::get_pro_config() const {
     std::optional<ProConfig> result = {};
-    if (const config::dict* s = data["s"].dict(); s) {
+    if (const config::dict* s = data["s"].dict()) {
         ProConfig pro = {};
         if (pro.load(*s))
             result = std::move(pro);
@@ -160,7 +160,7 @@ std::optional<ProConfig> UserProfile::get_pro_config() const {
 }
 
 void UserProfile::set_pro_config(const ProConfig& pro) {
-    const std::optional<ProConfig>& curr = get_pro_config();
+    std::optional<ProConfig> curr = get_pro_config();
     if (!curr || *curr != pro) {
         auto root = data["s"];
         root["r"] = pro.rotating_privkey;

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -165,13 +165,12 @@ void UserProfile::set_pro_config(const ProConfig& pro) {
         auto root = data["s"];
         root["r"] = pro.rotating_privkey;
 
-        const ProProof& pro_proof = pro.proof;
         auto proof_dict = root["p"];
-        proof_dict["@"] = pro_proof.version;
-        proof_dict["g"] = pro_proof.gen_index_hash;
-        proof_dict["r"] = pro_proof.rotating_pubkey;
-        proof_dict["e"] = pro_proof.expiry_unix_ts.time_since_epoch().count();
-        proof_dict["s"] = pro_proof.sig;
+        proof_dict["@"] = pro.proof.version;
+        proof_dict["g"] = pro.proof.gen_index_hash;
+        proof_dict["r"] = pro.proof.rotating_pubkey;
+        proof_dict["e"] = pro.proof.expiry_unix_ts.time_since_epoch().count();
+        proof_dict["s"] = pro.proof.sig;
 
         const auto target_timestamp =
                 (data["t"].integer_or(0) >= data["T"].integer_or(0) ? "t" : "T");

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -101,25 +101,22 @@ TEST_CASE("Pro", "[config][pro]") {
 
     // Try loading the proof from dict
     {
-        oxenc::bt_dict_producer good_dict;
-
-        // clang-format off
         const session::ProProof& proof = pro_cpp.proof;
-        {
-            auto p = good_dict.append_dict("p");
-            /*version*/         p.append("@", proof.version);
-            /*expiry unix ts*/  p.append("e", proof.expiry_unix_ts.time_since_epoch().count());
-            /*gen_index_hash*/  p.append("g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size()));
-            /*rotating pubkey*/ p.append("r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size()));
-            /*signature*/       p.append("s", std::string{reinterpret_cast<const char *>(proof.sig.data()), proof.sig.size()});
-        }
-        
-        good_dict.append("r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size()));
+        // clang-format off
+        session::config::dict good_dict = {
+            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size())},
+            {"p", session::config::dict{
+                /*version*/         {"@", proof.version},
+                /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},
+                /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
+                /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
+                /*signature*/       {"s", std::string{reinterpret_cast<const char *>(proof.sig.data()), proof.sig.size()}},
+            }}
+        };
         // clang-format on
 
         session::config::ProConfig loaded_pro = {};
-        auto good_dict_consumer = oxenc::bt_dict_consumer{good_dict.view()};
-        CHECK(loaded_pro.load(good_dict_consumer));
+        CHECK(loaded_pro.load(good_dict));
         CHECK(loaded_pro.rotating_privkey == pro_cpp.rotating_privkey);
         CHECK(loaded_pro.proof.version == pro_cpp.proof.version);
         CHECK(loaded_pro.proof.gen_index_hash == pro_cpp.proof.gen_index_hash);
@@ -131,27 +128,25 @@ TEST_CASE("Pro", "[config][pro]") {
 
     // Try loading a proof with a bad signature in it from dict
     {
-        oxenc::bt_dict_producer bad_dict;
         std::array<uint8_t, 64> broken_sig = pro_cpp.proof.sig;
         broken_sig[0] = ~broken_sig[0];  // Break the sig
+        const session::ProProof& proof = pro_cpp.proof;
 
         // clang-format off
-        const session::ProProof& proof = pro_cpp.proof;
-        {
-            auto p = bad_dict.append_dict("p");
-            /*version*/         p.append("@", proof.version);
-            /*expiry unix ts*/  p.append("e", proof.expiry_unix_ts.time_since_epoch().count());
-            /*gen_index_hash*/  p.append("g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size()));
-            /*rotating pubkey*/ p.append("r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size()));
-            /*signature*/       p.append("s", std::string{reinterpret_cast<const char *>(broken_sig.data()), broken_sig.size()});
-        }
-
-        bad_dict.append("r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size()));
+        session::config::dict bad_dict = {
+            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size())},
+            {"p", session::config::dict{
+                /*version*/         {"@", proof.version},
+                /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},
+                /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
+                /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
+                /*signature*/       {"s", std::string{reinterpret_cast<const char *>(broken_sig.data()), broken_sig.size()}},
+            }}
+        };
         // clang-format on
 
         session::config::ProConfig loaded_pro = {};
-        auto bad_dict_consumer = oxenc::bt_dict_consumer{bad_dict.view()};
-        CHECK(loaded_pro.load(bad_dict_consumer));
+        CHECK(loaded_pro.load(bad_dict));
         CHECK_FALSE(loaded_pro.proof.verify_signature(signing_pk));
     }
 }

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Pro", "[config][pro]") {
         const session::ProProof& proof = pro_cpp.proof;
         // clang-format off
         session::config::dict good_dict = {
-            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size())},
+            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), crypto_sign_ed25519_SEEDBYTES)},
             {"p", session::config::dict{
                 /*version*/         {"@", proof.version},
                 /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},
@@ -134,7 +134,7 @@ TEST_CASE("Pro", "[config][pro]") {
 
         // clang-format off
         session::config::dict bad_dict = {
-            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), rotating_sk.size())},
+            {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), crypto_sign_ed25519_SEEDBYTES)},
             {"p", session::config::dict{
                 /*version*/         {"@", proof.version},
                 /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},


### PR DESCRIPTION
Restore syncing to the swarms so that multi-device Session accounts agree and unify and use the same Session Pro proof. Having every device use the same proof is important to prevent observers from identifying devices based on their attached proof.

This removes the std::optional<ProConfig> from the user profile and instead it's loaded from the internal `.data` dict and follows the same pattern as the rest of the code. Caching the value is additional state that can go out of sync.