### PR TITLE
fix: reject corrupted attachment stream decrypts

### DIFF
--- a/include/session/attachments.hpp
+++ b/include/session/attachments.hpp
@@ -307,14 +307,14 @@ class Decryptor {
     /// previous failure).
     ///
     /// Throws std::logic_error if called after a successful finalize().
-    bool update(std::span<const std::byte> enc_data);
+    [[nodiscard]] bool update(std::span<const std::byte> enc_data);
 
     /// Called to signal the end of the encrypted data stream.  If all data was processed
     /// successfully and the stream ended properly, this returns true; returns false if the stream
     /// data did not indicate finality (or if a previous update returned failure).
     ///
     /// Throws std::logic_error if called after a successful finalize().
-    bool finalize();
+    [[nodiscard]] bool finalize();
 };
 
 /// API: crypto/attachment::decrypt

--- a/src/attachments.cpp
+++ b/src/attachments.cpp
@@ -91,6 +91,12 @@ std::optional<size_t> decrypted_max_size(size_t encrypted_size) {
     return sz;
 }
 
+class decryption_failure : public std::runtime_error {
+  public:
+    decryption_failure() :
+            std::runtime_error{"Attachment decryption failed: invalid key or corrupted data"} {}
+};
+
 // We have to roll our own custom version of crypto_secretstream_xchacha20poly1305_init_push here
 // because libsodium offers no way to provide the randomness it uses (it hard codes a call to
 // randombytes_buf), and so this repeats its internal implementation but using our hashed data for
@@ -703,7 +709,7 @@ void Decryptor::process_chunk(std::span<const std::byte> chunk, bool is_final) {
     output(out);
 }
 
-bool Decryptor::update(std::span<const std::byte> enc_data) {
+[[nodiscard]] bool Decryptor::update(std::span<const std::byte> enc_data) {
     if (failed)
         return false;
     if (finished)
@@ -758,7 +764,7 @@ bool Decryptor::update(std::span<const std::byte> enc_data) {
     return true;
 }
 
-bool Decryptor::finalize() {
+[[nodiscard]] bool Decryptor::finalize() {
     if (failed)
         return false;
 
@@ -791,8 +797,8 @@ void decrypt(
                         out.write(reinterpret_cast<const char*>(data.data()), data.size());
                     }};
 
-        d.update(encrypted);
-        d.finalize();
+        if (!d.update(encrypted) || !d.finalize())
+            throw decryption_failure{};
     } catch (const std::exception& e) {
         std::error_code ec;
         std::filesystem::remove(filename, ec);
@@ -832,12 +838,15 @@ size_t decrypt(
                 }};
 
     std::array<std::byte, 4096> chunk;
-    while (in.read(reinterpret_cast<char*>(chunk.data()), chunk.size()))
-        d.update(chunk);
-    if (in.gcount() > 0)
-        d.update(std::span{chunk}.first(in.gcount()));
+    while (in.read(reinterpret_cast<char*>(chunk.data()), chunk.size())) {
+        if (!d.update(chunk))
+            throw decryption_failure{};
+    }
+    if (in.gcount() > 0 && !d.update(std::span{chunk}.first(in.gcount())))
+        throw decryption_failure{};
 
-    d.finalize();
+    if (!d.finalize())
+        throw decryption_failure{};
 
     return decrypted - out.begin();
 }
@@ -881,11 +890,14 @@ void decrypt(
                     }};
 
         std::array<std::byte, 4096> chunk;
-        while (in.read(reinterpret_cast<char*>(chunk.data()), chunk.size()))
-            d.update(chunk);
-        if (in.gcount() > 0)
-            d.update(std::span{chunk}.first(in.gcount()));
-        d.finalize();
+        while (in.read(reinterpret_cast<char*>(chunk.data()), chunk.size())) {
+            if (!d.update(chunk))
+                throw decryption_failure{};
+        }
+        if (in.gcount() > 0 && !d.update(std::span{chunk}.first(in.gcount())))
+            throw decryption_failure{};
+        if (!d.finalize())
+            throw decryption_failure{};
     } catch (const std::exception& e) {
         std::error_code ec;
         std::filesystem::remove(file_out, ec);

--- a/tests/test_attachment_encrypt.cpp
+++ b/tests/test_attachment_encrypt.cpp
@@ -262,6 +262,24 @@ static std::vector<std::byte> slurp_file(const std::filesystem::path& filename) 
     return contents;
 }
 
