### PR TITLE
fix: remove modulo bias from random helper

### DIFF
--- a/include/session/random.hpp
+++ b/include/session/random.hpp
@@ -3,6 +3,10 @@
 #include <sodium/randombytes.h>
 
 #include <algorithm>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <random>
 
 #include "util.hpp"
 
@@ -75,13 +79,12 @@ std::string unique_id(std::string_view prefix);
 ///
 /// Outputs:
 /// - A random integer in the specified range
-template <typename T>
+template <std::integral T>
 T get_uniform_distribution(T min, T max) {
     if (min > max)
         return min;
 
-    const uint64_t range = static_cast<uint64_t>(max) - static_cast<uint64_t>(min) + 1;
-    return static_cast<T>(static_cast<uint64_t>(min) + (csrng() % range));
+    return std::uniform_int_distribution<T>{min, max}(csrng);
 }
 
 }  // namespace session::random

--- a/tests/test_random.cpp
+++ b/tests/test_random.cpp
@@ -1,4 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <limits>
 
 #include "session/random.h"
 #include "session/random.hpp"
@@ -13,4 +15,22 @@ TEST_CASE("Random generation", "[random][random]") {
     CHECK(rand2.size() == 10);
     CHECK(rand3.size() == 20);
     CHECK(rand1 != rand2);
+}
+
+TEST_CASE("Random uniform distribution", "[random][uniform]") {
+    CHECK(session::random::get_uniform_distribution<int>(7, 7) == 7);
+    CHECK(session::random::get_uniform_distribution<int>(9, 3) == 9);
+    CHECK_NOTHROW(session::random::get_uniform_distribution<uint64_t>(
+            0, std::numeric_limits<uint64_t>::max()));
+    CHECK_NOTHROW(session::random::get_uniform_distribution<int64_t>(
+            std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()));
+
+    for (int i = 0; i < 1000; ++i) {
+        const auto signed_value = session::random::get_uniform_distribution<int>(-5, 5);
+        CHECK(signed_value >= -5);
+        CHECK(signed_value <= 5);
+
+        const auto unsigned_value = session::random::get_uniform_distribution<size_t>(0, 10);
+        CHECK(unsigned_value <= 10);
+    }
 }


### PR DESCRIPTION
This replaces the `% range` reduction in `random::get_uniform_distribution` with `std::uniform_int_distribution`, using the existing libsodium-backed `CSRNG`

That keeps the helper aligned with its documented uniform behavior, while preserving the existing `min > max` fallback. The new tests cover equal bounds, inverted bounds, signed ranges, unsigned ranges, and full-width 64-bit ranges

## testing

- `./utils/format.sh verify`
- `git diff --check`
- `cmake --build Build-pr-system --parallel --verbose`
- `./Build-pr-system/tests/testLogging --colour-mode none -d yes`
- `./Build-pr-system/tests/testAll "[random]" --colour-mode none -d yes`
- `./Build-pr-system/tests/testAll --colour-mode none -d yes`