+static void write_file(const std::filesystem::path& filename, std::span<const std::byte> contents) {
+    std::ofstream out;
+    out.exceptions(std::ios::failbit | std::ios::badbit);
+    out.open(filename, std::ios::binary | std::ios::trunc);
+    out.write(reinterpret_cast<const char*>(contents.data()), contents.size());
+}
+
+static void corrupt_last_byte(std::vector<std::byte>& data) {
+    REQUIRE(!data.empty());
+    data.back() ^= std::byte{0x01};
+}
+
+static void corrupt_first_full_chunk(std::vector<std::byte>& data) {
+    constexpr size_t first_chunk_offset = 1 + attachment::ENCRYPT_HEADER;
+    REQUIRE(data.size() > first_chunk_offset + attachment::ENCRYPTED_CHUNK_TOTAL);
+    data[first_chunk_offset] ^= std::byte{0x01};
+}
+
 TEST_CASE(
         "Attachment encryption: plaintext buffer to encrypted file",
         "[attachments][files][encrypt]") {
@@ -361,4 +379,85 @@ TEST_CASE(
     auto contents = slurp_file(out_dec.path);
     CHECK(contents.size() == data.size());
     CHECK(!!(contents == data));
+}
+
+TEST_CASE(
+        "Attachment streaming decryption rejects corrupted data", "[attachments][files][decrypt]") {
+
+    auto seed = "a123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_b;
+    auto data = make_data(1000);
+
+    auto [enc, key] = attachment::encrypt(seed, data, attachment::Domain::ATTACHMENT);
+    corrupt_last_byte(enc);
+
+    SECTION("encrypted buffer to plaintext file") {
+        temp_data_file out;
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(enc, key, out.path), std::runtime_error, bad_data_message);
+        CHECK_FALSE(std::filesystem::exists(out.path));
+    }
+
+    SECTION("encrypted file to plaintext buffer") {
+        temp_data_file encrypted_file;
+        write_file(encrypted_file.path, enc);
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(encrypted_file.path, key),
+                std::runtime_error,
+                bad_data_message);
+    }
+
+    SECTION("encrypted file to plaintext file") {
+        temp_data_file encrypted_file;
+        temp_data_file out;
+        write_file(encrypted_file.path, enc);
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(encrypted_file.path, key, out.path),
+                std::runtime_error,
+                bad_data_message);
+        CHECK_FALSE(std::filesystem::exists(out.path));
+    }
+}
+
+TEST_CASE(
+        "Attachment streaming decryption rejects corrupted full chunks",
+        "[attachments][files][decrypt]") {
+
+    auto seed = "b123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_b;
+    auto data = make_data(attachment::ENCRYPT_CHUNK_SIZE * 2);
+
+    auto [enc, key] = attachment::encrypt(seed, data, attachment::Domain::ATTACHMENT);
+    corrupt_first_full_chunk(enc);
+
+    SECTION("encrypted buffer to plaintext file") {
+        temp_data_file out;
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(enc, key, out.path), std::runtime_error, bad_data_message);
+        CHECK_FALSE(std::filesystem::exists(out.path));
+    }
+
+    SECTION("encrypted file to plaintext buffer") {
+        temp_data_file encrypted_file;
+        write_file(encrypted_file.path, enc);
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(encrypted_file.path, key),
+                std::runtime_error,
+                bad_data_message);
+    }
+
+    SECTION("encrypted file to plaintext file") {
+        temp_data_file encrypted_file;
+        temp_data_file out;
+        write_file(encrypted_file.path, enc);
+
+        CHECK_THROWS_MATCHES(
+                attachment::decrypt(encrypted_file.path, key, out.path),
+                std::runtime_error,
+                bad_data_message);
+        CHECK_FALSE(std::filesystem::exists(out.path));
+    }
 }


### PR DESCRIPTION
## summary

- make attachment stream decrypt wrappers throw when `Decryptor::update()` or `finalize()` rejects corrupted data
- keep partial output cleanup for file decrypt paths
- add coverage for final-byte corruption and full-chunk corruption across the file/buffer decrypt wrappers

## testing

- `cmake -G Ninja -S . -B Build -DENABLE_NETWORKING=ON -DUSE_LTO=OFF`
- `./utils/format.sh verify`
- `cmake --build Build --target testAll --parallel 4`
- `Build/tests/testAll "Attachment streaming decryption rejects corrupted data" -s`
- `Build/tests/testAll "Attachment streaming decryption rejects corrupted full chunks" -s`
- `Build/tests/testAll "[attachments]"`
- `Build/tests/testAll`
