### PR TITLE
Pro backend updates for 0.2.0 backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(libsession-util
-    VERSION 1.6.7
+    VERSION 1.7.0
     DESCRIPTION "Session client utility library"
     LANGUAGES ${LANGS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,11 @@ else()
 endif()
 
 option(BUILD_STATIC_DEPS "Build all dependencies statically rather than trying to link to them on the system" ${static_default})
-option(STATIC_BUNDLE "Build a single static .a containing everything (both code and dependencies)" ${static_default})
+option(STATIC_BUNDLE "Build a single static .a containing everything (both code and dependencies)" ${BUILD_STATIC_DEPS})
+
+if(STATIC_BUNDLE AND NOT BUILD_STATIC_DEPS)
+    message(FATAL_ERROR "STATIC_BUNDLE requires BUILD_STATIC_DEPS=ON (cannot build a static bundle when using shared/system libs)")
+endif()
 
 if(BUILD_SHARED_LIBS OR libsession_IS_TOPLEVEL_PROJECT)
     set(install_default ON)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -110,8 +110,13 @@ endif()
 
 libsession_system_or_submodule(OXENC oxenc oxenc::oxenc liboxenc>=1.5.0 session-router/external/oxen-libquic/external/oxen-encoding)
 
-libsession_system_or_submodule(OXENLOGGING oxenlogging oxen::logging liboxen-logging>=1.2.0 session-router/external/oxen-libquic/external/oxen-logging)
-if(OXENLOGGING_FOUND)
+if(NOT TARGET oxen::logging)
+    # Find this one using an intermediate target alias (oxenlogging::oxenlogging) rather than the
+    # final oxen::logging alias target that we actually use: that way either we go into using it as
+    # a submodule (in which case the submodule sets up oxen::logging), or else we find via system
+    # lib, in which case we need an extra intermediate interface library that also brings in fmt and
+    # spdlog.
+    libsession_system_or_submodule(OXENLOGGING oxen-logging oxenlogging::oxenlogging liboxen-logging>=1.2.0 session-router/external/oxen-libquic/external/oxen-logging)
     if(NOT TARGET oxen::logging)
         # If we load oxen-logging via system lib then we won't necessarily have fmt/spdlog targets,
         # but this script will give us them:

--- a/include/session/config/convo_info_volatile.h
+++ b/include/session/config/convo_info_volatile.h
@@ -14,10 +14,10 @@ typedef struct convo_info_volatile_1to1 {
     int64_t last_read;  // milliseconds since unix epoch
     bool unread;        // true if the conversation is explicitly marked unread
 
-    bool has_pro_gen_index_hash;     // Flag indicating if hash is set
-    bytes32 pro_gen_index_hash;      // Hash of the generation index set by the Session Pro Backend
-    uint64_t pro_expiry_unix_ts_ms;  // Unix epoch timestamp to which this contacts entitlement to
-                                     // Session Pro features is valid to
+    bool has_pro_gen_index_hash;  // Flag indicating if hash is set
+    bytes32 pro_gen_index_hash;   // Hash of the generation index set by the Session Pro Backend
+    int64_t pro_expiry_ts;        // Unix epoch timestamp (seconds) until which this contact's
+                                  // entitlement to Session Pro features is valid
 } convo_info_volatile_1to1;
 
 typedef struct convo_info_volatile_community {
@@ -51,10 +51,10 @@ typedef struct convo_info_volatile_blinded_1to1 {
     int64_t last_read;  // ms since unix epoch
     bool unread;        // true if the conversation is explicitly marked unread
 
-    bool has_pro_gen_index_hash;     // Flag indicating if hash is set
-    bytes32 pro_gen_index_hash;      // Hash of the generation index set by the Session Pro Backend
-    uint64_t pro_expiry_unix_ts_ms;  // Unix epoch timestamp to which this contacts entitlement to
-                                     // Session Pro features is valid to
+    bool has_pro_gen_index_hash;  // Flag indicating if hash is set
+    bytes32 pro_gen_index_hash;   // Hash of the generation index set by the Session Pro Backend
+    int64_t pro_expiry_ts;        // Unix epoch timestamp (seconds) until which this contact's
+                                  // entitlement to Session Pro features is valid
 } convo_info_volatile_blinded_1to1;
 
 /// API: convo_info_volatile/convo_info_volatile_init

--- a/include/session/config/convo_info_volatile.h
+++ b/include/session/config/convo_info_volatile.h
@@ -14,8 +14,9 @@ typedef struct convo_info_volatile_1to1 {
     int64_t last_read;  // milliseconds since unix epoch
     bool unread;        // true if the conversation is explicitly marked unread
 
-    bool has_pro_gen_index_hash;  // Flag indicating if hash is set
-    bytes32 pro_gen_index_hash;   // Hash of the generation index set by the Session Pro Backend
+    bool has_pro_revocation_tag;  // Flag indicating if hash is set
+    bytes32 pro_revocation_tag;   // Opaque revocation tag identifying this proof (from the Session
+                                  // Pro backend)
     int64_t pro_expiry_ts;        // Unix epoch timestamp (seconds) until which this contact's
                                   // entitlement to Session Pro features is valid
 } convo_info_volatile_1to1;
@@ -51,8 +52,9 @@ typedef struct convo_info_volatile_blinded_1to1 {
     int64_t last_read;  // ms since unix epoch
     bool unread;        // true if the conversation is explicitly marked unread
 
-    bool has_pro_gen_index_hash;  // Flag indicating if hash is set
-    bytes32 pro_gen_index_hash;   // Hash of the generation index set by the Session Pro Backend
+    bool has_pro_revocation_tag;  // Flag indicating if hash is set
+    bytes32 pro_revocation_tag;   // Opaque revocation tag identifying this proof (from the Session
+                                  // Pro backend)
     int64_t pro_expiry_ts;        // Unix epoch timestamp (seconds) until which this contact's
                                   // entitlement to Session Pro features is valid
 } convo_info_volatile_blinded_1to1;

--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -89,9 +89,9 @@ namespace convo {
         /// Hash of the generation index set by the Session Pro Backend
         std::optional<array_uc32> pro_gen_index_hash;
 
-        /// Unix epoch timestamp to which this proof's entitlement to Session Pro features is valid
-        /// to
-        sys_ms pro_expiry_unix_ts{};
+        /// Unix epoch timestamp (seconds) until which this proof's entitlement to Session Pro
+        /// features is valid
+        sys_seconds pro_expiry_unix_ts{};
 
       protected:
         using base::base;

--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -32,7 +32,7 @@ class val_loader;
 /// 1 - dict of one-to-one conversations.  Each key is the Session ID of the contact (in hex).
 ///     Values are dicts with keys:
 ///     e - contacts pro expiry unix timestamp (in milliseconds)
-///     g - contacts pro gen_index_hash
+///     g - contacts pro revocation_tag
 ///     r - the unix timestamp (in integer milliseconds) of the last-read message.  Always
 ///         included, but will be 0 if no messages are read.
 ///     u - will be present and set to 1 if this conversation is specifically marked unread.
@@ -62,7 +62,7 @@ class val_loader;
 /// b - outgoing blinded message request conversations.  The key is the blinded Session ID without
 ///     the prefix.  Values are dicts with keys:
 ///     e - contacts pro expiry unix timestamp (in milliseconds)
-///     g - contacts pro gen_index_hash
+///     g - contacts pro revocation_tag
 ///     r - the unix timestamp (integer milliseconds) of the last-read message.  Always included,
 ///         but will be 0 if no messages are read.
 ///     u - will be present and set to 1 if this conversation is specifically marked unread.
@@ -86,8 +86,8 @@ namespace convo {
     };
 
     struct pro_base : base {
-        /// Hash of the generation index set by the Session Pro Backend
-        std::optional<array_uc32> pro_gen_index_hash;
+        /// Opaque revocation tag identifying this proof (from the Session Pro backend)
+        std::optional<array_uc32> pro_revocation_tag;
 
         /// Unix epoch timestamp (seconds) until which this proof's entitlement to Session Pro
         /// features is valid

--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -91,7 +91,7 @@ namespace convo {
 
         /// Unix epoch timestamp (seconds) until which this proof's entitlement to Session Pro
         /// features is valid
-        sys_seconds pro_expiry_unix_ts{};
+        sys_seconds pro_expiry_at{};
 
       protected:
         using base::base;

--- a/include/session/config/pro.hpp
+++ b/include/session/config/pro.hpp
@@ -14,7 +14,7 @@ namespace session::config {
 ///   |     |
 ///   |     +-- @ - version
 ///   |     +-- e - expiry unix timestamp (in milliseconds)
-///   |     +-- g - gen_index_hash
+///   |     +-- g - revocation_tag
 ///   |     +-- s - proof signature, signed by the Session Pro Backend's ed25519 key
 ///   |
 ///   +-- r - rotating ed25519 seed (32b)

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -375,7 +375,7 @@ LIBSESSION_EXPORT void user_profile_set_pro_badge(config_object* conf, bool enab
 /// - `enabled` -- Flag which specifies whether the users display picture is animated or not.
 LIBSESSION_EXPORT void user_profile_set_animated_avatar(config_object* conf, bool enabled);
 
-/// API: user_profile/user_profile_get_pro_access_expiry_ms
+/// API: user_profile/user_profile_get_pro_access_expiry
 ///
 /// Retrieves the Session Pro access expiry unix timestamp if it has been set, this should generally
 /// be the expiry value returned from /get_pro_details.
@@ -384,20 +384,20 @@ LIBSESSION_EXPORT void user_profile_set_animated_avatar(config_object* conf, boo
 /// - `conf` -- [in] Pointer to the config object
 ///
 /// Outputs:
-/// - `uint64_t` - The unix timestamp in milliseconds that the users pro access will expire, or 0 if
+/// - `int64_t` - The unix timestamp in seconds that the users pro access will expire, or 0 if
 /// unset.
-LIBSESSION_EXPORT uint64_t user_profile_get_pro_access_expiry_ms(const config_object* conf);
+LIBSESSION_EXPORT int64_t user_profile_get_pro_access_expiry(const config_object* conf);
 
-/// API: user_profile/user_profile_set_pro_access_expiry_ms
+/// API: user_profile/user_profile_set_pro_access_expiry
 ///
 /// Updates the Session Pro access expiry unix timestamp.
 ///
 /// Inputs:
 /// - `conf` -- [in] Pointer to the config object
-/// - `access_expiry_ts_ms` -- The timestamp that the users Session Pro access will expire, or 0 to
-/// remove the value.
-LIBSESSION_EXPORT void user_profile_set_pro_access_expiry_ms(
-        config_object* conf, uint64_t access_expiry_ts_ms);
+/// - `access_expiry_ts` -- The timestamp (unix epoch seconds) that the users Session Pro access
+/// will expire, or 0 to remove the value.
+LIBSESSION_EXPORT void user_profile_set_pro_access_expiry(
+        config_object* conf, int64_t access_expiry_ts);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -378,7 +378,7 @@ LIBSESSION_EXPORT void user_profile_set_animated_avatar(config_object* conf, boo
 /// API: user_profile/user_profile_get_pro_access_expiry
 ///
 /// Retrieves the Session Pro access expiry unix timestamp if it has been set, this should generally
-/// be the expiry value returned from /get_pro_details.
+/// be the expiry value returned from /get_pro_status.
 ///
 /// Inputs:
 /// - `conf` -- [in] Pointer to the config object

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -310,7 +310,7 @@ class UserProfile : public ConfigBase {
     /// API: user_profile/UserProfile::get_pro_access_expiry
     ///
     /// Retrieves the Session Pro access expiry unix timestamp if it has been set, this should
-    /// generally be the expiry value returned from /get_pro_details.
+    /// generally be the expiry value returned from /get_pro_status.
     ///
     /// Inputs:  None
     ///

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -315,19 +315,18 @@ class UserProfile : public ConfigBase {
     /// Inputs:  None
     ///
     /// Outputs:
-    /// - `std::optional<sys_ms>` - The unix timestamp in
-    /// milliseconds that the users pro access will expire, or nullopt if unset.
-    std::optional<sys_ms> get_pro_access_expiry() const;
+    /// - `std::optional<sys_seconds>` - The unix timestamp in
+    /// seconds that the users pro access will expire, or nullopt if unset.
+    std::optional<sys_seconds> get_pro_access_expiry() const;
 
     /// API: user_profile/UserProfile::set_pro_access_expiry
     ///
     /// Updates the Session Pro access expiry unix timestamp.
     ///
     /// Inputs:
-    /// - `access_expiry_ts_ms` -- The timestamp that the users Session Pro access will expire, or
-    /// nullopt to remove the value.
-    void set_pro_access_expiry(
-            std::optional<std::chrono::sys_time<std::chrono::milliseconds>> access_expiry_ts_ms);
+    /// - `access_expiry_ts` -- The timestamp (unix epoch seconds) that the users Session Pro access
+    /// will expire, or nullopt to remove the value.
+    void set_pro_access_expiry(std::optional<sys_seconds> access_expiry_ts);
 };
 
 }  // namespace session::config

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -113,69 +113,14 @@ struct session_pro_backend_request {
     const char* content_type;
     /// The opaque request payload. Relay untouched; do not parse or modify.
     string8 data;
-};
-
-typedef struct session_pro_backend_master_rotating_signatures
-        session_pro_backend_master_rotating_signatures;
-struct session_pro_backend_master_rotating_signatures {
-    bool success;
-    char error[256];
-    size_t error_count;
-    bytes64 master_sig;
-    bytes64 rotating_sig;
-};
-
-typedef struct session_pro_backend_signature session_pro_backend_signature;
-struct session_pro_backend_signature {
-    bool success;
-    char error[256];
-    size_t error_count;
-    bytes64 sig;
-};
-
-typedef struct session_pro_backend_add_pro_payment_user_transaction
-        session_pro_backend_add_pro_payment_user_transaction;
-struct session_pro_backend_add_pro_payment_user_transaction {
-    /// Provider code string (see SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*); opaque slug
-    char provider_code[64];
-    size_t provider_code_count;
-    /// Opaque payment identifier from the provider's purchase flow. Multi-part providers fold their
-    /// parts into this one string per a backend-defined composite (e.g. Google "token|order_id");
-    /// libsession treats it as opaque bytes hashed verbatim.
-    char payment_id[128];
-    size_t payment_id_count;
-};
-
-typedef struct session_pro_backend_add_pro_payment_request
-        session_pro_backend_add_pro_payment_request;
-struct session_pro_backend_add_pro_payment_request {
-    bytes32 master_pkey;
-    bytes32 rotating_pkey;
-    session_pro_backend_add_pro_payment_user_transaction payment_tx;
-    bytes64 master_sig;
-    bytes64 rotating_sig;
-};
-
-typedef struct session_pro_backend_generate_pro_proof_request
-        session_pro_backend_generate_pro_proof_request;
-struct session_pro_backend_generate_pro_proof_request {
-    bytes32 master_pkey;
-    bytes32 rotating_pkey;
-    int64_t ts;
-    bytes64 master_sig;
-    bytes64 rotating_sig;
+    /// Owned C++ object backing endpoint/content_type/data; do not touch (freed by request_free).
+    void* internal_;
 };
 
 typedef struct session_pro_backend_pro_proof_response session_pro_backend_pro_proof_response;
 struct session_pro_backend_pro_proof_response {
     session_pro_backend_response_header header;
     session_protocol_pro_proof proof;
-};
-
-typedef struct session_pro_backend_get_pro_revocations_request
-        session_pro_backend_get_pro_revocations_request;
-struct session_pro_backend_get_pro_revocations_request {
-    int64_t ticket;
 };
 
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
@@ -195,15 +140,6 @@ struct session_pro_backend_get_pro_revocations_response {
     /// Array of items, with items_count elements
     session_pro_backend_pro_revocation_item* items;
     size_t items_count;
-};
-
-typedef struct session_pro_backend_get_pro_details_request
-        session_pro_backend_get_pro_details_request;
-struct session_pro_backend_get_pro_details_request {
-    bytes32 master_pkey;
-    bytes64 master_sig;
-    int64_t ts;
-    uint32_t count;
 };
 
 typedef struct session_pro_backend_pro_payment_item session_pro_backend_pro_payment_item;
@@ -255,16 +191,6 @@ struct session_pro_backend_get_pro_details_response {
     uint32_t payments_total;
 };
 
-typedef struct session_pro_backend_set_payment_refund_requested_request
-        session_pro_backend_set_payment_refund_requested_request;
-struct session_pro_backend_set_payment_refund_requested_request {
-    bytes32 master_pkey;
-    bytes64 master_sig;
-    int64_t ts;
-    int64_t refund_requested_ts;
-    session_pro_backend_add_pro_payment_user_transaction payment_tx;
-};
-
 typedef struct session_pro_backend_set_payment_refund_requested_response
         session_pro_backend_set_payment_refund_requested_response;
 struct session_pro_backend_set_payment_refund_requested_response {
@@ -272,130 +198,73 @@ struct session_pro_backend_set_payment_refund_requested_response {
     bool updated;
 };
 
-/// API: session_pro_backend/add_pro_payment_request_build_sigs
+/// API: session_pro_backend/add_pro_payment_request_build
 ///
-/// Builds master and rotating signatures for an `add_pro_payment_request`.
-/// Returns false if the keys (32-byte or 64-byte libsodium format) or payment token hash are
-/// incorrectly sized. Using 64-byte libsodium keys is more efficient.
+/// Builds the add-payment request to POST, as a session_pro_backend_request (endpoint +
+/// content_type + opaque data). Free it with `session_pro_backend_request_free`. On a key-size
+/// error `success` is false and `error`/`error_count` describe it.
 ///
 /// Inputs:
-/// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
-/// - `master_privkey_len` -- Length of master_privkey.
-/// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
-/// - `rotating_privkey_len` -- Length of rotating_privkey.
-/// - `payment_tx_provider_code` -- Null-terminated provider code string the payment is coming from
-///   (use a SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* constant)
-/// - `payment_tx_payment_id` -- Opaque payment identifier from the provider. See
-///   `AddProPaymentUserTransaction`
-/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
-///
-/// Outputs:
-/// - `success` - True if signatures are built successfully, false otherwise.
-/// - `error` - Backing error buffer for the signatures if `success` is false
-/// - `errors_count` - length of the error if `success` is false
-/// - `master_sig` - Generated master signature
-/// - `rotating_sig` - Generated rotating signature
+/// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
+/// libsodium).
+/// - `rotating_privkey` / `rotating_privkey_len` -- Ed25519 rotating private key (32 or 64-byte).
+/// - `provider_code` -- null-terminated provider code
+/// (SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*).
+/// - `payment_id` / `payment_id_len` -- opaque provider payment identifier.
 LIBSESSION_EXPORT
-session_pro_backend_master_rotating_signatures
-session_pro_backend_add_pro_payment_request_build_sigs(
+session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(1, 3, 5, 6);
+        const char* provider_code,
+        const uint8_t* payment_id,
+        size_t payment_id_len) NON_NULL_ARG(1, 3, 5, 6);
 
-/// API: session_pro_backend/generate_pro_proof_request_build_sigs
+/// API: session_pro_backend/generate_pro_proof_request_build
 ///
-/// Builds master and rotating signatures for a `generate_pro_proof_request`.
-/// Returns false if the keys (32-byte or 64-byte libsodium format) are incorrectly sized.
-/// Using 64-byte libsodium keys is more efficient.
+/// Builds the generate-proof request to POST, as a session_pro_backend_request (endpoint +
+/// content_type + opaque data). Free it with `session_pro_backend_request_free`. On a key-size
+/// error `success` is false and `error`/`error_count` describe it.
 ///
 /// Inputs:
-/// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
-/// - `master_privkey_len` -- Length of master_privkey.
-/// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
-/// - `rotating_privkey_len` -- Length of rotating_privkey.
-/// - `ts` -- Unix timestamp for the request.
-///
-/// Outputs:
-/// - `bool` - True if signatures are built successfully, false otherwise.
-/// - `error` - Backing error buffer for the signatures if `success` is false
-/// - `errors_count` - length of the error if `success` is false
-/// - `master_sig` - Master signature
-/// - `rotating_sig` - Rotating signature
+/// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
+/// libsodium).
+/// - `rotating_privkey` / `rotating_privkey_len` -- Ed25519 rotating private key (32 or 64-byte).
+/// - `ts` -- Unix timestamp (seconds) for the request.
 LIBSESSION_EXPORT
-session_pro_backend_master_rotating_signatures
-session_pro_backend_generate_pro_proof_request_build_sigs(
+session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
         int64_t ts) NON_NULL_ARG(1, 3);
 
-/// API: session_pro_backend/get_pro_details_request_build_sig
-///
-/// Builds the JSON for a `get_pro_details_request`. Returns false if the keys (32-byte or
-/// 64-byte libsodium format) are incorrectly sized. Using 64-byte libsodium keys is more efficient.
-///
-/// Inputs:
-/// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
-/// - `master_privkey_len` -- Length of master_privkey.
-/// - `ts` -- Unix timestamp for the request.
-/// - `count` -- Amount of historical payments to request
-///
-/// Outputs:
-/// - `bool` -- True if signatures are built successfully, false otherwise.
-/// - `error` -- Backing error buffer for the signatures if `success` is false
-/// - `errors_count` -- length of the error if `success` is false
-/// - `sig` -- The generated signature
-LIBSESSION_EXPORT
-session_pro_backend_signature session_pro_backend_get_pro_details_request_build_sig(
-        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count)
-        NON_NULL_ARG(1);
-
-/// API: session_pro_backend/add_pro_payment_request_build
-///
-/// Builds the request to POST for an `add_pro_payment_request`, as a session_pro_backend_request
-/// (endpoint + content_type + opaque data).
-/// Free the returned request with `session_pro_backend_request_free`.
-///
-/// Inputs:
-/// - `request` -- Pointer to the request struct.
-LIBSESSION_EXPORT
-session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
-        const session_pro_backend_add_pro_payment_request* request);
-
-/// API: session_pro_backend/generate_pro_proof_request_build
-///
-/// Builds the request to POST for a `generate_pro_proof_request`, as a session_pro_backend_request
-/// (endpoint + content_type + opaque data).
-/// Free the returned request with `session_pro_backend_request_free`.
-///
-/// Inputs:
-/// - `request` -- Pointer to the request struct.
-LIBSESSION_EXPORT
-session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
-        const session_pro_backend_generate_pro_proof_request* request);
-
 /// API: session_pro_backend/get_pro_revocations_request_build
 ///
-/// Builds the request to POST for a `get_pro_revocations_request`, as a session_pro_backend_request
-/// (endpoint + content_type + opaque data).
-/// Free the returned request with `session_pro_backend_request_free`.
+/// Builds the get-revocations request to POST, as a session_pro_backend_request (endpoint +
+/// content_type + opaque data). Free it with `session_pro_backend_request_free`.
+///
+/// Inputs:
+/// - `ticket` -- revocation-list ticket to resume from (0 for a full list).
 LIBSESSION_EXPORT
-session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(
-        const session_pro_backend_get_pro_revocations_request* request);
+session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(int64_t ticket);
 
 /// API: session_pro_backend/get_pro_details_request_build
 ///
-/// Builds the request to POST for a `get_pro_details_request`, as a session_pro_backend_request
-/// (endpoint + content_type + opaque data).
-/// Free the returned request with `session_pro_backend_request_free`.
+/// Builds the get-details request to POST, as a session_pro_backend_request (endpoint +
+/// content_type + opaque data). Free it with `session_pro_backend_request_free`. On a key-size
+/// error `success` is false and `error`/`error_count` describe it.
+///
+/// Inputs:
+/// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
+/// libsodium).
+/// - `ts` -- Unix timestamp (seconds) for the request.
+/// - `count` -- number of historical payments to request.
 LIBSESSION_EXPORT
 session_pro_backend_request session_pro_backend_get_pro_details_request_build(
-        const session_pro_backend_get_pro_details_request* request);
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count)
+        NON_NULL_ARG(1);
 
 /// API: session_pro_backend/pro_proof_response_parse
 ///
@@ -434,47 +303,29 @@ LIBSESSION_EXPORT
 session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details_response_parse(
         const char* json, size_t json_len);
 
-/// API: session_pro_backend/set_payment_refund_requested_request_build_sigs
+/// API: session_pro_backend/set_payment_refund_requested_request_build
 ///
-/// Builds master and rotating signatures for an `set_payment_refund_requested_request`.
-/// Returns false if the keys (32-byte or 64-byte libsodium format) or payment token hash are
-/// incorrectly sized. Using 64-byte libsodium keys is more efficient.
+/// Builds the set-refund-requested request to POST, as a session_pro_backend_request (endpoint +
+/// content_type + opaque data). Free it with `session_pro_backend_request_free`. On a key-size
+/// error `success` is false and `error`/`error_count` describe it.
 ///
 /// Inputs:
-/// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
-/// - `master_privkey_len` -- Length of master_privkey.
-/// - `ts` -- Unix timestamp for the request
-/// - `refund_requested_ts` -- Unix timestamp to set as the timestamp that a refund was
-///   requested on this payment
-/// - `payment_tx_provider_code` -- Null-terminated provider code string the payment is coming from
-///   (use a SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* constant)
-/// - `payment_tx_payment_id` -- Opaque payment identifier from the provider. See
-///   `AddProPaymentUserTransaction`
-/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
-///
-/// Outputs:
-/// - `bool` -- True if signatures are built successfully, false otherwise.
-/// - `error` -- Backing error buffer for the signatures if `success` is false
-/// - `errors_count` -- length of the error if `success` is false
-/// - `sig` -- The generated signature
+/// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
+/// libsodium).
+/// - `ts` -- Unix timestamp (seconds) for the request.
+/// - `refund_requested_ts` -- Unix timestamp (seconds) to record the refund request at.
+/// - `provider_code` -- null-terminated provider code
+/// (SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*).
+/// - `payment_id` / `payment_id_len` -- opaque provider payment identifier.
 LIBSESSION_EXPORT
-session_pro_backend_signature session_pro_backend_set_payment_refund_requested_request_build_sigs(
+session_pro_backend_request session_pro_backend_set_payment_refund_requested_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(1, 5, 6);
-
-/// API: session_pro_backend/set_payment_refund_requested_request_build
-///
-/// Builds the request to POST for a `set_payment_refund_requested_request`, as a
-/// session_pro_backend_request (endpoint + content_type + opaque data). Free the returned request
-/// with `session_pro_backend_request_free`.
-LIBSESSION_EXPORT
-session_pro_backend_request session_pro_backend_set_payment_refund_requested_request_build(
-        const session_pro_backend_set_payment_refund_requested_request* request);
+        const char* provider_code,
+        const uint8_t* payment_id,
+        size_t payment_id_len) NON_NULL_ARG(1, 5, 6);
 
 /// API: session_pro_backend/set_payment_refund_requested_response_parse
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -11,13 +11,6 @@
 extern "C" {
 #endif
 
-/// Response status codes; must match the backend's status enum (session-pro-backend server.py).
-enum {
-    SESSION_PRO_BACKEND_STATUS_SUCCESS = 0,
-    SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR = 1,
-    SESSION_PRO_BACKEND_STATUS_PARSE_ERROR = 2,
-};
-
 /// Canonical payment-provider `code` strings — the value transmitted on the wire and folded into
 /// the add-payment / set-refund signed hashes (spec §1). Reference these constants rather than
 /// hardcoding the slug so a sent code cannot drift from what libsession hashes/parses. Unknown
@@ -80,12 +73,27 @@ typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
 } SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
 
+/// Response outcome (wire `status`, spec §5). CLOSED/exhaustive: the backend will never add a
+/// value, so an unrecognized wire status is reported as a protocol error (RESPONSE_STATUS_ERROR +
+/// error_code "invalid_response"). Mirrors C++ session::pro_backend::ResponseStatus.
+typedef enum SESSION_PRO_BACKEND_RESPONSE_STATUS {
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_OK,     ///< Success; the response's payload fields are set.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_FAIL,   ///< Rejected on client input / a precondition.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR,  ///< Backend fault; the same request may succeed
+                                                ///< later.
+} SESSION_PRO_BACKEND_RESPONSE_STATUS;
+
 typedef struct session_pro_backend_response_header session_pro_backend_response_header;
 struct session_pro_backend_response_header {
-    /// Error messages (NULL if none), with errors_count elements. The response succeeded iff
-    /// errors_count == 0; on failure the messages carry the reason(s) (backend- or parse-supplied).
-    string8* errors;
-    size_t errors_count;
+    /// Outcome category. Success iff `status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK`.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS status;
+    /// On non-OK, the machine-readable outcome slug (spec §5.1); {NULL, 0} on success. Opaque and
+    /// forward-compatible (unknown slugs pass through); "invalid_response" if libsession could not
+    /// parse the reply at all.
+    string8 error_code;
+    /// On non-OK, an English diagnostic string (NOT user-facing text -- that comes from mapping
+    /// error_code to a localized string); {NULL, 0} on success. Always safe to log.
+    string8 error;
     uint8_t* internal_arena_buf_;  /// Internal buffer for all the memory allocations, do not touch
 };
 

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -95,8 +95,8 @@ typedef struct session_pro_backend_request {
     const char* endpoint;
     /// Value for the request's Content-Type header; static, null-terminated string. Relay verbatim.
     const char* content_type;
-    /// The opaque request payload. Relay untouched; do not parse or modify.
-    string8 data;
+    /// The opaque request payload (raw bytes). Relay untouched; do not parse or modify.
+    span_u8 data;
     /// Owned C++ object backing endpoint/content_type/data; do not touch (freed by request_free).
     void* internal_;
 } session_pro_backend_request;

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -263,7 +263,6 @@ typedef struct session_pro_backend_set_payment_refund_requested_response
         session_pro_backend_set_payment_refund_requested_response;
 struct session_pro_backend_set_payment_refund_requested_response {
     session_pro_backend_response_header header;
-    uint8_t version;
     bool updated;
 };
 

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -192,7 +192,8 @@ struct session_pro_backend_get_pro_revocations_request {
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
 struct session_pro_backend_pro_revocation_item {
     bytes32 revocation_tag;
-    int64_t expiry_ts;
+    /// Unix timestamp (seconds); a matching proof is revoked once the client clock reaches this
+    int64_t effective_ts;
 };
 
 typedef struct session_pro_backend_get_pro_revocations_response
@@ -200,6 +201,8 @@ typedef struct session_pro_backend_get_pro_revocations_response
 struct session_pro_backend_get_pro_revocations_response {
     session_pro_backend_response_header header;
     int64_t ticket;
+    int64_t retry_in;    /// Recommended seconds to wait before polling the list again
+    int64_t retain_for;  /// Seconds to retain each item after first seeing it (memory-only aging)
     /// Array of items, with items_count elements
     session_pro_backend_pro_revocation_item* items;
     size_t items_count;

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -11,8 +11,7 @@
 extern "C" {
 #endif
 
-/// Must match:
-///   https://github.com/Doy-lee/session-pro-backend/blob/41a794e2998b528566d0c27d34c4faeed5602e26/server.py#L457
+/// Response status codes; must match the backend's status enum (session-pro-backend server.py).
 enum {
     SESSION_PRO_BACKEND_STATUS_SUCCESS = 0,
     SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR = 1,
@@ -27,8 +26,41 @@ static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY[] = "goo
 static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE[] = "app_store";
 static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF[] = "rangeproof";
 
-/// Must match:
-///   https://github.com/Doy-lee/session-pro-backend/blob/f4e2c84794470e7932ba1a1968fdb49117bb5870/backend.py#L18
+/// Endpoint path (relative to the backend base URL) that each request type is POSTed to. libsession
+/// owns the body<->route pairing, so reference these rather than hardcoding the path client-side.
+/// The C++ `*_request()` helpers return the matching endpoint alongside the body; C callers read
+/// the constant beside each request's build function. Each is a pointer to the single master string
+/// owned in the C++ implementation (defined once, shared by the C and C++ sides).
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const
+        SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT;
+
+/// Per-provider support/management URLs, keyed by provider code. These are identical for every user
+/// (not translation data), so libsession owns them as the single source of truth rather than each
+/// client duplicating them; the human-readable provider/store names are translation data and remain
+/// the client's job. An unknown provider code (or one with no applicable URLs, e.g. rangeproof)
+/// yields all-NULL fields. Otherwise each is a static, null-terminated C string.
+typedef struct session_pro_backend_provider_urls session_pro_backend_provider_urls;
+struct session_pro_backend_provider_urls {
+    const char* refund_platform_url;      /// Native store refund flow
+    const char* refund_support_url;       /// Session support page for requesting a refund
+    const char* refund_status_url;        /// Where a user checks refund status
+    const char* update_subscription_url;  /// Manage/update the subscription
+    const char* cancel_subscription_url;  /// Cancel the subscription
+};
+
+/// API: session_pro_backend/get_provider_urls
+///
+/// Returns the support/management URLs for `provider_code` (a
+/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* value). A provider with no applicable URLs (unknown
+/// code, or e.g. rangeproof) returns a struct with all fields NULL.
+LIBSESSION_EXPORT session_pro_backend_provider_urls
+session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1);
+
+/// Must match the backend's payment status enum (session-pro-backend backend.py).
 typedef enum SESSION_PRO_BACKEND_PAYMENT_STATUS {
     SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL,
     SESSION_PRO_BACKEND_PAYMENT_STATUS_UNREDEEMED,
@@ -38,8 +70,7 @@ typedef enum SESSION_PRO_BACKEND_PAYMENT_STATUS {
     SESSION_PRO_BACKEND_PAYMENT_STATUS_COUNT,
 } SESSION_PRO_BACKEND_PAYMENT_STATUS;
 
-/// Must match:
-///   https://github.com/Doy-lee/session-pro-backend/blob/a0e0ba24bc4ab3a062465d861aa57df2269b6dde/server.py#L373
+/// Must match the backend's user Pro status enum (session-pro-backend server.py).
 typedef enum SESSION_PRO_BACKEND_USER_PRO_STATUS {
     SESSION_PRO_BACKEND_USER_PRO_STATUS_NEVER_BEEN_PRO,
     SESSION_PRO_BACKEND_USER_PRO_STATUS_ACTIVE,
@@ -53,8 +84,7 @@ typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
 } SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
 
-/// Must match:
-///   https://github.com/Doy-lee/session-pro-backend/blob/41a794e2998b528566d0c27d34c4faeed5602e26/server.py#L461
+/// Must match the backend's add-pro-payment response status enum (session-pro-backend server.py).
 typedef enum SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS {
     SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_SUCCESS =
             SESSION_PRO_BACKEND_STATUS_SUCCESS,
@@ -118,7 +148,6 @@ struct session_pro_backend_add_pro_payment_user_transaction {
 typedef struct session_pro_backend_add_pro_payment_request
         session_pro_backend_add_pro_payment_request;
 struct session_pro_backend_add_pro_payment_request {
-    uint8_t version;
     bytes32 master_pkey;
     bytes32 rotating_pkey;
     session_pro_backend_add_pro_payment_user_transaction payment_tx;
@@ -129,7 +158,6 @@ struct session_pro_backend_add_pro_payment_request {
 typedef struct session_pro_backend_generate_pro_proof_request
         session_pro_backend_generate_pro_proof_request;
 struct session_pro_backend_generate_pro_proof_request {
-    uint8_t version;
     bytes32 master_pkey;
     bytes32 rotating_pkey;
     int64_t ts;
@@ -137,9 +165,8 @@ struct session_pro_backend_generate_pro_proof_request {
     bytes64 rotating_sig;
 };
 
-typedef struct session_pro_backend_add_pro_payment_or_generate_pro_proof_response
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response;
-struct session_pro_backend_add_pro_payment_or_generate_pro_proof_response {
+typedef struct session_pro_backend_pro_proof_response session_pro_backend_pro_proof_response;
+struct session_pro_backend_pro_proof_response {
     session_pro_backend_response_header header;
     session_protocol_pro_proof proof;
 };
@@ -147,7 +174,6 @@ struct session_pro_backend_add_pro_payment_or_generate_pro_proof_response {
 typedef struct session_pro_backend_get_pro_revocations_request
         session_pro_backend_get_pro_revocations_request;
 struct session_pro_backend_get_pro_revocations_request {
-    uint8_t version;
     int64_t ticket;
 };
 
@@ -173,7 +199,6 @@ struct session_pro_backend_get_pro_revocations_response {
 typedef struct session_pro_backend_get_pro_details_request
         session_pro_backend_get_pro_details_request;
 struct session_pro_backend_get_pro_details_request {
-    uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
     int64_t ts;
@@ -224,7 +249,6 @@ struct session_pro_backend_get_pro_details_response {
 typedef struct session_pro_backend_set_payment_refund_requested_request
         session_pro_backend_set_payment_refund_requested_request;
 struct session_pro_backend_set_payment_refund_requested_request {
-    uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
     int64_t ts;
@@ -247,7 +271,6 @@ struct session_pro_backend_set_payment_refund_requested_response {
 /// incorrectly sized. Using 64-byte libsodium keys is more efficient.
 ///
 /// Inputs:
-/// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
@@ -267,32 +290,13 @@ struct session_pro_backend_set_payment_refund_requested_response {
 LIBSESSION_EXPORT
 session_pro_backend_master_rotating_signatures
 session_pro_backend_add_pro_payment_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
         const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 4, 6, 7);
-
-/// API: session_pro_backend/add_pro_payment_request_build_to_json
-///
-/// Builds the JSON for a `add_pro_payment_request`. This function is the same as filling in the
-/// struct and calling the corresponding `to_json` function.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
-///
-/// See: session_pro_backend_add_pro_payment_request_build_sigs
-LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_add_pro_payment_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        const uint8_t* rotating_privkey,
-        size_t rotating_privkey_len,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 4, 6, 7);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(1, 3, 5, 6);
 
 /// API: session_pro_backend/generate_pro_proof_request_build_sigs
 ///
@@ -301,7 +305,6 @@ session_pro_backend_to_json session_pro_backend_add_pro_payment_request_build_to
 /// Using 64-byte libsodium keys is more efficient.
 ///
 /// Inputs:
-/// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
@@ -317,28 +320,11 @@ session_pro_backend_to_json session_pro_backend_add_pro_payment_request_build_to
 LIBSESSION_EXPORT
 session_pro_backend_master_rotating_signatures
 session_pro_backend_generate_pro_proof_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        int64_t ts) NON_NULL_ARG(2, 4);
-
-/// API: session_pro_backend/generate_pro_proof_request_build_to_json
-///
-/// Builds the JSON for a `generate_pro_proof_request`. This function is the same as filling in the
-/// struct and calling the corresponding `to_json` function.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
-///
-/// See: `session_pro_backend_generate_pro_proof_request_build_sigs`
-LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        const uint8_t* rotating_privkey,
-        size_t rotating_privkey_len,
-        int64_t ts) NON_NULL_ARG(2, 4);
+        int64_t ts) NON_NULL_ARG(1, 3);
 
 /// API: session_pro_backend/get_pro_details_request_build_sig
 ///
@@ -346,7 +332,6 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
 /// 64-byte libsodium format) are incorrectly sized. Using 64-byte libsodium keys is more efficient.
 ///
 /// Inputs:
-/// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `ts` -- Unix timestamp for the request.
@@ -359,26 +344,8 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
 /// - `sig` -- The generated signature
 LIBSESSION_EXPORT
 session_pro_backend_signature session_pro_backend_get_pro_details_request_build_sig(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        uint32_t count) NON_NULL_ARG(2);
-
-/// API: session_pro_backend/get_pro_details_request_build_to_json
-///
-/// Builds the JSON for a `get_pro_details_request`. This function is the same as filling in the
-/// struct and calling the corresponding `to_json` function.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
-///
-/// See: `session_pro_backend_get_pro_details_request_build_sig`
-LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_get_pro_details_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        uint32_t count) NON_NULL_ARG(2);
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count)
+        NON_NULL_ARG(1);
 
 /// API: session_pro_backend/add_pro_payment_request_to_json
 ///
@@ -418,18 +385,17 @@ LIBSESSION_EXPORT
 session_pro_backend_to_json session_pro_backend_get_pro_details_request_to_json(
         const session_pro_backend_get_pro_details_request* request);
 
-/// API: session_pro_backend/add_pro_payment_or_generate_pro_proof_response_parse
+/// API: session_pro_backend/pro_proof_response_parse
 ///
-/// Parses a JSON string into an `add_pro_payment_or_generate_pro_proof_response` struct.
+/// Parses a JSON string into an `pro_proof_response` struct.
 /// The caller must free the response using
-/// `session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free`.
+/// `session_pro_backend_pro_proof_response_free`.
 ///
 /// Inputs:
 /// - `json` -- JSON string to parse.
 /// - `json_len` -- Length of the JSON string.
 LIBSESSION_EXPORT
-session_pro_backend_add_pro_payment_or_generate_pro_proof_response
-session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
+session_pro_backend_pro_proof_response session_pro_backend_pro_proof_response_parse(
         const char* json, size_t json_len);
 
 /// API: session_pro_backend/get_pro_revocations_response_parse
@@ -463,7 +429,6 @@ session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details
 /// incorrectly sized. Using 64-byte libsodium keys is more efficient.
 ///
 /// Inputs:
-/// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `ts` -- Unix timestamp for the request
@@ -482,32 +447,13 @@ session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details
 /// - `sig` -- The generated signature
 LIBSESSION_EXPORT
 session_pro_backend_signature session_pro_backend_set_payment_refund_requested_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
         const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 6, 7);
-
-/// API: session_pro_backend/set_payment_refund_requested_request_build_to_json
-///
-/// Builds the JSON for a `set_payment_refund_requested_request`. This function is the same as
-/// filling in the struct and calling the corresponding `to_json` function. The caller must free the
-/// returned string using `session_pro_backend_to_json_free`.
-///
-/// See: session_pro_backend_set_payment_refund_requested_request_build_sigs
-LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        int64_t refund_requested_ts,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 6, 7);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(1, 5, 6);
 
 /// API: session_pro_backend/set_payment_refund_requested_request_to_json
 ///
@@ -535,12 +481,11 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
 LIBSESSION_EXPORT
 void session_pro_backend_to_json_free(session_pro_backend_to_json* to_json);
 
-/// API: session_pro_backend/add_pro_payment_or_generate_pro_proof_response_free
+/// API: session_pro_backend/pro_proof_response_free
 ///
 /// Frees the response
 LIBSESSION_EXPORT
-void session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response* response);
+void session_pro_backend_pro_proof_response_free(session_pro_backend_pro_proof_response* response);
 
 /// API: session_pro_backend/get_pro_revocations_response_free
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -76,35 +76,6 @@ session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1)
 /// its strings are static storage owned by libsession — do not free.
 LIBSESSION_EXPORT const char* const* session_pro_backend_visible_platforms(size_t* count);
 
-typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_SUCCESS,
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR,
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
-} SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
-
-/// Response outcome (wire `status`, spec §5). CLOSED/exhaustive: the backend will never add a
-/// value, so an unrecognized wire status is reported as a protocol error (RESPONSE_STATUS_ERROR +
-/// error_code "invalid_response"). Mirrors C++ session::pro_backend::ResponseStatus.
-typedef enum SESSION_PRO_BACKEND_RESPONSE_STATUS {
-    SESSION_PRO_BACKEND_RESPONSE_STATUS_OK,     ///< Success; the response's payload fields are set.
-    SESSION_PRO_BACKEND_RESPONSE_STATUS_FAIL,   ///< Rejected on client input / a precondition.
-    SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR,  ///< Backend fault; the same request may succeed
-                                                ///< later.
-} SESSION_PRO_BACKEND_RESPONSE_STATUS;
-
-typedef struct session_pro_backend_response_header {
-    /// Outcome category. Success iff `status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK`.
-    SESSION_PRO_BACKEND_RESPONSE_STATUS status;
-    /// On non-OK, the machine-readable outcome slug (spec §5.1); {NULL, 0} on success. Opaque and
-    /// forward-compatible (unknown slugs pass through); "invalid_response" if libsession could not
-    /// parse the reply at all.
-    string8 error_code;
-    /// On non-OK, an English diagnostic string (NOT user-facing text -- that comes from mapping
-    /// error_code to a localized string); {NULL, 0} on success. Always safe to log.
-    string8 error;
-    uint8_t* internal_arena_buf_;  /// Internal buffer for all the memory allocations, do not touch
-} session_pro_backend_response_header;
-
 /// A built request to POST to the Session Pro backend. Mirrors the C++
 /// `session::pro_backend::ProRequest`: an `endpoint`, the `content_type` to send as the request's
 /// Content-Type header, and the opaque `data` payload. `data` is libsession's data for the backend
@@ -124,13 +95,58 @@ typedef struct session_pro_backend_request {
     void* internal_;
 } session_pro_backend_request;
 
+/// API: session_pro_backend/request_free
+///
+/// Frees a `session_pro_backend_request` returned by a `*_request_build` function.
+LIBSESSION_EXPORT
+void session_pro_backend_request_free(session_pro_backend_request* request);
+
+typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
+    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_SUCCESS,
+    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR,
+    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
+} SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
+
+/// Response outcome (wire `status`, spec §5). CLOSED/exhaustive: the backend will never add a
+/// value, so an unrecognized wire status is reported as a protocol error (RESPONSE_STATUS_ERROR +
+/// error_code "invalid_response"). Mirrors C++ session::pro_backend::ResponseStatus.
+typedef enum SESSION_PRO_BACKEND_RESPONSE_STATUS {
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_OK,     ///< Success; the response's payload fields are set.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_FAIL,   ///< Rejected on client input / a precondition.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR,  ///< Backend fault; the same request may succeed
+                                                ///< later.
+} SESSION_PRO_BACKEND_RESPONSE_STATUS;
+
+typedef struct session_pro_backend_response_header {
+    /// Outcome category. Success iff `status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK`.
+    SESSION_PRO_BACKEND_RESPONSE_STATUS status;
+    /// On non-OK, the machine-readable outcome slug (spec §5.1); NULL on success. Opaque and
+    /// forward-compatible (unknown slugs pass through); "invalid_response" if libsession could not
+    /// parse the reply at all. NUL-terminated; valid until the response is freed.
+    const char* error_code;
+    /// On non-OK, an English diagnostic string (NOT user-facing text -- that comes from mapping
+    /// error_code to a localized string); NULL on success. Always safe to log. NUL-terminated;
+    /// valid until the response is freed.
+    const char* error;
+    /// Opaque implementation detail; do not touch. Released by the response's *_free function.
+    void* internal_;
+} session_pro_backend_response_header;
+
 typedef struct session_pro_backend_pro_proof_response {
     session_pro_backend_response_header header;
     session_protocol_pro_proof proof;
 } session_pro_backend_pro_proof_response;
 
+/// API: session_pro_backend/pro_proof_response_free
+///
+/// Frees the response.
+LIBSESSION_EXPORT
+void session_pro_backend_pro_proof_response_free(session_pro_backend_pro_proof_response* response);
+
 typedef struct session_pro_backend_pro_revocation_item {
-    bytes32 revocation_tag;
+    /// 32-byte revocation tag (compare for equality against a proof's tag); valid until the
+    /// response is freed.
+    const unsigned char* revocation_tag;
     /// Unix timestamp (seconds); a matching proof is revoked once the client clock reaches this
     int64_t effective_ts;
 } session_pro_backend_pro_revocation_item;
@@ -144,6 +160,13 @@ typedef struct session_pro_backend_get_pro_revocations_response {
     session_pro_backend_pro_revocation_item* items;
     size_t items_count;
 } session_pro_backend_get_pro_revocations_response;
+
+/// API: session_pro_backend/get_pro_revocations_response_free
+///
+/// Frees the response.
+LIBSESSION_EXPORT
+void session_pro_backend_get_pro_revocations_response_free(
+        session_pro_backend_get_pro_revocations_response* response);
 
 /// Unit of a parsed billing period (`plan_unit` below); mirrors C++
 /// session::pro_backend::ProPlanUnit (same order). A closed set (pro-wire-protocol.md §1 / Delta
@@ -159,18 +182,17 @@ typedef enum SESSION_PRO_BACKEND_PLAN_UNIT {
 
 typedef struct session_pro_backend_pro_payment_item {
     /// Opaque payment lifecycle status code (e.g. "unredeemed"/"redeemed"/"expired"/"revoked");
-    /// unknown values pass through as-is
-    char status[64];
-    size_t status_count;
+    /// unknown values pass through as-is. NUL-terminated; points into the response's `internal_`.
+    const char* status;
     /// Parsed billing period (pro-wire-protocol.md §1 / Delta #14). `plan_count` is the period
     /// count
     /// (>= 1 for periodic units); for `plan_unit == ..._LIFETIME` it is 0 and not meaningful
     /// (switch on `plan_unit`, never render "<count> <unit>" for lifetime).
     int plan_count;
     SESSION_PRO_BACKEND_PLAN_UNIT plan_unit;
-    /// Provider code (e.g. "google_play"); opaque -- an unknown value passes through as-is
-    char payment_provider[64];
-    size_t payment_provider_count;
+    /// Provider code (e.g. "google_play"); opaque -- an unknown value passes through as-is.
+    /// NUL-terminated; points into the response's `internal_`.
+    const char* payment_provider;
 
     bool auto_renewing;
     /// Provider purchase time, fractional UNIX seconds. Millisecond-precise: the value passes
@@ -185,9 +207,9 @@ typedef struct session_pro_backend_pro_payment_item {
     int64_t refund_requested_ts;
 
     /// Opaque payment identifier (the value passed at add-payment; multi-part providers fold their
-    /// parts in per the backend-defined composite -- libsession does not interpret it)
-    char payment_id[128];
-    size_t payment_id_count;
+    /// parts in per the backend-defined composite -- libsession does not interpret it).
+    /// NUL-terminated; points into the response's `internal_`.
+    const char* payment_id;
 } session_pro_backend_pro_payment_item;
 
 typedef struct session_pro_backend_get_pro_details_response {
@@ -195,9 +217,9 @@ typedef struct session_pro_backend_get_pro_details_response {
     /// Array of payment items, with items_count elements
     session_pro_backend_pro_payment_item* items;
     size_t items_count;
-    /// Opaque account Pro status code ("never"/"active"/"expired"); unknown values pass through
-    char status[64];
-    size_t status_count;
+    /// Opaque account Pro status code ("never"/"active"/"expired"); unknown values pass through.
+    /// NUL-terminated; points into the response's `internal_`.
+    const char* status;
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
     bool auto_renewing;
     int64_t expiry_ts;
@@ -206,10 +228,24 @@ typedef struct session_pro_backend_get_pro_details_response {
     uint32_t payments_total;
 } session_pro_backend_get_pro_details_response;
 
+/// API: session_pro_backend/get_pro_details_response_free
+///
+/// Frees the response.
+LIBSESSION_EXPORT
+void session_pro_backend_get_pro_details_response_free(
+        session_pro_backend_get_pro_details_response* response);
+
 typedef struct session_pro_backend_set_payment_refund_requested_response {
     session_pro_backend_response_header header;
     bool updated;
 } session_pro_backend_set_payment_refund_requested_response;
+
+/// API: session_pro_backend/set_payment_refund_requested_response_free
+///
+/// Frees the response.
+LIBSESSION_EXPORT
+void session_pro_backend_set_payment_refund_requested_response_free(
+        session_pro_backend_set_payment_refund_requested_response* response);
 
 /// API: session_pro_backend/add_pro_payment_request_build
 ///
@@ -352,38 +388,6 @@ session_pro_backend_request session_pro_backend_set_payment_refund_requested_req
 LIBSESSION_EXPORT session_pro_backend_set_payment_refund_requested_response
 session_pro_backend_set_payment_refund_requested_response_parse(const char* json, size_t json_len);
 
-/// API: session_pro_backend/request_free
-///
-/// Frees a `session_pro_backend_request` returned by a `*_request_build` function.
-LIBSESSION_EXPORT
-void session_pro_backend_request_free(session_pro_backend_request* request);
-
-/// API: session_pro_backend/pro_proof_response_free
-///
-/// Frees the response
-LIBSESSION_EXPORT
-void session_pro_backend_pro_proof_response_free(session_pro_backend_pro_proof_response* response);
-
-/// API: session_pro_backend/get_pro_revocations_response_free
-///
-/// Frees the respone
-LIBSESSION_EXPORT
-void session_pro_backend_get_pro_revocations_response_free(
-        session_pro_backend_get_pro_revocations_response* response);
-
-/// API: session_pro_backend/get_pro_details_response_free
-///
-/// Frees the respone
-LIBSESSION_EXPORT
-void session_pro_backend_get_pro_details_response_free(
-        session_pro_backend_get_pro_details_response* response);
-
-/// API: session_pro_backend/session_pro_backend_set_payment_refund_requested_response_free
-///
-/// Frees the respone
-LIBSESSION_EXPORT
-void session_pro_backend_set_payment_refund_requested_response_free(
-        session_pro_backend_set_payment_refund_requested_response* response);
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -97,12 +97,22 @@ struct session_pro_backend_response_header {
     uint8_t* internal_arena_buf_;  /// Internal buffer for all the memory allocations, do not touch
 };
 
-typedef struct session_pro_backend_to_json session_pro_backend_to_json;
-struct session_pro_backend_to_json {
+/// A built request to POST to the Session Pro backend. Mirrors the C++
+/// `session::pro_backend::ProRequest`: an `endpoint`, the `content_type` to send as the request's
+/// Content-Type header, and the opaque `data` payload. `data` is libsession's data for the backend
+/// -- relay it verbatim with the given `content_type` and do NOT parse, inspect, or assume a format
+/// for it. libsession owns the wire encoding and may change it without client involvement.
+typedef struct session_pro_backend_request session_pro_backend_request;
+struct session_pro_backend_request {
     char error[256];
     size_t error_count;
-    bool success;  /// True if conversion to JSON was successful, false if out-of-memory
-    string8 json;
+    bool success;  /// True if the request was built successfully, false if out-of-memory
+    /// Endpoint path (relative to the backend base URL) to POST to; static, null-terminated string.
+    const char* endpoint;
+    /// Value for the request's Content-Type header; static, null-terminated string. Relay verbatim.
+    const char* content_type;
+    /// The opaque request payload. Relay untouched; do not parse or modify.
+    string8 data;
 };
 
 typedef struct session_pro_backend_master_rotating_signatures
@@ -345,42 +355,46 @@ session_pro_backend_signature session_pro_backend_get_pro_details_request_build_
         const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count)
         NON_NULL_ARG(1);
 
-/// API: session_pro_backend/add_pro_payment_request_to_json
+/// API: session_pro_backend/add_pro_payment_request_build
 ///
-/// Serializes an `add_pro_payment_request` to a JSON string.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
+/// Builds the request to POST for an `add_pro_payment_request`, as a session_pro_backend_request
+/// (endpoint + content_type + opaque data).
+/// Free the returned request with `session_pro_backend_request_free`.
 ///
 /// Inputs:
 /// - `request` -- Pointer to the request struct.
 LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_add_pro_payment_request_to_json(
+session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
         const session_pro_backend_add_pro_payment_request* request);
 
-/// API: session_pro_backend/generate_pro_proof_request_to_json
+/// API: session_pro_backend/generate_pro_proof_request_build
 ///
-/// Serializes a `generate_pro_proof_request` to a JSON string.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
+/// Builds the request to POST for a `generate_pro_proof_request`, as a session_pro_backend_request
+/// (endpoint + content_type + opaque data).
+/// Free the returned request with `session_pro_backend_request_free`.
 ///
 /// Inputs:
 /// - `request` -- Pointer to the request struct.
 LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_to_json(
+session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
         const session_pro_backend_generate_pro_proof_request* request);
 
-/// API: session_pro_backend/get_pro_revocations_request_to_json
+/// API: session_pro_backend/get_pro_revocations_request_build
 ///
-/// Serializes a `get_pro_revocations_request` to a JSON string.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
+/// Builds the request to POST for a `get_pro_revocations_request`, as a session_pro_backend_request
+/// (endpoint + content_type + opaque data).
+/// Free the returned request with `session_pro_backend_request_free`.
 LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_get_pro_revocations_request_to_json(
+session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(
         const session_pro_backend_get_pro_revocations_request* request);
 
-/// API: session_pro_backend/get_pro_details_request_to_json
+/// API: session_pro_backend/get_pro_details_request_build
 ///
-/// Serializes a `get_pro_details_request` to a JSON string.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
+/// Builds the request to POST for a `get_pro_details_request`, as a session_pro_backend_request
+/// (endpoint + content_type + opaque data).
+/// Free the returned request with `session_pro_backend_request_free`.
 LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_get_pro_details_request_to_json(
+session_pro_backend_request session_pro_backend_get_pro_details_request_build(
         const session_pro_backend_get_pro_details_request* request);
 
 /// API: session_pro_backend/pro_proof_response_parse
@@ -453,12 +467,13 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len) NON_NULL_ARG(1, 5, 6);
 
-/// API: session_pro_backend/set_payment_refund_requested_request_to_json
+/// API: session_pro_backend/set_payment_refund_requested_request_build
 ///
-/// Serializes a `set_payment_refund_requested_request` to a JSON string.
-/// The caller must free the returned string using `session_pro_backend_to_json_free`.
+/// Builds the request to POST for a `set_payment_refund_requested_request`, as a
+/// session_pro_backend_request (endpoint + content_type + opaque data). Free the returned request
+/// with `session_pro_backend_request_free`.
 LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_request_to_json(
+session_pro_backend_request session_pro_backend_set_payment_refund_requested_request_build(
         const session_pro_backend_set_payment_refund_requested_request* request);
 
 /// API: session_pro_backend/set_payment_refund_requested_response_parse
@@ -473,11 +488,11 @@ session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_req
 LIBSESSION_EXPORT session_pro_backend_set_payment_refund_requested_response
 session_pro_backend_set_payment_refund_requested_response_parse(const char* json, size_t json_len);
 
-/// API: session_pro_backend/to_json_free
+/// API: session_pro_backend/request_free
 ///
-/// Frees the JSON
+/// Frees a `session_pro_backend_request` returned by a `*_request_build` function.
 LIBSESSION_EXPORT
-void session_pro_backend_to_json_free(session_pro_backend_to_json* to_json);
+void session_pro_backend_request_free(session_pro_backend_request* request);
 
 /// API: session_pro_backend/pro_proof_response_free
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -191,7 +191,7 @@ struct session_pro_backend_get_pro_revocations_request {
 
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
 struct session_pro_backend_pro_revocation_item {
-    bytes32 gen_index_hash;
+    bytes32 revocation_tag;
     int64_t expiry_ts;
 };
 

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -176,8 +176,7 @@ void session_pro_backend_get_pro_revocations_response_free(
         session_pro_backend_get_pro_revocations_response* response);
 
 /// Unit of a parsed billing period (`plan_unit` below); mirrors C++
-/// session::pro_backend::ProPlanUnit (same order). A closed set (pro-wire-protocol.md §1 / Delta
-/// #14).
+/// session::pro_backend::ProPlanUnit (same order). A closed set (pro-wire-protocol.md §1).
 typedef enum SESSION_PRO_BACKEND_PLAN_UNIT {
     SESSION_PRO_BACKEND_PLAN_UNIT_SECOND,
     SESSION_PRO_BACKEND_PLAN_UNIT_DAY,
@@ -191,8 +190,7 @@ typedef struct session_pro_backend_pro_payment_item {
     /// Opaque payment lifecycle status code (e.g. "unredeemed"/"redeemed"/"expired"/"revoked");
     /// unknown values pass through as-is. NUL-terminated; points into the response's `internal_`.
     const char* status;
-    /// Parsed billing period (pro-wire-protocol.md §1 / Delta #14). `plan_count` is the period
-    /// count
+    /// Parsed billing period (pro-wire-protocol.md §1). `plan_count` is the period count
     /// (>= 1 for periodic units); for `plan_unit == ..._LIFETIME` it is 0 and not meaningful
     /// (switch on `plan_unit`, never render "<count> <unit>" for lifetime).
     int plan_count;

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -60,24 +60,6 @@ struct session_pro_backend_provider_urls {
 LIBSESSION_EXPORT session_pro_backend_provider_urls
 session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1);
 
-/// Must match the backend's payment status enum (session-pro-backend backend.py).
-typedef enum SESSION_PRO_BACKEND_PAYMENT_STATUS {
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_UNREDEEMED,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_EXPIRED,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_REVOKED,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_COUNT,
-} SESSION_PRO_BACKEND_PAYMENT_STATUS;
-
-/// Must match the backend's user Pro status enum (session-pro-backend server.py).
-typedef enum SESSION_PRO_BACKEND_USER_PRO_STATUS {
-    SESSION_PRO_BACKEND_USER_PRO_STATUS_NEVER_BEEN_PRO,
-    SESSION_PRO_BACKEND_USER_PRO_STATUS_ACTIVE,
-    SESSION_PRO_BACKEND_USER_PRO_STATUS_EXPIRED,
-    SESSION_PRO_BACKEND_USER_PRO_STATUS_COUNT,
-} SESSION_PRO_BACKEND_USER_PRO_STATUS;
-
 typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_SUCCESS,
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR,
@@ -207,7 +189,10 @@ struct session_pro_backend_get_pro_details_request {
 
 typedef struct session_pro_backend_pro_payment_item session_pro_backend_pro_payment_item;
 struct session_pro_backend_pro_payment_item {
-    SESSION_PRO_BACKEND_PAYMENT_STATUS status;
+    /// Opaque payment lifecycle status code (e.g. "unredeemed"/"redeemed"/"expired"/"revoked");
+    /// unknown values pass through as-is
+    char status[64];
+    size_t status_count;
     /// Billing-period code (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for non-period plans
     char plan[64];
     size_t plan_count;
@@ -240,7 +225,9 @@ struct session_pro_backend_get_pro_details_response {
     /// Array of payment items, with items_count elements
     session_pro_backend_pro_payment_item* items;
     size_t items_count;
-    SESSION_PRO_BACKEND_USER_PRO_STATUS status;
+    /// Opaque account Pro status code ("never"/"active"/"expired"); unknown values pass through
+    char status[64];
+    size_t status_count;
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
     bool auto_renewing;
     int64_t expiry_ts;

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -170,7 +170,7 @@ struct session_pro_backend_generate_pro_proof_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes32 rotating_pkey;
-    uint64_t unix_ts_ms;
+    uint64_t ts;
     bytes64 master_sig;
     bytes64 rotating_sig;
 };
@@ -192,7 +192,7 @@ struct session_pro_backend_get_pro_revocations_request {
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
 struct session_pro_backend_pro_revocation_item {
     bytes32 gen_index_hash;
-    uint64_t expiry_unix_ts_ms;
+    uint64_t expiry_ts;
 };
 
 typedef struct session_pro_backend_get_pro_revocations_response
@@ -211,7 +211,7 @@ struct session_pro_backend_get_pro_details_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
-    uint64_t unix_ts_ms;
+    uint64_t ts;
     uint32_t count;
 };
 
@@ -225,13 +225,13 @@ struct session_pro_backend_pro_payment_item {
     const session_pro_backend_payment_provider_metadata* payment_provider_metadata;
 
     bool auto_renewing;
-    uint64_t unredeemed_unix_ts_ms;
-    uint64_t redeemed_unix_ts_ms;
-    uint64_t expiry_unix_ts_ms;
-    uint64_t grace_period_duration_ms;
-    uint64_t platform_refund_expiry_unix_ts_ms;
-    uint64_t revoked_unix_ts_ms;
-    uint64_t refund_requested_unix_ts_ms;
+    uint64_t unredeemed_ts;
+    uint64_t redeemed_ts;
+    uint64_t expiry_ts;
+    uint64_t grace_period_duration;
+    uint64_t platform_refund_expiry_ts;
+    uint64_t revoked_ts;
+    uint64_t refund_requested_ts;
 
     char google_payment_token[128];
     size_t google_payment_token_count;
@@ -257,9 +257,9 @@ struct session_pro_backend_get_pro_details_response {
     SESSION_PRO_BACKEND_USER_PRO_STATUS status;
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
     bool auto_renewing;
-    uint64_t expiry_unix_ts_ms;
-    uint64_t grace_period_duration_ms;
-    uint64_t refund_requested_unix_ts_ms;
+    uint64_t expiry_ts;
+    uint64_t grace_period_duration;
+    uint64_t refund_requested_ts;
     uint32_t payments_total;
 };
 
@@ -269,8 +269,8 @@ struct session_pro_backend_set_payment_refund_requested_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
-    uint64_t unix_ts_ms;
-    uint64_t refund_requested_unix_ts_ms;
+    uint64_t ts;
+    uint64_t refund_requested_ts;
     session_pro_backend_add_pro_payment_user_transaction payment_tx;
 };
 
@@ -354,7 +354,7 @@ session_pro_backend_to_json session_pro_backend_add_pro_payment_request_build_to
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
 /// - `rotating_privkey_len` -- Length of rotating_privkey.
-/// - `unix_ts_ms` -- Unix timestamp for the request.
+/// - `ts` -- Unix timestamp for the request.
 ///
 /// Outputs:
 /// - `bool` - True if signatures are built successfully, false otherwise.
@@ -370,7 +370,7 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t unix_ts_ms) NON_NULL_ARG(2, 4);
+        uint64_t ts) NON_NULL_ARG(2, 4);
 
 /// API: session_pro_backend/generate_pro_proof_request_build_to_json
 ///
@@ -386,7 +386,7 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t unix_ts_ms) NON_NULL_ARG(2, 4);
+        uint64_t ts) NON_NULL_ARG(2, 4);
 
 /// API: session_pro_backend/get_pro_details_request_build_sig
 ///
@@ -397,7 +397,7 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
 /// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
-/// - `unix_ts_ms` -- Unix timestamp for the request.
+/// - `ts` -- Unix timestamp for the request.
 /// - `count` -- Amount of historical payments to request
 ///
 /// Outputs:
@@ -410,7 +410,7 @@ session_pro_backend_signature session_pro_backend_get_pro_details_request_build_
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         uint32_t count) NON_NULL_ARG(2);
 
 /// API: session_pro_backend/get_pro_details_request_build_to_json
@@ -425,7 +425,7 @@ session_pro_backend_to_json session_pro_backend_get_pro_details_request_build_to
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         uint32_t count) NON_NULL_ARG(2);
 
 /// API: session_pro_backend/add_pro_payment_request_to_json
@@ -514,8 +514,8 @@ session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details
 /// - `request_version` -- Version of the request.
 /// - `master_privkey` -- Ed25519 master private key (32-byte or 64-byte libsodium format).
 /// - `master_privkey_len` -- Length of master_privkey.
-/// - `unix_ts_ms` -- Unix timestamp for the request
-/// - `refund_requested_unix_ts_ms` -- Unix timestamp to set as the timestamp that a refund was
+/// - `ts` -- Unix timestamp for the request
+/// - `refund_requested_ts` -- Unix timestamp to set as the timestamp that a refund was
 ///   requested on this payment
 /// - `payment_tx_provider` -- Provider that the payment to register is coming from
 /// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment provider.
@@ -535,8 +535,8 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
-        uint64_t refund_requested_unix_ts_ms,
+        uint64_t ts,
+        uint64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,
@@ -555,8 +555,8 @@ session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_req
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
-        uint64_t refund_requested_unix_ts_ms,
+        uint64_t ts,
+        uint64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -12,12 +12,14 @@ extern "C" {
 #endif
 
 /// Canonical payment-provider `code` strings — the value transmitted on the wire and folded into
-/// the add-payment / set-refund signed hashes (spec §1). Reference these constants rather than
-/// hardcoding the slug so a sent code cannot drift from what libsession hashes/parses. Unknown
-/// codes (e.g. a future provider) are still valid on the wire and pass through as opaque strings.
-static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY[] = "google_play";
-static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE[] = "app_store";
-static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF[] = "rangeproof";
+/// the add-payment / set-refund signed messages (§3). Reference these rather than hardcoding the
+/// slug so a sent code cannot drift from what libsession signs/parses. Unknown codes (e.g. a future
+/// provider) are still valid on the wire and pass through as opaque strings. Each points at the
+/// C++ `session::pro_backend::PAYMENT_PROVIDER_*` value (defined there — the primary; C
+/// references).
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF;
 
 /// Endpoint path (relative to the backend base URL) that each request type is POSTed to. libsession
 /// owns the body<->route pairing, so reference these rather than hardcoding the path client-side.

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -38,6 +38,15 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIO
 LIBSESSION_EXPORT extern const char* const
         SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT;
 
+/// The Session Pro Backend's production base URL (POST a request body to `<URL>/<endpoint>`).
+/// Canonical production value; clients may override with a dev/test server. Points at the single
+/// master string owned in the C++ implementation.
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_URL;
+
+/// The Session Pro Backend's Ed25519 public signing key, 32 bytes, for verifying a proof was issued
+/// by the backend. Points at the same value as the C++ `session::pro_backend::PUBKEY`.
+LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY;
+
 /// Per-provider support/management URLs, keyed by provider code. These are identical for every user
 /// (not translation data), so libsession owns them as the single source of truth rather than each
 /// client duplicating them; the human-readable provider/store names are translation data and remain

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -47,6 +47,11 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_URL;
 /// by the backend. Points at the same value as the C++ `session::pro_backend::PUBKEY`.
 LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY;
 
+/// The X25519 form of SESSION_PRO_BACKEND_PUBKEY, 32 bytes (the Ed25519 key converted via
+/// crypto_sign_ed25519_pk_to_curve25519). Points at the same value as the C++
+/// `session::pro_backend::PUBKEY_X25519`.
+LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X25519;
+
 /// Per-provider support/management URLs, keyed by provider code. These are identical for every user
 /// (not translation data), so libsession owns them as the single source of truth rather than each
 /// client duplicating them; the human-readable provider/store names are translation data and remain

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -216,12 +216,15 @@ struct session_pro_backend_pro_payment_item {
     size_t payment_provider_count;
 
     bool auto_renewing;
-    int64_t unredeemed_ts;
+    /// Provider purchase time, fractional UNIX seconds. Millisecond-precise: the value passes
+    /// through a millisecond-resolution representation, so sub-millisecond digits are not retained.
+    double purchased_ts;
     int64_t redeemed_ts;
     int64_t expiry_ts;
     int64_t grace_period_duration;
     int64_t platform_refund_expiry_ts;
-    int64_t revoked_ts;
+    /// Provider revocation instant, fractional UNIX seconds (millisecond-precise; 0 if not revoked)
+    double revoked_ts;
     int64_t refund_requested_ts;
 
     /// Opaque payment identifier (the value passed at add-payment; multi-part providers fold their

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -80,23 +80,10 @@ typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
 } SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
 
-/// Must match the backend's add-pro-payment response status enum (session-pro-backend server.py).
-typedef enum SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS {
-    SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_SUCCESS =
-            SESSION_PRO_BACKEND_STATUS_SUCCESS,
-    SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_PARSE_ERROR =
-            SESSION_PRO_BACKEND_STATUS_PARSE_ERROR,
-    SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_ERROR =
-            SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR,
-
-    SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_ALREADY_REDEEMED = 100,
-    SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_UNKNOWN_PAYMENT = 101,
-} SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS;
-
 typedef struct session_pro_backend_response_header session_pro_backend_response_header;
 struct session_pro_backend_response_header {
-    uint32_t status;
-    /// Array of error messages (NULL if no errors), with errors_count elements
+    /// Error messages (NULL if none), with errors_count elements. The response succeeded iff
+    /// errors_count == 0; on failure the messages carry the reason(s) (backend- or parse-supplied).
     string8* errors;
     size_t errors_count;
     uint8_t* internal_arena_buf_;  /// Internal buffer for all the memory allocations, do not touch

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -67,6 +67,14 @@ struct session_pro_backend_provider_urls {
 LIBSESSION_EXPORT session_pro_backend_provider_urls
 session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1);
 
+/// API: session_pro_backend/visible_platforms
+///
+/// Returns the user-visible purchasable platforms as an array of `*count` provider-code C strings
+/// (a subset of the SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* values). Order is not significant;
+/// clients pick their own. Hidden mechanisms (e.g. rangeproof) are excluded. The returned array and
+/// its strings are static storage owned by libsession — do not free.
+LIBSESSION_EXPORT const char* const* session_pro_backend_visible_platforms(size_t* count);
+
 typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_SUCCESS,
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR,

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -28,7 +28,8 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_
 /// owned in the C++ implementation (defined once, shared by the C and C++ sides).
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT;
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT;
-LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_STATUS_ENDPOINT;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PAYMENT_DETAILS_ENDPOINT;
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT;
 LIBSESSION_EXPORT extern const char* const
         SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT;
@@ -107,11 +108,11 @@ typedef struct session_pro_backend_request {
 LIBSESSION_EXPORT
 void session_pro_backend_request_free(session_pro_backend_request* request);
 
-typedef enum SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT {
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_SUCCESS,
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR,
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT,
-} SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT;
+typedef enum SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT {
+    SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_SUCCESS,
+    SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR,
+    SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_COUNT,
+} SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT;
 
 /// Response outcome (wire `status`, spec §5). CLOSED/exhaustive: the backend will never add a
 /// value, so an unrecognized wire status is reported as a protocol error (RESPONSE_STATUS_ERROR +
@@ -218,28 +219,50 @@ typedef struct session_pro_backend_pro_payment_item {
     const char* payment_id;
 } session_pro_backend_pro_payment_item;
 
-typedef struct session_pro_backend_get_pro_details_response {
+typedef struct session_pro_backend_get_pro_status_response {
     session_pro_backend_response_header header;
-    /// Array of payment items, with items_count elements
-    session_pro_backend_pro_payment_item* items;
-    size_t items_count;
     /// Opaque account Pro status code ("never"/"active"/"expired"); unknown values pass through.
     /// NUL-terminated; points into the response's `internal_`.
     const char* status;
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
+    SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT error_report;
     bool auto_renewing;
     int64_t expiry_ts;
     int64_t grace_period_duration;
     int64_t refund_requested_ts;
-    uint32_t payments_total;
-} session_pro_backend_get_pro_details_response;
+    /// True if the account has at least one payment, in which case `latest_payment` is populated
+    /// with the most recent one; false means the account has no payments and `latest_payment` is
+    /// unset.
+    bool has_latest_payment;
+    session_pro_backend_pro_payment_item latest_payment;
+} session_pro_backend_get_pro_status_response;
 
-/// API: session_pro_backend/get_pro_details_response_free
+/// API: session_pro_backend/get_pro_status_response_free
 ///
 /// Frees the response.
 LIBSESSION_EXPORT
-void session_pro_backend_get_pro_details_response_free(
-        session_pro_backend_get_pro_details_response* response);
+void session_pro_backend_get_pro_status_response_free(
+        session_pro_backend_get_pro_status_response* response);
+
+typedef struct session_pro_backend_get_payment_details_response {
+    session_pro_backend_response_header header;
+    /// Array of payment items (one keyset page, newest-first), with items_count elements.
+    session_pro_backend_pro_payment_item* items;
+    size_t items_count;
+    /// Total number of payments the backend knows for the user (may exceed items_count).
+    uint32_t payments_total;
+    /// Opaque keyset-pagination cursor: pass as `before` to
+    /// session_pro_backend_get_payment_details_request_build to fetch the next (older) page. NULL
+    /// at end-of-data. NUL-terminated and points into the response's `internal_`; echo it verbatim,
+    /// do NOT parse or synthesize it.
+    const char* next_cursor;
+} session_pro_backend_get_payment_details_response;
+
+/// API: session_pro_backend/get_payment_details_response_free
+///
+/// Frees the response.
+LIBSESSION_EXPORT
+void session_pro_backend_get_payment_details_response_free(
+        session_pro_backend_get_payment_details_response* response);
 
 typedef struct session_pro_backend_set_payment_refund_requested_response {
     session_pro_backend_response_header header;
@@ -305,9 +328,9 @@ session_pro_backend_request session_pro_backend_generate_pro_proof_request_build
 LIBSESSION_EXPORT
 session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(int64_t ticket);
 
-/// API: session_pro_backend/get_pro_details_request_build
+/// API: session_pro_backend/get_pro_status_request_build
 ///
-/// Builds the get-details request to POST, as a session_pro_backend_request (endpoint +
+/// Builds the get-pro-status request to POST, as a session_pro_backend_request (endpoint +
 /// content_type + opaque data). Free it with `session_pro_backend_request_free`. On a key-size
 /// error `success` is false and `error`/`error_count` describe it.
 ///
@@ -315,11 +338,31 @@ session_pro_backend_request session_pro_backend_get_pro_revocations_request_buil
 /// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
 /// libsodium).
 /// - `ts` -- Unix timestamp (seconds) for the request.
-/// - `count` -- number of historical payments to request.
 LIBSESSION_EXPORT
-session_pro_backend_request session_pro_backend_get_pro_details_request_build(
-        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count)
-        NON_NULL_ARG(1);
+session_pro_backend_request session_pro_backend_get_pro_status_request_build(
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts) NON_NULL_ARG(1);
+
+/// API: session_pro_backend/get_payment_details_request_build
+///
+/// Builds the get-payment-details (paginated history) request to POST, as a
+/// session_pro_backend_request (endpoint + content_type + opaque data). Free it with
+/// `session_pro_backend_request_free`. On a key-size error `success` is false and
+/// `error`/`error_count` describe it.
+///
+/// Inputs:
+/// - `master_privkey` / `master_privkey_len` -- Ed25519 master private key (32 or 64-byte
+/// libsodium).
+/// - `ts` -- Unix timestamp (seconds) for the request.
+/// - `limit` -- maximum payments to return on this page (the backend may clamp it).
+/// - `before` -- opaque pagination cursor from a previous response's `next_cursor`, or NULL / the
+///   empty string for the newest page. Pass through verbatim; do not parse or synthesize it.
+LIBSESSION_EXPORT
+session_pro_backend_request session_pro_backend_get_payment_details_request_build(
+        const uint8_t* master_privkey,
+        size_t master_privkey_len,
+        int64_t ts,
+        uint32_t limit,
+        const char* before) NON_NULL_ARG(1);
 
 /// API: session_pro_backend/pro_proof_response_parse
 ///
@@ -346,17 +389,29 @@ LIBSESSION_EXPORT
 session_pro_backend_get_pro_revocations_response
 session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t json_len);
 
-/// API: session_pro_backend/get_pro_details_response_parse
+/// API: session_pro_backend/get_pro_status_response_parse
 ///
-/// Parses a JSON string into a GetProPaymentsResponse struct.
-/// The caller must free the response using session_pro_backend_get_pro_details_response_free.
+/// Parses a JSON string into a session_pro_backend_get_pro_status_response struct.
+/// The caller must free the response using session_pro_backend_get_pro_status_response_free.
 ///
 /// Inputs:
 /// - `json` -- JSON string to parse.
 /// - `json_len` -- Length of the JSON string.
 LIBSESSION_EXPORT
-session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details_response_parse(
+session_pro_backend_get_pro_status_response session_pro_backend_get_pro_status_response_parse(
         const char* json, size_t json_len);
+
+/// API: session_pro_backend/get_payment_details_response_parse
+///
+/// Parses a JSON string into a session_pro_backend_get_payment_details_response struct.
+/// The caller must free the response using session_pro_backend_get_payment_details_response_free.
+///
+/// Inputs:
+/// - `json` -- JSON string to parse.
+/// - `json_len` -- Length of the JSON string.
+LIBSESSION_EXPORT
+session_pro_backend_get_payment_details_response
+session_pro_backend_get_payment_details_response_parse(const char* json, size_t json_len);
 
 /// API: session_pro_backend/set_payment_refund_requested_request_build
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -50,14 +50,13 @@ LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X
 /// client duplicating them; the human-readable provider/store names are translation data and remain
 /// the client's job. An unknown provider code (or one with no applicable URLs, e.g. rangeproof)
 /// yields all-NULL fields. Otherwise each is a static, null-terminated C string.
-typedef struct session_pro_backend_provider_urls session_pro_backend_provider_urls;
-struct session_pro_backend_provider_urls {
+typedef struct session_pro_backend_provider_urls {
     const char* refund_platform_url;      /// Native store refund flow
     const char* refund_support_url;       /// Session support page for requesting a refund
     const char* refund_status_url;        /// Where a user checks refund status
     const char* update_subscription_url;  /// Manage/update the subscription
     const char* cancel_subscription_url;  /// Cancel the subscription
-};
+} session_pro_backend_provider_urls;
 
 /// API: session_pro_backend/get_provider_urls
 ///
@@ -91,8 +90,7 @@ typedef enum SESSION_PRO_BACKEND_RESPONSE_STATUS {
                                                 ///< later.
 } SESSION_PRO_BACKEND_RESPONSE_STATUS;
 
-typedef struct session_pro_backend_response_header session_pro_backend_response_header;
-struct session_pro_backend_response_header {
+typedef struct session_pro_backend_response_header {
     /// Outcome category. Success iff `status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK`.
     SESSION_PRO_BACKEND_RESPONSE_STATUS status;
     /// On non-OK, the machine-readable outcome slug (spec §5.1); {NULL, 0} on success. Opaque and
@@ -103,15 +101,14 @@ struct session_pro_backend_response_header {
     /// error_code to a localized string); {NULL, 0} on success. Always safe to log.
     string8 error;
     uint8_t* internal_arena_buf_;  /// Internal buffer for all the memory allocations, do not touch
-};
+} session_pro_backend_response_header;
 
 /// A built request to POST to the Session Pro backend. Mirrors the C++
 /// `session::pro_backend::ProRequest`: an `endpoint`, the `content_type` to send as the request's
 /// Content-Type header, and the opaque `data` payload. `data` is libsession's data for the backend
 /// -- relay it verbatim with the given `content_type` and do NOT parse, inspect, or assume a format
 /// for it. libsession owns the wire encoding and may change it without client involvement.
-typedef struct session_pro_backend_request session_pro_backend_request;
-struct session_pro_backend_request {
+typedef struct session_pro_backend_request {
     char error[256];
     size_t error_count;
     bool success;  /// True if the request was built successfully, false if out-of-memory
@@ -123,24 +120,20 @@ struct session_pro_backend_request {
     string8 data;
     /// Owned C++ object backing endpoint/content_type/data; do not touch (freed by request_free).
     void* internal_;
-};
+} session_pro_backend_request;
 
-typedef struct session_pro_backend_pro_proof_response session_pro_backend_pro_proof_response;
-struct session_pro_backend_pro_proof_response {
+typedef struct session_pro_backend_pro_proof_response {
     session_pro_backend_response_header header;
     session_protocol_pro_proof proof;
-};
+} session_pro_backend_pro_proof_response;
 
-typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
-struct session_pro_backend_pro_revocation_item {
+typedef struct session_pro_backend_pro_revocation_item {
     bytes32 revocation_tag;
     /// Unix timestamp (seconds); a matching proof is revoked once the client clock reaches this
     int64_t effective_ts;
-};
+} session_pro_backend_pro_revocation_item;
 
-typedef struct session_pro_backend_get_pro_revocations_response
-        session_pro_backend_get_pro_revocations_response;
-struct session_pro_backend_get_pro_revocations_response {
+typedef struct session_pro_backend_get_pro_revocations_response {
     session_pro_backend_response_header header;
     int64_t ticket;
     int64_t retry_in;    /// Recommended seconds to wait before polling the list again
@@ -148,7 +141,7 @@ struct session_pro_backend_get_pro_revocations_response {
     /// Array of items, with items_count elements
     session_pro_backend_pro_revocation_item* items;
     size_t items_count;
-};
+} session_pro_backend_get_pro_revocations_response;
 
 /// Unit of a parsed billing period (`plan_unit` below); mirrors C++
 /// session::pro_backend::ProPlanUnit (same order). A closed set (pro-wire-protocol.md §1 / Delta
@@ -162,8 +155,7 @@ typedef enum SESSION_PRO_BACKEND_PLAN_UNIT {
     SESSION_PRO_BACKEND_PLAN_UNIT_LIFETIME,
 } SESSION_PRO_BACKEND_PLAN_UNIT;
 
-typedef struct session_pro_backend_pro_payment_item session_pro_backend_pro_payment_item;
-struct session_pro_backend_pro_payment_item {
+typedef struct session_pro_backend_pro_payment_item {
     /// Opaque payment lifecycle status code (e.g. "unredeemed"/"redeemed"/"expired"/"revoked");
     /// unknown values pass through as-is
     char status[64];
@@ -194,11 +186,9 @@ struct session_pro_backend_pro_payment_item {
     /// parts in per the backend-defined composite -- libsession does not interpret it)
     char payment_id[128];
     size_t payment_id_count;
-};
+} session_pro_backend_pro_payment_item;
 
-typedef struct session_pro_backend_get_pro_details_response
-        session_pro_backend_get_pro_details_response;
-struct session_pro_backend_get_pro_details_response {
+typedef struct session_pro_backend_get_pro_details_response {
     session_pro_backend_response_header header;
     /// Array of payment items, with items_count elements
     session_pro_backend_pro_payment_item* items;
@@ -212,14 +202,12 @@ struct session_pro_backend_get_pro_details_response {
     int64_t grace_period_duration;
     int64_t refund_requested_ts;
     uint32_t payments_total;
-};
+} session_pro_backend_get_pro_details_response;
 
-typedef struct session_pro_backend_set_payment_refund_requested_response
-        session_pro_backend_set_payment_refund_requested_response;
-struct session_pro_backend_set_payment_refund_requested_response {
+typedef struct session_pro_backend_set_payment_refund_requested_response {
     session_pro_backend_response_header header;
     bool updated;
-};
+} session_pro_backend_set_payment_refund_requested_response;
 
 /// API: session_pro_backend/add_pro_payment_request_build
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -150,15 +150,30 @@ struct session_pro_backend_get_pro_revocations_response {
     size_t items_count;
 };
 
+/// Unit of a parsed billing period (`plan_unit` below); mirrors C++
+/// session::pro_backend::ProPlanUnit (same order). A closed set (pro-wire-protocol.md §1 / Delta
+/// #14).
+typedef enum SESSION_PRO_BACKEND_PLAN_UNIT {
+    SESSION_PRO_BACKEND_PLAN_UNIT_SECOND,
+    SESSION_PRO_BACKEND_PLAN_UNIT_DAY,
+    SESSION_PRO_BACKEND_PLAN_UNIT_WEEK,
+    SESSION_PRO_BACKEND_PLAN_UNIT_MONTH,
+    SESSION_PRO_BACKEND_PLAN_UNIT_YEAR,
+    SESSION_PRO_BACKEND_PLAN_UNIT_LIFETIME,
+} SESSION_PRO_BACKEND_PLAN_UNIT;
+
 typedef struct session_pro_backend_pro_payment_item session_pro_backend_pro_payment_item;
 struct session_pro_backend_pro_payment_item {
     /// Opaque payment lifecycle status code (e.g. "unredeemed"/"redeemed"/"expired"/"revoked");
     /// unknown values pass through as-is
     char status[64];
     size_t status_count;
-    /// Billing-period code (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for non-period plans
-    char plan[64];
-    size_t plan_count;
+    /// Parsed billing period (pro-wire-protocol.md §1 / Delta #14). `plan_count` is the period
+    /// count
+    /// (>= 1 for periodic units); for `plan_unit == ..._LIFETIME` it is 0 and not meaningful
+    /// (switch on `plan_unit`, never render "<count> <unit>" for lifetime).
+    int plan_count;
+    SESSION_PRO_BACKEND_PLAN_UNIT plan_unit;
     /// Provider code (e.g. "google_play"); opaque -- an unknown value passes through as-is
     char payment_provider[64];
     size_t payment_provider_count;

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -50,9 +50,14 @@ LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X
 /// Per-provider support/management URLs, keyed by provider code. These are identical for every user
 /// (not translation data), so libsession owns them as the single source of truth rather than each
 /// client duplicating them; the human-readable provider/store names are translation data and remain
-/// the client's job. An unknown provider code (or one with no applicable URLs, e.g. rangeproof)
-/// yields all-NULL fields. Otherwise each is a static, null-terminated C string.
+/// the client's job. Each URL field is NULL when that provider has no such URL, and is otherwise a
+/// static, null-terminated C string. Use `found` (not the URL fields) to tell an unknown provider
+/// code from a known provider that simply has no URLs.
 typedef struct session_pro_backend_provider_urls {
+    /// True if `provider_code` is a recognised provider; false if it is unknown (or e.g.
+    /// rangeproof), in which case every URL field below is NULL. A recognised provider may still
+    /// leave any or all URL fields NULL.
+    bool found;
     const char* refund_platform_url;      /// Native store refund flow
     const char* refund_support_url;       /// Session support page for requesting a refund
     const char* refund_status_url;        /// Where a user checks refund status
@@ -63,8 +68,9 @@ typedef struct session_pro_backend_provider_urls {
 /// API: session_pro_backend/get_provider_urls
 ///
 /// Returns the support/management URLs for `provider_code` (a
-/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* value). A provider with no applicable URLs (unknown
-/// code, or e.g. rangeproof) returns a struct with all fields NULL.
+/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* value). On an unrecognised code the result has
+/// `found == false` and all URL fields NULL; on a recognised code `found == true` and each URL
+/// field is either a static, null-terminated C string or NULL if that provider lacks that URL.
 LIBSESSION_EXPORT session_pro_backend_provider_urls
 session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1);
 

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -170,7 +170,7 @@ struct session_pro_backend_generate_pro_proof_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes32 rotating_pkey;
-    uint64_t ts;
+    int64_t ts;
     bytes64 master_sig;
     bytes64 rotating_sig;
 };
@@ -192,7 +192,7 @@ struct session_pro_backend_get_pro_revocations_request {
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
 struct session_pro_backend_pro_revocation_item {
     bytes32 gen_index_hash;
-    uint64_t expiry_ts;
+    int64_t expiry_ts;
 };
 
 typedef struct session_pro_backend_get_pro_revocations_response
@@ -211,7 +211,7 @@ struct session_pro_backend_get_pro_details_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
-    uint64_t ts;
+    int64_t ts;
     uint32_t count;
 };
 
@@ -225,13 +225,13 @@ struct session_pro_backend_pro_payment_item {
     const session_pro_backend_payment_provider_metadata* payment_provider_metadata;
 
     bool auto_renewing;
-    uint64_t unredeemed_ts;
-    uint64_t redeemed_ts;
-    uint64_t expiry_ts;
-    uint64_t grace_period_duration;
-    uint64_t platform_refund_expiry_ts;
-    uint64_t revoked_ts;
-    uint64_t refund_requested_ts;
+    int64_t unredeemed_ts;
+    int64_t redeemed_ts;
+    int64_t expiry_ts;
+    int64_t grace_period_duration;
+    int64_t platform_refund_expiry_ts;
+    int64_t revoked_ts;
+    int64_t refund_requested_ts;
 
     char google_payment_token[128];
     size_t google_payment_token_count;
@@ -257,9 +257,9 @@ struct session_pro_backend_get_pro_details_response {
     SESSION_PRO_BACKEND_USER_PRO_STATUS status;
     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
     bool auto_renewing;
-    uint64_t expiry_ts;
-    uint64_t grace_period_duration;
-    uint64_t refund_requested_ts;
+    int64_t expiry_ts;
+    int64_t grace_period_duration;
+    int64_t refund_requested_ts;
     uint32_t payments_total;
 };
 
@@ -269,8 +269,8 @@ struct session_pro_backend_set_payment_refund_requested_request {
     uint8_t version;
     bytes32 master_pkey;
     bytes64 master_sig;
-    uint64_t ts;
-    uint64_t refund_requested_ts;
+    int64_t ts;
+    int64_t refund_requested_ts;
     session_pro_backend_add_pro_payment_user_transaction payment_tx;
 };
 
@@ -370,7 +370,7 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t ts) NON_NULL_ARG(2, 4);
+        int64_t ts) NON_NULL_ARG(2, 4);
 
 /// API: session_pro_backend/generate_pro_proof_request_build_to_json
 ///
@@ -386,7 +386,7 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t ts) NON_NULL_ARG(2, 4);
+        int64_t ts) NON_NULL_ARG(2, 4);
 
 /// API: session_pro_backend/get_pro_details_request_build_sig
 ///
@@ -410,7 +410,7 @@ session_pro_backend_signature session_pro_backend_get_pro_details_request_build_
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
+        int64_t ts,
         uint32_t count) NON_NULL_ARG(2);
 
 /// API: session_pro_backend/get_pro_details_request_build_to_json
@@ -425,7 +425,7 @@ session_pro_backend_to_json session_pro_backend_get_pro_details_request_build_to
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
+        int64_t ts,
         uint32_t count) NON_NULL_ARG(2);
 
 /// API: session_pro_backend/add_pro_payment_request_to_json
@@ -535,8 +535,8 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
-        uint64_t refund_requested_ts,
+        int64_t ts,
+        int64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,
@@ -555,8 +555,8 @@ session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_req
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
-        uint64_t refund_requested_ts,
+        int64_t ts,
+        int64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -19,15 +19,13 @@ enum {
     SESSION_PRO_BACKEND_STATUS_PARSE_ERROR = 2,
 };
 
-/// Store front that a Session Pro payment came from. Must match:
-///   https://github.com/session-foundation/session-pro-backend/blob/8ec0aacca2e5975407df1b60f5346477e17de44d/base.py#L78
-typedef enum SESSION_PRO_BACKEND_PAYMENT_PROVIDER {
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL,
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE,
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_IOS_APP_STORE,
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF,
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT,
-} SESSION_PRO_BACKEND_PAYMENT_PROVIDER;
+/// Canonical payment-provider `code` strings — the value transmitted on the wire and folded into
+/// the add-payment / set-refund signed hashes (spec §1). Reference these constants rather than
+/// hardcoding the slug so a sent code cannot drift from what libsession hashes/parses. Unknown
+/// codes (e.g. a future provider) are still valid on the wire and pass through as opaque strings.
+static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY[] = "google_play";
+static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE[] = "app_store";
+static const char SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF[] = "rangeproof";
 
 /// Must match:
 ///   https://github.com/Doy-lee/session-pro-backend/blob/f4e2c84794470e7932ba1a1968fdb49117bb5870/backend.py#L18
@@ -36,19 +34,9 @@ typedef enum SESSION_PRO_BACKEND_PAYMENT_STATUS {
     SESSION_PRO_BACKEND_PAYMENT_STATUS_UNREDEEMED,
     SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED,
     SESSION_PRO_BACKEND_PAYMENT_STATUS_EXPIRED,
-    SESSION_PRO_BACKEND_PAYMENT_STATUS_REFUNDED,
+    SESSION_PRO_BACKEND_PAYMENT_STATUS_REVOKED,
     SESSION_PRO_BACKEND_PAYMENT_STATUS_COUNT,
 } SESSION_PRO_BACKEND_PAYMENT_STATUS;
-
-/// Must match:
-///   https://github.com/Doy-lee/session-pro-backend/blob/b9fb4301fecbd82e4631536fa378d4c1220b1a4d/base.py#L53
-typedef enum SESSION_PRO_BACKEND_PLAN {
-    SESSION_PRO_BACKEND_PLAN_NIL,
-    SESSION_PRO_BACKEND_PLAN_ONE_MONTH,
-    SESSION_PRO_BACKEND_PLAN_THREE_MONTHS,
-    SESSION_PRO_BACKEND_PLAN_TWELVE_MONTHS,
-    SESSION_PRO_BACKEND_PLAN_COUNT,
-} SESSION_PRO_BACKEND_PLAN;
 
 /// Must match:
 ///   https://github.com/Doy-lee/session-pro-backend/blob/a0e0ba24bc4ab3a062465d861aa57df2269b6dde/server.py#L373
@@ -78,35 +66,6 @@ typedef enum SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS {
     SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_ALREADY_REDEEMED = 100,
     SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_UNKNOWN_PAYMENT = 101,
 } SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS;
-
-/// Bundle of hard-coded strings that are associated with each platform for clients to use for
-/// string substitution typically. This structure is stored in a global table
-/// `SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA` that is can be indexed into using the
-/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER value directly.
-typedef struct session_pro_backend_payment_provider_metadata
-        session_pro_backend_payment_provider_metadata;
-struct session_pro_backend_payment_provider_metadata {
-    string8 device;
-    string8 store;
-    string8 platform;
-    string8 platform_account;
-    string8 refund_platform_url;
-
-    /// Some platforms disallow a refund via their native support channels after some time period
-    /// (e.g. 48 hours after a purchase on Google, refunds must be dealt by the developers
-    /// themselves). If a platform does not have this restriction, this URL is typically the same as
-    /// the `refund_platform_url`.
-    string8 refund_support_url;
-
-    string8 refund_status_url;
-    string8 update_subscription_url;
-    string8 cancel_subscription_url;
-};
-
-/// The centralised list of common URLs and properties for handling payment provider specific
-/// integrations. Especially useful for cross-device management of Session Pro subscriptions.
-extern const session_pro_backend_payment_provider_metadata
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA[SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT];
 
 typedef struct session_pro_backend_response_header session_pro_backend_response_header;
 struct session_pro_backend_response_header {
@@ -146,11 +105,14 @@ struct session_pro_backend_signature {
 typedef struct session_pro_backend_add_pro_payment_user_transaction
         session_pro_backend_add_pro_payment_user_transaction;
 struct session_pro_backend_add_pro_payment_user_transaction {
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER provider;
+    /// Provider code string (see SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*); opaque slug
+    char provider_code[64];
+    size_t provider_code_count;
+    /// Opaque payment identifier from the provider's purchase flow. Multi-part providers fold their
+    /// parts into this one string per a backend-defined composite (e.g. Google "token|order_id");
+    /// libsession treats it as opaque bytes hashed verbatim.
     char payment_id[128];
     size_t payment_id_count;
-    char order_id[128];
-    size_t order_id_count;
 };
 
 typedef struct session_pro_backend_add_pro_payment_request
@@ -221,11 +183,12 @@ struct session_pro_backend_get_pro_details_request {
 typedef struct session_pro_backend_pro_payment_item session_pro_backend_pro_payment_item;
 struct session_pro_backend_pro_payment_item {
     SESSION_PRO_BACKEND_PAYMENT_STATUS status;
-    SESSION_PRO_BACKEND_PLAN plan;
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_provider;
-    /// Pointer to payment provider metadata. This pointer is always defined to be pointing to valid
-    /// memory when the structure is received through the pro_backend APIs.
-    const session_pro_backend_payment_provider_metadata* payment_provider_metadata;
+    /// Billing-period code (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for non-period plans
+    char plan[64];
+    size_t plan_count;
+    /// Provider code (e.g. "google_play"); opaque -- an unknown value passes through as-is
+    char payment_provider[64];
+    size_t payment_provider_count;
 
     bool auto_renewing;
     int64_t unredeemed_ts;
@@ -236,18 +199,10 @@ struct session_pro_backend_pro_payment_item {
     int64_t revoked_ts;
     int64_t refund_requested_ts;
 
-    char google_payment_token[128];
-    size_t google_payment_token_count;
-    char google_order_id[128];
-    size_t google_order_id_count;
-    char apple_original_tx_id[128];
-    size_t apple_original_tx_id_count;
-    char apple_tx_id[128];
-    size_t apple_tx_id_count;
-    char apple_web_line_order_id[128];
-    size_t apple_web_line_order_id_count;
-    char rangeproof_order_id[128];
-    size_t rangeproof_order_id_count;
+    /// Opaque payment identifier (the value passed at add-payment; multi-part providers fold their
+    /// parts in per the backend-defined composite -- libsession does not interpret it)
+    char payment_id[128];
+    size_t payment_id_count;
 };
 
 typedef struct session_pro_backend_get_pro_details_response
@@ -297,13 +252,11 @@ struct session_pro_backend_set_payment_refund_requested_response {
 /// - `master_privkey_len` -- Length of master_privkey.
 /// - `rotating_privkey` -- Ed25519 rotating private key (32-byte or 64-byte libsodium format).
 /// - `rotating_privkey_len` -- Length of rotating_privkey.
-/// - `payment_tx_provider` -- Provider that the payment to register is coming from
-/// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment provider.
-///   See `AddProPaymentUserTransaction`
-/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
-/// - `payment_tx_order_id` -- Order ID that is associated with the payment see
+/// - `payment_tx_provider_code` -- Null-terminated provider code string the payment is coming from
+///   (use a SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* constant)
+/// - `payment_tx_payment_id` -- Opaque payment identifier from the provider. See
 ///   `AddProPaymentUserTransaction`
-/// - `payment_tx_order_id_len` -- Length of the `payment_tx_order_id` payload
+/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
 ///
 /// Outputs:
 /// - `success` - True if signatures are built successfully, false otherwise.
@@ -319,11 +272,9 @@ session_pro_backend_add_pro_payment_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) NON_NULL_ARG(2, 4, 7, 9);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 4, 6, 7);
 
 /// API: session_pro_backend/add_pro_payment_request_build_to_json
 ///
@@ -339,11 +290,9 @@ session_pro_backend_to_json session_pro_backend_add_pro_payment_request_build_to
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) NON_NULL_ARG(2, 4, 7, 9);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 4, 6, 7);
 
 /// API: session_pro_backend/generate_pro_proof_request_build_sigs
 ///
@@ -520,13 +469,11 @@ session_pro_backend_get_pro_details_response session_pro_backend_get_pro_details
 /// - `ts` -- Unix timestamp for the request
 /// - `refund_requested_ts` -- Unix timestamp to set as the timestamp that a refund was
 ///   requested on this payment
-/// - `payment_tx_provider` -- Provider that the payment to register is coming from
-/// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment provider.
-///   See `AddProPaymentUserTransaction`
-/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
-/// - `payment_tx_order_id` -- Order ID that is associated with the payment see
+/// - `payment_tx_provider_code` -- Null-terminated provider code string the payment is coming from
+///   (use a SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* constant)
+/// - `payment_tx_payment_id` -- Opaque payment identifier from the provider. See
 ///   `AddProPaymentUserTransaction`
-/// - `payment_tx_order_id_len` -- Length of the `payment_tx_order_id` payload
+/// - `payment_tx_payment_id_len` -- Length of the `payment_tx_payment_id` payload
 ///
 /// Outputs:
 /// - `bool` -- True if signatures are built successfully, false otherwise.
@@ -540,11 +487,9 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) NON_NULL_ARG(2, 7, 9);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 6, 7);
 
 /// API: session_pro_backend/set_payment_refund_requested_request_build_to_json
 ///
@@ -560,11 +505,9 @@ session_pro_backend_to_json session_pro_backend_set_payment_refund_requested_req
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) NON_NULL_ARG(2, 7, 9);
+        size_t payment_tx_payment_id_len) NON_NULL_ARG(2, 6, 7);
 
 /// API: session_pro_backend/set_payment_refund_requested_request_to_json
 ///

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -186,7 +186,7 @@ typedef struct session_pro_backend_get_pro_revocations_request
         session_pro_backend_get_pro_revocations_request;
 struct session_pro_backend_get_pro_revocations_request {
     uint8_t version;
-    uint32_t ticket;
+    int64_t ticket;
 };
 
 typedef struct session_pro_backend_pro_revocation_item session_pro_backend_pro_revocation_item;
@@ -199,7 +199,7 @@ typedef struct session_pro_backend_get_pro_revocations_response
         session_pro_backend_get_pro_revocations_response;
 struct session_pro_backend_get_pro_revocations_response {
     session_pro_backend_response_header header;
-    uint32_t ticket;
+    int64_t ticket;
     /// Array of items, with items_count elements
     session_pro_backend_pro_revocation_item* items;
     size_t items_count;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <oxenc/hex.h>
 #include <session/pro_backend.h>
 
 #include <chrono>
@@ -56,12 +57,13 @@
 
 namespace session::pro_backend {
 
-/// TODO: Assign the Session Pro backend public key for verifying proofs to allow users of the
-/// library to have the pubkey available for verifying proofs.
-constexpr array_uc32 PUBKEY = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-static_assert(sizeof(PUBKEY) == array_uc32{}.size());
+using namespace oxenc::literals;
+
+/// The Session Pro Backend's Ed25519 public key: verify that a proof was issued by the backend by
+/// checking its signature against this key (see ProProof::verify_signature). This is the current
+/// backend signing key (test deployment, expected to carry through to production).
+constexpr auto PUBKEY = "479ffca8bcec7b4a0f0f7afe48b8a6d15635a8c7ff15ad16add05752c19414d4"_hex_u;
+static_assert(PUBKEY.size() == 32);
 
 enum struct AddProPaymentResponseStatus {
     /// Payment was claimed and the pro proof was successfully generated

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -276,8 +276,10 @@ struct ProPaymentItem {
     /// billing cycle.
     bool auto_renewing;
 
-    /// Unix timestamp of when the payment was witnessed by the Pro Backend. Always set
-    sys_seconds unredeemed_unix_ts;
+    /// Provider purchase time (when the upstream provider recorded the purchase). Always set.
+    /// Carries the provider's sub-second precision as a millisecond-resolution `sys_ms`; the wire
+    /// sends it as a float of seconds.
+    sys_ms purchased_unix_ts;
 
     /// Unix timestamp of when the payment was redeemed. 0 if not activated
     sys_seconds redeemed_unix_ts;
@@ -295,8 +297,10 @@ struct ProPaymentItem {
     /// provider. Thereafter the user must initiate a refund manually via Session support.
     sys_seconds platform_refund_expiry_unix_ts;
 
-    /// Unix timestamp of when the payment was revoked or refunded. 0 if not applicable.
-    sys_seconds revoked_unix_ts;
+    /// Provider revocation instant (when the payment was revoked). Epoch (0) if not applicable.
+    /// Carries the provider's sub-second precision as a millisecond-resolution `sys_ms`; the wire
+    /// sends it as a float of seconds.
+    sys_ms revoked_unix_ts;
 
     /// UNIX timestamp at which a refund request was requested for this payment. This is set to 0
     /// if no refund has been requested for this payment yet.

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -78,6 +78,15 @@ static_assert(PUBKEY_X25519.size() == 32);
 /// point at a different dev/test server if it chooses.
 constexpr std::string_view URL = "https://pro.session.codes";
 
+/// Canonical payment-provider code strings — the value transmitted on the wire and folded into the
+/// add-payment / set-refund signed messages (§3). Reference these rather than hardcoding the slug
+/// so a sent code cannot drift from what libsession signs/parses. The C
+/// `SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*` symbols point at these. An unknown code is still
+/// valid on the wire and passes through as an opaque string.
+constexpr std::string_view PAYMENT_PROVIDER_GOOGLE_PLAY = "google_play";
+constexpr std::string_view PAYMENT_PROVIDER_APP_STORE = "app_store";
+constexpr std::string_view PAYMENT_PROVIDER_RANGEPROOF = "rangeproof";
+
 /// Response outcome category (the wire `status`, spec §5). CLOSED/exhaustive by design: the backend
 /// will never add a fourth value, so libsession treats any unrecognized wire status as a protocol
 /// error (fail-closed) rather than passing it through. New categories/detail arrive via

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -18,7 +18,7 @@
 /// The high level summary of the functionality in this file. Clients can:
 ///
 /// 1. Build a request with `add_payment_request(...)` from a Session Pro payment and submit its
-///    `{endpoint, body}` to the backend to register the specified Ed25519 keys for Session Pro.
+///    `{endpoint, content_type, data}` to the backend to register the specified Ed25519 keys.
 ///
 ///    Parse the server's reply with `parse_add_payment(...)`. Clients should validate the response
 ///    and update their `UserProfile` by constructing a `ProConfig` with the `proof` from the
@@ -127,16 +127,24 @@ struct ProviderUrls {
 /// hunting for empty members.
 std::optional<ProviderUrls> provider_urls(std::string_view provider_code);
 
-/// Route + body pair for a request to be POSTed to the Session Pro backend, returned by the
-/// `*_request()` helpers below.
+/// Endpoint + content-type + opaque payload for a request to be POSTed to the Session Pro backend,
+/// returned by the `*_request()` helpers below. Callers relay `data` verbatim under `content_type`
+/// and never inspect or assume its format -- libsession owns the wire encoding.
 struct ProRequest {
     /// Endpoint path relative to the backend base URL, e.g. "add_pro_payment". As returned from a
     /// `*_request()` function this points at a static, null-terminated string, so using
     /// `endpoint.data()` as a C string is valid.
     std::string_view endpoint;
 
-    /// The JSON request body to POST to `endpoint`.
-    std::string body;
+    /// Content type to send as the request's `Content-Type` header. Points at a static,
+    /// null-terminated string. Clients MUST relay this verbatim and MUST NOT assume a particular
+    /// format: `data` is libsession's opaque payload for the backend and libsession owns the wire
+    /// encoding, which may change without client involvement.
+    std::string_view content_type;
+
+    /// The opaque request payload to POST to `endpoint`. This is libsession's data for the backend;
+    /// clients relay it untouched and must not parse, inspect, or modify it.
+    std::string data;
 };
 
 /// Register a new Session Pro payment with the backend (endpoint `add_pro_payment`). The payment is

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -285,6 +285,25 @@ array_uc64 payment_details_sig(
 ProRequest payment_details_request(
         std::span<const uint8_t> master_privkey, sys_seconds unix_ts, uint32_t count);
 
+/// Unit of a billing period (the `unit` of a parsed `plan` code, pro-wire-protocol.md §1 / Delta
+/// #14). A closed set: the backend emits only these, so an unrecognized code is a protocol error.
+enum class ProPlanUnit { second, day, week, month, year, lifetime };
+
+/// A parsed `plan` billing-period code. The `unit` is preserved exactly as transmitted and never
+/// canonicalized ("12m" and "1y" are the same duration but distinct values). `count` is meaningful
+/// only for the periodic units and is >= 1; for `lifetime` it is 0 (invariant: count == 0 iff unit
+/// == lifetime), so consumers switch on `unit` and never render "<count> <unit>" for lifetime.
+struct ProPlanPeriod {
+    int count;
+    ProPlanUnit unit;
+};
+
+/// Parse a `plan` billing-period code (pro-wire-protocol.md §1, Delta #14): "<N><unit>" with N a
+/// positive integer (no leading zeros) and unit one of s/d/w/m/y (second/day/week/month/year), or
+/// the literal "lifetime". Single-unit only ("1y6m" is invalid). Returns std::nullopt for any
+/// non-conforming code (the caller treats that as a protocol error).
+std::optional<ProPlanPeriod> parse_plan_period(std::string_view plan_code);
+
 struct ProPaymentItem {
     /// Describes the current status of the consumption of the payment for Session Pro entitlement
     /// The status should be used to determine which timestamps should be used.
@@ -294,9 +313,10 @@ struct ProPaymentItem {
     /// book-keeping purposes.
     std::string status;
 
-    /// Billing-period code that was purchased (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for
-    /// non-period plans. The client maps/parses it for display.
-    std::string plan;
+    /// The parsed billing period that was purchased (e.g. "1m" -> {1, month}, "lifetime" -> {0,
+    /// lifetime}). libsession parses the closed `plan` grammar (§1 / Delta #14); the client just
+    /// localizes the display. The unit is preserved as transmitted, never canonicalized.
+    ProPlanPeriod plan;
 
     /// Provider code this payment came from (e.g. "google_play"); opaque -- an unknown value passes
     /// through as-is for the client to handle.

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -262,7 +262,7 @@ struct ProPaymentItem {
     /// For example, a payment can be in a redeemed state whilst also have a refunded timestamp set
     /// if the payment was refunded and then the refund was reversed. We preserve all timestamps for
     /// book-keeping purposes.
-    SESSION_PRO_BACKEND_PAYMENT_STATUS status;
+    std::string status;
 
     /// Billing-period code that was purchased (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for
     /// non-period plans. The client maps/parses it for display.
@@ -317,7 +317,7 @@ struct GetProDetailsResponse : Response {
     std::vector<ProPaymentItem> items;
 
     /// Current Session Pro entitlement status for the master public key
-    SESSION_PRO_BACKEND_USER_PRO_STATUS user_status;
+    std::string user_status;
 
     /// Error code that indicates that the Session Pro Backend encountered an error book-keeping
     /// Session Pro entitlement for the user. If this value is not `SUCCESS` implementing clients

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -124,23 +124,25 @@ struct MasterRotatingSignatures {
     array_uc64 rotating_sig;
 };
 
-/// Per-provider support/management URLs. These are identical for every user (not translation data),
-/// so libsession owns them as the single source of truth rather than each client duplicating them;
-/// the human-readable provider/store *names* are translation data and remain the client's job.
-/// Returned by `provider_urls()`. The views point at static, null-terminated storage.
-struct ProviderUrls {
-    std::string_view refund_platform_url;      ///< Native store refund flow
-    std::string_view refund_support_url;       ///< Session support page for requesting a refund
-    std::string_view refund_status_url;        ///< Where a user checks refund status
-    std::string_view update_subscription_url;  ///< Manage/update the subscription
-    std::string_view cancel_subscription_url;  ///< Cancel the subscription
+/// Per-provider support/management URLs (from provider_urls()). These are identical for every user
+/// (not translation data), so libsession owns them as the single source of truth rather than each
+/// client duplicating them; the human-readable provider/store *names* are translation data and
+/// remain the client's job. Each field is std::nullopt when that provider has no such URL -- clients
+/// test the optional rather than an empty-string sentinel. Present views point at static,
+/// null-terminated string literals.
+struct ProviderURLs {
+    std::optional<std::string_view> refund_platform_url;  ///< Native store refund flow
+    std::optional<std::string_view> refund_support_url;   ///< Session page for requesting a refund
+    std::optional<std::string_view> refund_status_url;    ///< Where a user checks refund status
+    std::optional<std::string_view> update_subscription_url;  ///< Manage/update the subscription
+    std::optional<std::string_view> cancel_subscription_url;  ///< Cancel the subscription
 };
 
 /// Look up the support/management URLs for a provider code (see
-/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*). Returns std::nullopt for a provider with no
-/// applicable URLs (an unknown code, or e.g. rangeproof) — so callers test the optional rather than
-/// hunting for empty members.
-std::optional<ProviderUrls> provider_urls(std::string_view provider_code);
+/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*). Returns a pointer to a static per-provider
+/// constant, or nullptr for a provider with no applicable URLs at all (an unknown code, or e.g.
+/// rangeproof); within a returned set each field is present or std::nullopt per that provider.
+const ProviderURLs* provider_urls(std::string_view provider_code);
 
 /// The user-visible purchasable platforms, as provider-code slugs (a subset of the
 /// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* values — currently "google_play" and "app_store").

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -3,28 +3,28 @@
 #include <session/pro_backend.h>
 
 #include <chrono>
+#include <optional>
 #include <session/session_protocol.hpp>
 #include <session/types.hpp>
 #include <span>
 #include <string>
 
 /// Helper functions to construct payloads to communicate with the Session Pro Backend. The data
-/// structures here are largely bindings to the endpoints exposed on the Session Pro Backend:
-///
-///   https://github.com/Doy-lee/session-pro-backend/blob/06e82c9d5b5a0a881d12d0182358219a4081acf5/server.py#L2
+/// structures here are largely bindings to the endpoints exposed on the Session Pro Backend; the
+/// wire format they produce and parse is byte-pinned in pro-wire-protocol.md (the authoritative
+/// spec).
 ///
 /// The high level summary of the functionality in this file. Clients can:
 ///
-/// 1. Build a request with `AddProPaymentRequest::build_to_json` from a Session Pro payment and
-///    submit it to the backend to register the specified Ed25519 keys for Session Pro.
+/// 1. Build a request with `add_payment_request(...)` from a Session Pro payment and submit its
+///    `{endpoint, body}` to the backend to register the specified Ed25519 keys for Session Pro.
 ///
-///    Server responds JSON to be parsed with `AddProPaymentOrGenerateProProofResponse::parse`.
-///    Clients should validate the response and update their `UserProfile` by constructing a
-///    `ProConfig` with the `proof` from the response and filling in the relevant rotating private
-///    key that the proof was authorised for.
+///    Parse the server's reply with `parse_add_payment(...)`. Clients should validate the response
+///    and update their `UserProfile` by constructing a `ProConfig` with the `proof` from the
+///    response and filling in the relevant rotating private key that the proof was authorised for.
 ///
 ///    The server will only respond successfully if it can also independently verify the purchase
-///    otherwise an error is returned and can be read from the `ResponseHeader` after parsing the
+///    otherwise an error is returned and can be read from the `Response` after parsing the
 ///    raw response.
 ///
 /// 2. Attach the `ProProof` constructed from (1) into their messages. Libsession has helper
@@ -39,21 +39,18 @@
 ///    to enable pro features for that message.
 ///
 /// 3. Periodically poll the global revocation list which overrides the validity of current
-///    circulating proofs. This is done by constructing the request via
-///    `GetProRevocationsRequest::to_json` and sending it to the backend.
+///    circulating proofs. This is done by building the request via `revocations_request(...)` and
+///    sending it to the backend.
 ///
-///    Server responds JSON to be parsed with `GetProRevocationResponse::parse` which contains the
-///    list that clients should cache. Any incoming messages with a Pro proof that is in the list of
-///    revoked proofs will not be entitled to Pro features.
+///    Parse the reply with `parse_revocations(...)`, which contains the list that clients should
+///    cache. Any incoming messages with a Pro proof that is in the list of revoked proofs will not
+///    be entitled to Pro features.
 ///
 /// 4. Query the status (and optionally payment history) of a user's Session Pro Master Ed25519 key
-///    has registered by building a `GetProDetailsRequest::build_to_json` query and submitting it.
+///    by building a `payment_details_request(...)` query and submitting it.
 ///
-///    Server responds JSON to be parsed with `GetProDetailsResponse::parse` which they can use to
-///    populate their client's payment history.
-///
-/// 5. Get a list of per-payment provider URLs, such as links to the support page for refunds and
-///    subscription via the `PAYMENT_PROVIDER_METADATA` global variable defined in the C header.
+///    Parse the reply with `parse_payment_details(...)`, which they can use to populate their
+///    client's payment history.
 ///
 /// See the unit tests for examples of using the APIs mentioned.
 
@@ -84,7 +81,7 @@ enum struct AddProPaymentResponseStatus {
     UnknownPayment = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_UNKNOWN_PAYMENT,
 };
 
-struct ResponseHeader {
+struct Response {
     /// Status code for the response, maps to a specific enum for some requests otherwise it uses 0
     /// for success, other values indicate errors. For the following responses, the status code maps
     /// to
@@ -105,216 +102,114 @@ struct MasterRotatingSignatures {
     array_uc64 rotating_sig;
 };
 
-struct AddProPaymentUserTransaction {
-    /// Provider code string (see SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*)
-    std::string provider_code;
-
-    /// Opaque payment identifier from the provider's purchase flow. Multi-part providers fold their
-    /// parts into this one string per a backend-defined composite (e.g. Google "token|order_id");
-    /// libsession treats it as opaque bytes hashed verbatim.
-    std::string payment_id;
+/// Per-provider support/management URLs. These are identical for every user (not translation data),
+/// so libsession owns them as the single source of truth rather than each client duplicating them;
+/// the human-readable provider/store *names* are translation data and remain the client's job.
+/// Returned by `provider_urls()`. The views point at static, null-terminated storage.
+struct ProviderUrls {
+    std::string_view refund_platform_url;      ///< Native store refund flow
+    std::string_view refund_support_url;       ///< Session support page for requesting a refund
+    std::string_view refund_status_url;        ///< Where a user checks refund status
+    std::string_view update_subscription_url;  ///< Manage/update the subscription
+    std::string_view cancel_subscription_url;  ///< Cancel the subscription
 };
 
-/// Register a new Session Pro proof to the backend. The payment is registered under the
-/// `master_pkey` and authorises the `rotating_pkey` to use the proof. In practice this means that
-/// the caller will receive a Session Pro Proof that can be attached to messages that have to be
-/// signed by the `rotating_pkey` for other clients to entitle that message to Pro privileges.
+/// Look up the support/management URLs for a provider code (see
+/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*). Returns std::nullopt for a provider with no
+/// applicable URLs (an unknown code, or e.g. rangeproof) — so callers test the optional rather than
+/// hunting for empty members.
+std::optional<ProviderUrls> provider_urls(std::string_view provider_code);
+
+/// Route + body pair for a request to be POSTed to the Session Pro backend, returned by the
+/// `*_request()` helpers below.
+struct ProRequest {
+    /// Endpoint path relative to the backend base URL, e.g. "add_pro_payment". As returned from a
+    /// `*_request()` function this points at a static, null-terminated string, so using
+    /// `endpoint.data()` as a C string is valid.
+    std::string_view endpoint;
+
+    /// The JSON request body to POST to `endpoint`.
+    std::string body;
+};
+
+/// Register a new Session Pro payment with the backend (endpoint `add_pro_payment`). The payment is
+/// registered under the master key and authorises the rotating key to use the resulting proof, so
+/// that proof can be attached to messages signed by the rotating key to entitle them to Pro.
 ///
-/// The attached signatures must sign over the contents of the request which can be generated by the
-/// helper function `build_sigs`.
-struct AddProPaymentRequest {
-    /// Request version. The latest accepted version is 0
-    std::uint8_t version;
+/// `add_payment_sigs` computes just the master+rotating signatures over the request;
+/// `add_payment_request` builds the whole request (computing the signatures internally) and returns
+/// the endpoint + JSON body. Both throw if a key is not a 32-byte Ed25519 seed or 64-byte libsodium
+/// key.
+///
+/// Inputs:
+/// - `master_privkey` / `rotating_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium private key
+/// - `provider_code` -- provider code string the payment is coming from (see
+///   SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*)
+/// - `payment_id` -- opaque payment identifier from the provider (multi-part providers fold their
+///   parts into this one value per a backend-defined composite; hashed verbatim)
+MasterRotatingSignatures add_payment_sigs(
+        std::span<const uint8_t> master_privkey,
+        std::span<const uint8_t> rotating_privkey,
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id);
 
-    /// 32-byte Ed25519 Session Pro master public key derived from the Session account seed to
-    /// register a Session Pro payment under.
-    array_uc32 master_pkey;
+ProRequest add_payment_request(
+        std::span<const uint8_t> master_privkey,
+        std::span<const uint8_t> rotating_privkey,
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id);
 
-    /// 32-byte Ed25519 Session Pro rotating public key to authorise to use the generated Session
-    /// Pro proof
-    array_uc32 rotating_pkey;
-
-    /// Transaction containing the payment details to register on the Session Pro backend
-    AddProPaymentUserTransaction payment_tx;
-
-    /// 64-byte signature proving knowledge of the master key's secret component
-    array_uc64 master_sig;
-
-    /// 64-byte signature proving knowledge of the rotating key's secret component
-    array_uc64 rotating_sig;
-
-    /// API: pro/AddProPaymentRequest::to_json
-    ///
-    /// Serializes the request to a JSON string.
-    ///
-    /// Outputs:
-    /// - `std::string` - JSON representation of the request.
-    std::string to_json() const;
-
-    /// API: pro/AddProPaymentRequest::build_sigs
-    ///
-    /// Builds the master and rotating signatures using the provided private keys and payment token
-    /// hash. Throws if the keys (32-byte or 64-byte libsodium format) are incorrectly sized.
-    /// Using 64-byte libsodium keys is more efficient.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a hash for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `rotating_privkey` -- 64-byte libsodium style or 32 byte Ed25519 rotating private key
-    /// - `payment_tx_provider` -- Provider that the payment to register is coming from
-    /// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment
-    ///   provider. See `AddProPaymentUserTransaction`
-    ///   this is the transaction ID).
-    /// - `payment_tx_order_id` -- Order ID that is associated with the payment see
-    ///   `AddProPaymentUserTransaction`
-    ///
-    /// Outputs:
-    /// - `MasterRotatingSignatures` - Struct containing the 64-byte master and rotating signatures.
-    static MasterRotatingSignatures build_sigs(
-            std::uint8_t request_version,
-            std::span<const uint8_t> master_privkey,
-            std::span<const uint8_t> rotating_privkey,
-            std::string_view payment_tx_provider_code,
-            std::span<const uint8_t> payment_tx_payment_id);
-
-    /// API: pro/AddProPaymentRequest::build_to_json
-    ///
-    /// Builds a AddProPaymentRequest and serialize it to JSON. This function is the same as filling
-    /// the struct fields and calling `to_json`.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a hash for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `rotating_privkey` -- 64-byte libsodium style or 32 byte Ed25519 rotating private key
-    /// - `payment_tx_provider` -- Provider that the payment to register is coming from
-    /// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment
-    ///   provider. See `AddProPaymentUserTransaction`
-    ///   this is the transaction ID).
-    /// - `payment_tx_order_id` -- Order ID that is associated with the payment see
-    ///   `AddProPaymentUserTransaction`
-    ///
-    /// Outputs:
-    /// - `std::string` -- Request serialised to JSON
-    static std::string build_to_json(
-            std::uint8_t request_version,
-            std::span<const uint8_t> master_privkey,
-            std::span<const uint8_t> rotating_privkey,
-            std::string_view payment_tx_provider_code,
-            std::span<const uint8_t> payment_tx_payment_id);
-};
-
-/// The generated proof from the Session Pro backend that has been parsed from JSON. This structure
-/// is the raw parse result that can then be converted into the config::ProProof or equivalent
-/// structure.
-struct AddProPaymentOrGenerateProProofResponse : public ResponseHeader {
+/// Common base for the responses that carry a freshly-issued Session Pro proof: both add-payment
+/// and generate-proof reply with exactly a proof. `AddProPaymentResponse` and
+/// `GenerateProProofResponse` are distinct, currently empty types (each parsed by its own free
+/// function below) that share every field today but can diverge independently later. `proof` is the
+/// raw parse result, convertible to a config::ProProof.
+struct ProProofResponse : Response {
     ProProof proof;
-
-    /// API: pro/AddProPaymentOrGenerateProProofResponse::parse
-    ///
-    /// Parses a JSON string into the response struct.
-    ///
-    /// Inputs:
-    /// - `json` -- JSON string to parse.
-    ///
-    /// Outputs:
-    /// - The response struct with `status` set to an error state on failure. Errors are stored in
-    ///   `errors`
-    static AddProPaymentOrGenerateProProofResponse parse(std::string_view json);
 };
 
-/// Request a new Session Pro proof from the backend. The specified `master_pkey` must have
-/// previously already registered a payment to the backend that is still active and hence entitled
-/// to Session Pro features. This endpoint can then be used to pair a new Ed25519 key to be
-/// authorised to use a the Session Pro proof.
-struct GenerateProProofRequest {
-    /// Request version. The latest accepted version is 0
-    std::uint8_t version;
+/// Response to `add_payment_request` (endpoint `add_pro_payment`).
+struct AddProPaymentResponse : ProProofResponse {};
 
-    /// 32-byte Ed25519 Session Pro master public key to generate a Session Pro proof from. This key
-    /// must have had a prior, and still active payment registered under it for a new proof to be
-    /// generated successfully.
-    array_uc32 master_pkey;
+/// Response to `pro_proof_request` (endpoint `generate_pro_proof`).
+struct GenerateProProofResponse : ProProofResponse {};
 
-    /// 32-byte Ed25519 Session Pro rotating public key authorized to use the generated proof
-    array_uc32 rotating_pkey;
+/// Parse the reply to an add-payment / generate-proof request. On failure `status` is set to an
+/// error state and `errors` is populated; on success `proof` holds the issued proof.
+AddProPaymentResponse parse_add_payment(std::string_view json);
+GenerateProProofResponse parse_pro_proof(std::string_view json);
 
-    /// Unix timestamp of the request
-    sys_seconds unix_ts;
+/// Request a new Session Pro proof from the backend (endpoint `generate_pro_proof`). The master key
+/// must already have a prior, still-active payment registered; this pairs a (new) rotating key to a
+/// freshly-issued proof.
+///
+/// `pro_proof_sigs` computes the master+rotating signatures; `pro_proof_request` builds the whole
+/// request (signing internally) and returns the endpoint + JSON body. Both throw on an
+/// incorrectly-sized key.
+///
+/// Inputs:
+/// - `master_privkey` / `rotating_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium private key
+/// - `unix_ts` -- Unix timestamp for the request
+MasterRotatingSignatures pro_proof_sigs(
+        std::span<const uint8_t> master_privkey,
+        std::span<const uint8_t> rotating_privkey,
+        sys_seconds unix_ts);
 
-    /// 64-byte signature proving knowledge of the master key's secret component
-    array_uc64 master_sig;
+ProRequest pro_proof_request(
+        std::span<const uint8_t> master_privkey,
+        std::span<const uint8_t> rotating_privkey,
+        sys_seconds unix_ts);
 
-    /// 64-byte signature proving knowledge of the rotating key's secret component
-    array_uc64 rotating_sig;
-
-    /// API: pro/GenerateProProofRequest::build_sigs
-    ///
-    /// Builds master and rotating signatures using the provided private keys and timestamp.
-    /// Throws if the keys (32-byte or 64-byte libsodium format) are incorrectly sized.
-    /// Using 64-byte libsodium keys is more efficient.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a hash for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `rotating_privkey` -- 64-byte libsodium style or 32 byte Ed25519 rotating private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    ///
-    /// Outputs:
-    /// - `MasterRotatingSignatures` - Struct containing the 64-byte master and rotating signatures.
-    static MasterRotatingSignatures build_sigs(
-            std::uint8_t request_version,
-            std::span<const uint8_t> master_privkey,
-            std::span<const uint8_t> rotating_privkey,
-            sys_seconds unix_ts);
-
-    /// API: pro/GenerateProProofRequest::build_to_json
-    ///
-    /// Builds a GenerateProProofRequest and serialize it to JSON. This function is the same as
-    /// filling the struct fields and calling `to_json`.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a request for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `rotating_privkey` -- 64-byte libsodium style or 32 byte Ed25519 rotating private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    ///
-    /// Outputs:
-    /// - `std::string` -- Request serialised to JSON
-    static std::string build_to_json(
-            std::uint8_t request_version,
-            std::span<const uint8_t> master_privkey,
-            std::span<const uint8_t> rotating_privkey,
-            sys_seconds unix_ts);
-
-    /// API: pro/GenerateProProofRequest::to_json
-    ///
-    /// Serializes the request to a JSON string.
-    ///
-    /// Outputs:
-    /// - `std::string` - JSON representation of the request.
-    std::string to_json() const;
-};
-
-/// Retrieve the current list of revocations for currently active Session Pro proofs (because of
-/// refunds for example). The caller retains each returned item for the response's `retain_for`
+/// Build a request for the current Session Pro revocation list (endpoint `get_pro_revocations`).
+/// This request is unsigned. The caller retains each returned item for the response's `retain_for`
 /// window after first seeing it (memory-only aging) and polls again after `retry_in`.
-struct GetProRevocationsRequest {
-    /// Request version. The latest accepted version is 0
-    std::uint8_t version;
-
-    /// 64-bit monotonic integer for the caller's revocation list iteration. Set to 0 if unknown;
-    /// otherwise, use the latest known `ticket` from a prior `GetProRevocationResponse` to allow
-    /// the Session Pro Backend to omit the revocation list if it has not changed.
-    std::int64_t ticket;
-
-    /// API: pro/GenerateProProofRequest::to_json
-    ///
-    /// Serializes the request to a JSON string.
-    ///
-    /// Outputs:
-    /// - `std::string` - JSON representation of the request.
-    std::string to_json() const;
-};
+///
+/// Inputs:
+/// - `ticket` -- 64-bit monotonic revocation-list iteration. Pass 0 if unknown; otherwise the
+/// latest
+///   known `ticket` from a prior `GetProRevocationsResponse`, so the backend may omit an unchanged
+///   list.
+ProRequest revocations_request(std::int64_t ticket);
 
 struct ProRevocationItem {
     /// 32-byte opaque revocation tag identifying a proof
@@ -324,7 +219,7 @@ struct ProRevocationItem {
     sys_seconds effective_unix_ts;
 };
 
-struct GetProRevocationsResponse : public ResponseHeader {
+struct GetProRevocationsResponse : Response {
     /// 64-bit monotonic integer for the latest revocation list iteration.
     /// Update the caller's ticket to this value for subsequent requests.
     std::int64_t ticket;
@@ -339,83 +234,26 @@ struct GetProRevocationsResponse : public ResponseHeader {
 
     /// List of revoked Session Pro proofs
     std::vector<ProRevocationItem> items;
-
-    /// API: pro/GetProRevocationsResponse::parse
-    ///
-    /// Parses a JSON string into the response struct.
-    ///
-    /// Inputs:
-    /// - `json` -- JSON string to parse.
-    ///
-    /// Outputs:
-    /// - The response struct with `status` set to an error state on failure. Errors are stored in
-    ///   `errors`
-    static GetProRevocationsResponse parse(std::string_view json);
 };
 
-struct GetProDetailsRequest {
-    /// Request version for the API
-    std::uint8_t version;
+/// Parse the reply to a `revocations_request`. On failure `status` is set to an error state and
+/// `errors` is populated.
+GetProRevocationsResponse parse_revocations(std::string_view json);
 
-    /// 32-byte Ed25519 master public key to retrieve payments for
-    array_uc32 master_pkey;
+/// Query a master key's Session Pro payment/subscription details and history (endpoint
+/// `get_pro_details`). `payment_details_sig` computes the master signature;
+/// `payment_details_request` builds the whole request (signing internally) and returns the endpoint
+/// + JSON body. Both throw on an incorrectly-sized key.
+///
+/// Inputs:
+/// - `master_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium master private key
+/// - `unix_ts` -- Unix timestamp for the request
+/// - `count` -- maximum number of historical payments to request
+array_uc64 payment_details_sig(
+        std::span<const uint8_t> master_privkey, sys_seconds unix_ts, uint32_t count);
 
-    /// 64-byte signature proving knowledge of the master public key's secret component
-    array_uc64 master_sig;
-
-    /// Unix timestamp of the request
-    sys_seconds unix_ts;
-
-    /// Max amount of historical payments to request from the backend
-    uint32_t count;
-
-    /// API: pro/AddProPaymentRequest::build_sigs
-    ///
-    /// Builds the master and rotating signatures using the provided private keys and payment token
-    /// hash. Throws if the keys (32-byte or 64-byte libsodium format) or 32-byte payment token hash
-    /// are passed with an incorrect size. Using 64-byte libsodium keys is more efficient.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a hash for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    /// - `count` -- Amount of historical payments to request
-    ///
-    /// Outputs:
-    /// - `array_uc64` - the 64-byte signature
-    static array_uc64 build_sig(
-            uint8_t version,
-            std::span<const uint8_t> master_privkey,
-            sys_seconds unix_ts,
-            uint32_t count);
-
-    /// API: pro/GetProDetailsRequest::build_to_json
-    ///
-    /// Builds a GetProDetailsRequest and serialize it to JSON. This function is the same as filling
-    /// the struct fields and calling `to_json`.
-    ///
-    /// Inputs:
-    /// - `version` -- Version of the request to build a request from
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    /// - `count` -- Amount of historical payments to request
-    ///
-    /// Outputs:
-    /// - `std::string` -- Request serialised to JSON
-    static std::string build_to_json(
-            std::uint8_t version,
-            std::span<const uint8_t> master_privkey,
-            sys_seconds unix_ts,
-            uint32_t count);
-
-    /// API: pro/GenerateProProofRequest::to_json
-    ///
-    /// Serializes the request to a JSON string.
-    ///
-    /// Outputs:
-    /// - `std::string` - JSON representation of the request.
-    std::string to_json() const;
-};
+ProRequest payment_details_request(
+        std::span<const uint8_t> master_privkey, sys_seconds unix_ts, uint32_t count);
 
 struct ProPaymentItem {
     /// Describes the current status of the consumption of the payment for Session Pro entitlement
@@ -470,7 +308,7 @@ struct ProPaymentItem {
     std::string payment_id;
 };
 
-struct GetProDetailsResponse : public ResponseHeader {
+struct GetProDetailsResponse : Response {
     /// List of payment items for the master public key
     std::vector<ProPaymentItem> items;
 
@@ -526,126 +364,48 @@ struct GetProDetailsResponse : public ResponseHeader {
     /// Total number of payments known by the backend for the user. This may be greater than the
     /// length of items if the request, requested less than the number of payments the user has.
     uint32_t payments_total;
-
-    /// API: pro/GetProDetailsResponse::parse
-    ///
-    /// Parses a JSON string into the response struct.
-    ///
-    /// Inputs:
-    /// - `json` -- JSON string to parse.
-    ///
-    /// Outputs:
-    /// - The response struct with `status` set to an error state on failure. Errors are stored in
-    ///   `errors`
-    static GetProDetailsResponse parse(std::string_view json);
 };
 
-struct SetPaymentRefundRequestedRequest {
-    /// Request version for the API
-    std::uint8_t version;
+/// Parse the reply to a `payment_details_request`. On failure `status` is set to an error state and
+/// `errors` is populated.
+GetProDetailsResponse parse_payment_details(std::string_view json);
 
-    /// 32-byte Ed25519 master public key to retrieve payments for
-    array_uc32 master_pkey;
+/// Record a refund request against an existing Session Pro payment (endpoint
+/// `set_payment_refund_requested`). `refund_sig` computes the master signature; `refund_request`
+/// builds the whole request (signing internally) and returns the endpoint + JSON body. Both throw
+/// on an incorrectly-sized key.
+///
+/// Inputs:
+/// - `master_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium master private key
+/// - `unix_ts` -- Unix timestamp for the request
+/// - `refund_requested_unix_ts` -- timestamp to record as when the refund was requested
+/// - `provider_code` -- provider code string the payment is from (see
+///   SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*)
+/// - `payment_id` -- opaque payment identifier from the provider (hashed verbatim)
+array_uc64 refund_sig(
+        std::span<const uint8_t> master_privkey,
+        sys_seconds unix_ts,
+        sys_seconds refund_requested_unix_ts,
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id);
 
-    /// 64-byte signature proving knowledge of the master public key's secret component
-    array_uc64 master_sig;
+ProRequest refund_request(
+        std::span<const uint8_t> master_privkey,
+        sys_seconds unix_ts,
+        sys_seconds refund_requested_unix_ts,
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id);
 
-    /// Unix timestamp of the current time
-    sys_seconds unix_ts;
-
-    /// Unix timestamp to set as the timestamp that a refund was requested on this payment.
-    sys_seconds refund_requested_unix_ts;
-
-    /// Payment details to set the refund request on
-    AddProPaymentUserTransaction payment_tx;
-
-    /// API: pro/SetPaymentRefundRequested::build_sigs
-    ///
-    /// Builds the signature that must be included in the request to authenticate and permit
-    /// updating the refund requested status of a payment. Throws if the keys (32-byte or
-    /// 64-byte libsodium format) are incorrectly sized. Using 64-byte libsodium keys is more
-    /// efficient.
-    ///
-    /// Inputs:
-    /// - `request_version` -- Version of the request to build a hash for
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    /// - `refund_requested_unix_ts` -- Unix timestamp to set as the timestamp that a refund was
-    ///   requested on this payment
-    /// - `payment_tx_provider` -- Provider that the payment to set a refund request on is coming
-    ///   from
-    /// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment
-    ///   provider. See `AddProPaymentUserTransaction`
-    ///   this is the transaction ID).
-    /// - `payment_tx_order_id` -- Order ID that is associated with the payment see
-    ///   `AddProPaymentUserTransaction`
-    ///
-    /// Outputs:
-    /// - `array_uc64` - the 64-byte signature
-    static array_uc64 build_sig(
-            uint8_t version,
-            std::span<const uint8_t> master_privkey,
-            sys_seconds unix_ts,
-            sys_seconds refund_requested_unix_ts,
-            std::string_view payment_tx_provider_code,
-            std::span<const uint8_t> payment_tx_payment_id);
-
-    /// API: pro/SetPaymentRefundRequested::build_to_json
-    ///
-    /// Builds a SetPaymentRefundRequested and serialize it to JSON. This function is the same as
-    /// filling the struct fields and calling `to_json`.
-    ///
-    /// Inputs:
-    /// - `version` -- Version of the request to build a request from
-    /// - `master_privkey` -- 64-byte libsodium style or 32 byte Ed25519 master private key
-    /// - `unix_ts` -- Unix timestamp for the request.
-    /// - `refund_requested_unix_ts` -- Unix timestamp to set as the timestamp that a refund was
-    ///   requested on this payment
-    /// - `payment_tx_provider` -- Provider that the payment to set a refund request on is coming
-    ///   from
-    /// - `payment_tx_payment_id` -- ID that is associated with the payment from the payment
-    ///   provider. See `AddProPaymentUserTransaction`
-    ///   this is the transaction ID).
-    /// - `payment_tx_order_id` -- Order ID that is associated with the payment see
-    ///   `AddProPaymentUserTransaction`
-    ///
-    /// Outputs:
-    /// - `std::string` -- Request serialised to JSON
-    static std::string build_to_json(
-            std::uint8_t version,
-            std::span<const uint8_t> master_privkey,
-            sys_seconds unix_ts,
-            sys_seconds refund_requested_unix_ts,
-            std::string_view payment_tx_provider_code,
-            std::span<const uint8_t> payment_tx_payment_id);
-
-    /// API: pro/SetPaymentRefundRequested::to_json
-    ///
-    /// Serializes the request to a JSON string.
-    ///
-    /// Outputs:
-    /// - `std::string` - JSON representation of the request.
-    std::string to_json() const;
-};
-
-struct SetPaymentRefundRequestedResponse : public ResponseHeader {
+struct SetPaymentRefundRequestedResponse : Response {
     /// Version from the request
     std::uint8_t version;
 
     /// True if a payment was found matching the given payment information and that the refund
     /// request unix timestamp was set
     bool updated;
-
-    /// API: pro/SetPaymentRefundRequestedResponse::parse
-    ///
-    /// Parses a JSON string into the response struct.
-    ///
-    /// Inputs:
-    /// - `json` -- JSON string to parse.
-    ///
-    /// Outputs:
-    /// - The response struct with `status` set to an error state on failure. Errors are stored in
-    ///   `errors`
-    static SetPaymentRefundRequestedResponse parse(std::string_view json);
 };
+
+/// Parse the reply to a `refund_request`. On failure `status` is set to an error state and `errors`
+/// is populated.
+SetPaymentRefundRequestedResponse parse_refund(std::string_view json);
 }  // namespace session::pro_backend

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -223,7 +223,7 @@ struct ProRevocationItem {
     array_uc32 revocation_tag;
 
     /// A matching proof is revoked once the client's clock reaches this unix timestamp (not before)
-    sys_seconds effective_unix_ts;
+    sys_seconds effective_at;
 };
 
 struct GetProRevocationsResponse : Response {
@@ -286,32 +286,32 @@ struct ProPaymentItem {
     /// Provider purchase time (when the upstream provider recorded the purchase). Always set.
     /// Carries the provider's sub-second precision as a millisecond-resolution `sys_ms`; the wire
     /// sends it as a float of seconds.
-    sys_ms purchased_unix_ts;
+    sys_ms purchased_at;
 
     /// Unix timestamp of when the payment was redeemed. 0 if not activated
-    sys_seconds redeemed_unix_ts;
+    sys_seconds redeemed_at;
 
     /// Unix timestamp of when the payment was expiry. 0 if not activated
-    sys_seconds expiry_unix_ts;
+    sys_seconds expiry_at;
 
     /// Duration of the grace period, e.g. when the payment provider will start to attempt to renew
     /// the Session Pro subscription. During the period between
-    /// [expiry_unix_ts, expiry_unix_ts + grace_period_duration] the user continues to have
+    /// [expiry_at, expiry_at + grace_period_duration] the user continues to have
     /// entitlement to Session Pro. This value is only applicable if `auto_renewing` is `true`.
     std::chrono::seconds grace_period_duration;
 
     /// Unix deadline timestamp of when the user is able to refund the subscription via the payment
     /// provider. Thereafter the user must initiate a refund manually via Session support.
-    sys_seconds platform_refund_expiry_unix_ts;
+    sys_seconds platform_refund_expiry_at;
 
     /// Provider revocation instant (when the payment was revoked). Epoch (0) if not applicable.
     /// Carries the provider's sub-second precision as a millisecond-resolution `sys_ms`; the wire
     /// sends it as a float of seconds.
-    sys_ms revoked_unix_ts;
+    sys_ms revoked_at;
 
     /// UNIX timestamp at which a refund request was requested for this payment. This is set to 0
     /// if no refund has been requested for this payment yet.
-    sys_seconds refund_requested_unix_ts;
+    sys_seconds refund_requested_at;
 
     /// Opaque payment identifier (the value passed at add-payment; multi-part providers fold their
     /// parts in per the backend-defined composite -- libsession does not interpret it).
@@ -347,10 +347,10 @@ struct GetProDetailsResponse : Response {
     /// some leeway as to the time required for the payment provider to successfully bill the user.
     /// This expiry timestamp is hence calculated as:
     ///
-    ///   expiry_unix_ts_ms = (subscription_expiry_unix_ts + grace_period_duration_ms)
+    ///   expiry_at = subscription_expiry + grace_period_duration
     ///
     /// E.g. The subscription expiry timestamp can be calculated by subtracting
-    /// `grace_period_duration_ms` to determine if the user is currently in a grace period. Some
+    /// `grace_period_duration` to determine if the user is currently in a grace period. Some
     /// platforms do not support a grace period so this value can be 0.
     ///
     /// Finally, a reminder that the grace period is not activated or included in this deadline
@@ -359,18 +359,18 @@ struct GetProDetailsResponse : Response {
     /// This timestamp may be in the past if the user no longer has active payments. Overtime the
     /// Pro Backend may prune user history and so after long lapses of activity, a user's
     /// subscription history may be deleted.
-    sys_seconds expiry_unix_ts;
+    sys_seconds expiry_at;
 
     /// Duration that a user is entitled to for their grace period. This value is to be ignored if
     /// `auto_renewing` is false. It can be used to calculate the subscription expiry timestamp by
-    /// subtracting `expiry_unix_ts_ms` from this value.
+    /// subtracting it from `expiry_at`.
     std::chrono::seconds grace_period_duration;
 
     /// UNIX timestamp at which a refund request was requested by this user. This timestamp comes
     /// from the latest payment that the backend has deemed to be active for the user (e.g. the
-    /// payment associated with the `expiry_unix_ts_ms`). This value is 0 if no refund has been
+    /// payment associated with the `expiry_at`). This value is 0 if no refund has been
     /// requested on the active payment.
-    sys_seconds refund_requested_unix_ts;
+    sys_seconds refund_requested_at;
 
     /// Total number of payments known by the backend for the user. This may be greater than the
     /// length of items if the request, requested less than the number of payments the user has.
@@ -389,21 +389,21 @@ GetProDetailsResponse parse_payment_details(std::string_view json);
 /// Inputs:
 /// - `master_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium master private key
 /// - `unix_ts` -- Unix timestamp for the request
-/// - `refund_requested_unix_ts` -- timestamp to record as when the refund was requested
+/// - `refund_requested_at` -- timestamp to record as when the refund was requested
 /// - `provider_code` -- provider code string the payment is from (see
 ///   SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*)
 /// - `payment_id` -- opaque payment identifier from the provider (hashed verbatim)
 array_uc64 refund_sig(
         std::span<const uint8_t> master_privkey,
         sys_seconds unix_ts,
-        sys_seconds refund_requested_unix_ts,
+        sys_seconds refund_requested_at,
         std::string_view provider_code,
         std::span<const uint8_t> payment_id);
 
 ProRequest refund_request(
         std::span<const uint8_t> master_privkey,
         sys_seconds unix_ts,
-        sys_seconds refund_requested_unix_ts,
+        sys_seconds refund_requested_at,
         std::string_view provider_code,
         std::span<const uint8_t> payment_id);
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -47,11 +47,12 @@
 ///    cache. Any incoming messages with a Pro proof that is in the list of revoked proofs will not
 ///    be entitled to Pro features.
 ///
-/// 4. Query the status (and optionally payment history) of a user's Session Pro Master Ed25519 key
-///    by building a `payment_details_request(...)` query and submitting it.
+/// 4. Query a user's Session Pro entitlement status for their Master Ed25519 key by building a
+///    `pro_status_request(...)` query (the hot "am I Pro?" path) and submitting it. Parse the reply
+///    with `parse_pro_status(...)`, which yields the account status plus its single latest payment.
 ///
-///    Parse the reply with `parse_payment_details(...)`, which they can use to populate their
-///    client's payment history.
+///    For the full payment history (e.g. a receipts view), page through it with
+///    `payment_details_request(...)` / `parse_payment_details(...)` using the opaque keyset cursor.
 ///
 /// See the unit tests for examples of using the APIs mentioned.
 
@@ -127,8 +128,8 @@ struct MasterRotatingSignatures {
 /// Per-provider support/management URLs (from provider_urls()). These are identical for every user
 /// (not translation data), so libsession owns them as the single source of truth rather than each
 /// client duplicating them; the human-readable provider/store *names* are translation data and
-/// remain the client's job. Each field is std::nullopt when that provider has no such URL -- clients
-/// test the optional rather than an empty-string sentinel. Present views point at static,
+/// remain the client's job. Each field is std::nullopt when that provider has no such URL --
+/// clients test the optional rather than an empty-string sentinel. Present views point at static,
 /// null-terminated string literals.
 struct ProviderURLs {
     std::optional<std::string_view> refund_platform_url;  ///< Native store refund flow
@@ -281,20 +282,41 @@ struct GetProRevocationsResponse : ResponseBase {
 /// `errors` is populated.
 GetProRevocationsResponse parse_revocations(std::string_view json);
 
-/// Query a master key's Session Pro payment/subscription details and history (endpoint
-/// `get_pro_details`). `payment_details_sig` computes the master signature;
-/// `payment_details_request` builds the whole request (signing internally) and returns the endpoint
-/// + JSON body. Both throw on an incorrectly-sized key.
+/// Query a master key's Session Pro status (endpoint `get_pro_status`): the account entitlement
+/// state plus its single latest payment -- the hot "am I Pro?" path. `pro_status_sig` computes the
+/// master signature; `pro_status_request` builds the whole request (signing internally) and returns
+/// the endpoint + JSON body. Both throw on an incorrectly-sized key.
 ///
 /// Inputs:
 /// - `master_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium master private key
 /// - `unix_ts` -- Unix timestamp for the request
-/// - `count` -- maximum number of historical payments to request
+array_uc64 pro_status_sig(std::span<const uint8_t> master_privkey, sys_seconds unix_ts);
+
+ProRequest pro_status_request(std::span<const uint8_t> master_privkey, sys_seconds unix_ts);
+
+/// Query a master key's Session Pro payment history (endpoint `get_payment_details`), one keyset
+/// page at a time. `payment_details_sig` computes the master signature; `payment_details_request`
+/// builds the whole request (signing internally) and returns the endpoint + JSON body. Both throw
+/// on an incorrectly-sized key.
+///
+/// Inputs:
+/// - `master_privkey` -- 32-byte Ed25519 seed or 64-byte libsodium master private key
+/// - `unix_ts` -- Unix timestamp for the request
+/// - `limit` -- maximum payments to return on this page (the backend may clamp it)
+/// - `before` -- opaque pagination cursor from a previous page's `next_cursor` (see
+///   PaymentDetailsResponse); the empty string requests the newest page. Pass it through verbatim;
+///   it must not be parsed or synthesized.
 array_uc64 payment_details_sig(
-        std::span<const uint8_t> master_privkey, sys_seconds unix_ts, uint32_t count);
+        std::span<const uint8_t> master_privkey,
+        sys_seconds unix_ts,
+        uint32_t limit,
+        std::string_view before);
 
 ProRequest payment_details_request(
-        std::span<const uint8_t> master_privkey, sys_seconds unix_ts, uint32_t count);
+        std::span<const uint8_t> master_privkey,
+        sys_seconds unix_ts,
+        uint32_t limit,
+        std::string_view before);
 
 /// Unit of a billing period (the `unit` of a parsed `plan` code, pro-wire-protocol.md §1 / Delta
 /// #14). A closed set: the backend emits only these, so an unrecognized code is a protocol error.
@@ -373,17 +395,19 @@ struct ProPaymentItem {
     std::string payment_id;
 };
 
-struct GetProDetailsResponse : ResponseBase {
-    /// List of payment items for the master public key
-    std::vector<ProPaymentItem> items;
-
+struct ProStatusResponse : ResponseBase {
     /// Current Session Pro entitlement status for the master public key
+    /// ("never"/"active"/"expired"; opaque -- an unknown value passes through as-is).
     std::string user_status;
+
+    /// The single most-recent payment for the master public key, or std::nullopt when the account
+    /// has no payments. (The full payment history is a separate query -- parse_payment_details.)
+    std::optional<ProPaymentItem> latest_payment;
 
     /// Error code that indicates that the Session Pro Backend encountered an error book-keeping
     /// Session Pro entitlement for the user. If this value is not `SUCCESS` implementing clients
     /// can optionally prompt the user that they should contact support for investigation.
-    SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT error_report;
+    SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT error_report;
 
     /// Flag to indicate if the user will automatically renew their subscription.
     bool auto_renewing;
@@ -425,15 +449,31 @@ struct GetProDetailsResponse : ResponseBase {
     /// payment associated with the `expiry_at`). This value is 0 if no refund has been
     /// requested on the active payment.
     sys_seconds refund_requested_at;
+};
+
+struct PaymentDetailsResponse : ResponseBase {
+    /// One keyset page of the master public key's payment history, newest-first (at most the
+    /// `limit` passed to payment_details_request).
+    std::vector<ProPaymentItem> items;
 
     /// Total number of payments known by the backend for the user. This may be greater than the
-    /// length of items if the request, requested less than the number of payments the user has.
+    /// length of `items` when the requested page did not cover the full history.
     uint32_t payments_total;
+
+    /// Opaque keyset-pagination cursor for the next (older) page: re-request with this value as
+    /// `before` to continue, and stop when it is std::nullopt (end-of-data). Store and echo it
+    /// verbatim -- it is an encrypted token and MUST NOT be parsed or synthesized (a tampered or
+    /// foreign cursor is rejected). (pro-wire-protocol.md §5.3.)
+    std::optional<std::string> next_cursor;
 };
+
+/// Parse the reply to a `pro_status_request`. On failure `status` is set to an error state and
+/// `errors` is populated.
+ProStatusResponse parse_pro_status(std::string_view json);
 
 /// Parse the reply to a `payment_details_request`. On failure `status` is set to an error state and
 /// `errors` is populated.
-GetProDetailsResponse parse_payment_details(std::string_view json);
+PaymentDetailsResponse parse_payment_details(std::string_view json);
 
 /// Record a refund request against an existing Session Pro payment (endpoint
 /// `set_payment_refund_requested`). `refund_sig` computes the master signature; `refund_request`

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -308,10 +308,10 @@ struct GetProRevocationsRequest {
     /// Request version. The latest accepted version is 0
     std::uint8_t version;
 
-    /// 4-byte monotonic integer for the caller's revocation list iteration. Set to 0 if unknown;
+    /// 64-bit monotonic integer for the caller's revocation list iteration. Set to 0 if unknown;
     /// otherwise, use the latest known `ticket` from a prior `GetProRevocationResponse` to allow
     /// the Session Pro Backend to omit the revocation list if it has not changed.
-    std::uint32_t ticket;
+    std::int64_t ticket;
 
     /// API: pro/GenerateProProofRequest::to_json
     ///
@@ -331,9 +331,9 @@ struct ProRevocationItem {
 };
 
 struct GetProRevocationsResponse : public ResponseHeader {
-    /// 4-byte monotonic integer for the latest revocation list iteration.
+    /// 64-bit monotonic integer for the latest revocation list iteration.
     /// Update the caller's ticket to this value for subsequent requests.
-    std::uint32_t ticket;
+    std::int64_t ticket;
 
     /// List of revoked Session Pro proofs
     std::vector<ProRevocationItem> items;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -78,38 +78,15 @@ static_assert(PUBKEY_X25519.size() == 32);
 /// point at a different dev/test server if it chooses.
 constexpr std::string_view URL = "https://pro.session.codes";
 
-enum struct AddProPaymentResponseStatus {
-    /// Payment was claimed and the pro proof was successfully generated
-    Success = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_SUCCESS,
-
-    /// Backend encountered an error when attempting to claim the payment
-    Error = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_ERROR,
-
-    /// Request JSON failed to be parsed correctly, payload was malformed or missing values
-    ParseError = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_PARSE_ERROR,
-
-    /// Payment is already claimed
-    AlreadyRedeemed = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_ALREADY_REDEEMED,
-
-    /// Payment transaction attempted to claim a payment that the backend does not have. Either the
-    /// payment doesn't exist or the backend has not witnessed the payment from the provider yet.
-    UnknownPayment = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_UNKNOWN_PAYMENT,
-};
-
 struct Response {
-    /// Status code for the response, maps to a specific enum for some requests otherwise it uses 0
-    /// for success, other values indicate errors. For the following responses, the status code maps
-    /// to
-    ///
-    ///  | Request            | Enum
-    ///  | AddProPayment      | AddProPaymentResponseStatus
-    ///  | Everything else ...| SESSION_PRO_BACKEND_STATUS_SUCCESS or
-    ///                         SESSION_PRO_BACKEND_STATUS_ERROR
-    std::uint32_t status;
-
-    /// List of parsing or processing errors. Empty if there are no parsing errors, if there are
-    /// errors, the parse may be partially complete, always check the errors before proceeding.
+    /// Parsing or processing errors, from the backend or from libsession while parsing. Empty on
+    /// success; may hold several messages (one request can fail multiple checks at once). On
+    /// failure the parse may be partial, so always check `success()`/`errors` before using other
+    /// fields.
     std::vector<std::string> errors;
+
+    /// True iff the response came back without any errors.
+    [[nodiscard]] bool success() const { return errors.empty(); }
 };
 
 struct MasterRotatingSignatures {
@@ -184,14 +161,16 @@ ProRequest add_payment_request(
 
 /// Common base for the responses that carry a freshly-issued Session Pro proof: both add-payment
 /// and generate-proof reply with exactly a proof. `AddProPaymentResponse` and
-/// `GenerateProProofResponse` are distinct, currently empty types (each parsed by its own free
-/// function below) that share every field today but can diverge independently later. `proof` is the
-/// raw parse result, convertible to a config::ProProof.
+/// `GenerateProProofResponse` are distinct types (each parsed by its own free function below) that
+/// share `proof` today but can diverge independently. `proof` is the raw parse result, convertible
+/// to a config::ProProof.
 struct ProProofResponse : Response {
     ProProof proof;
 };
 
-/// Response to `add_payment_request` (endpoint `add_pro_payment`).
+/// Response to `add_payment_request` (endpoint `add_pro_payment`). On failure the reason(s) are in
+/// `errors` (the backend sends a human-readable message, including for already-redeemed /
+/// unknown-payment); check `success()`.
 struct AddProPaymentResponse : ProProofResponse {};
 
 /// Response to `pro_proof_request` (endpoint `generate_pro_proof`).

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -133,6 +133,13 @@ struct ProviderUrls {
 /// hunting for empty members.
 std::optional<ProviderUrls> provider_urls(std::string_view provider_code);
 
+/// The user-visible purchasable platforms, as provider-code slugs (a subset of the
+/// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* values — currently "google_play" and "app_store").
+/// Order is not significant; clients pick their own. Hidden mechanisms (e.g. rangeproof) are
+/// excluded — they surface only for users who already hold them — so this is the set that drives a
+/// "purchase via …" store list.
+std::span<const std::string_view> visible_platforms();
+
 /// Endpoint + content-type + opaque payload for a request to be POSTed to the Session Pro backend,
 /// returned by the `*_request()` helpers below. Callers relay `data` verbatim under `content_type`
 /// and never inspect or assume its format -- libsession owns the wire encoding.

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -245,7 +245,7 @@ struct GenerateProProofRequest {
     array_uc32 rotating_pkey;
 
     /// Unix timestamp of the request
-    sys_ms unix_ts;
+    sys_seconds unix_ts;
 
     /// 64-byte signature proving knowledge of the master key's secret component
     array_uc64 master_sig;
@@ -271,7 +271,7 @@ struct GenerateProProofRequest {
             std::uint8_t request_version,
             std::span<const uint8_t> master_privkey,
             std::span<const uint8_t> rotating_privkey,
-            sys_ms unix_ts);
+            sys_seconds unix_ts);
 
     /// API: pro/GenerateProProofRequest::build_to_json
     ///
@@ -290,7 +290,7 @@ struct GenerateProProofRequest {
             std::uint8_t request_version,
             std::span<const uint8_t> master_privkey,
             std::span<const uint8_t> rotating_privkey,
-            sys_ms unix_ts);
+            sys_seconds unix_ts);
 
     /// API: pro/GenerateProProofRequest::to_json
     ///
@@ -327,7 +327,7 @@ struct ProRevocationItem {
     array_uc32 gen_index_hash;
 
     /// Unix timestamp when the proof expires
-    sys_ms expiry_unix_ts;
+    sys_seconds expiry_unix_ts;
 };
 
 struct GetProRevocationsResponse : public ResponseHeader {
@@ -362,7 +362,7 @@ struct GetProDetailsRequest {
     array_uc64 master_sig;
 
     /// Unix timestamp of the request
-    sys_ms unix_ts;
+    sys_seconds unix_ts;
 
     /// Max amount of historical payments to request from the backend
     uint32_t count;
@@ -384,7 +384,7 @@ struct GetProDetailsRequest {
     static array_uc64 build_sig(
             uint8_t version,
             std::span<const uint8_t> master_privkey,
-            sys_ms unix_ts,
+            sys_seconds unix_ts,
             uint32_t count);
 
     /// API: pro/GetProDetailsRequest::build_to_json
@@ -403,7 +403,7 @@ struct GetProDetailsRequest {
     static std::string build_to_json(
             std::uint8_t version,
             std::span<const uint8_t> master_privkey,
-            sys_ms unix_ts,
+            sys_seconds unix_ts,
             uint32_t count);
 
     /// API: pro/GenerateProProofRequest::to_json
@@ -441,30 +441,30 @@ struct ProPaymentItem {
     bool auto_renewing;
 
     /// Unix timestamp of when the payment was witnessed by the Pro Backend. Always set
-    sys_ms unredeemed_unix_ts;
+    sys_seconds unredeemed_unix_ts;
 
     /// Unix timestamp of when the payment was redeemed. 0 if not activated
-    sys_ms redeemed_unix_ts;
+    sys_seconds redeemed_unix_ts;
 
     /// Unix timestamp of when the payment was expiry. 0 if not activated
-    sys_ms expiry_unix_ts;
+    sys_seconds expiry_unix_ts;
 
     /// Duration of the grace period, e.g. when the payment provider will start to attempt to renew
     /// the Session Pro subscription. During the period between
-    /// [expiry_unix_ts, expiry_unix_ts + grace_period_duration_ms] the user continues to have
+    /// [expiry_unix_ts, expiry_unix_ts + grace_period_duration] the user continues to have
     /// entitlement to Session Pro. This value is only applicable if `auto_renewing` is `true`.
-    std::chrono::milliseconds grace_period_duration_ms;
+    std::chrono::seconds grace_period_duration;
 
     /// Unix deadline timestamp of when the user is able to refund the subscription via the payment
     /// provider. Thereafter the user must initiate a refund manually via Session support.
-    sys_ms platform_refund_expiry_unix_ts;
+    sys_seconds platform_refund_expiry_unix_ts;
 
     /// Unix timestamp of when the payment was revoked or refunded. 0 if not applicable.
-    sys_ms revoked_unix_ts;
+    sys_seconds revoked_unix_ts;
 
     /// UNIX timestamp at which a refund request was requested for this payment. This is set to 0
     /// if no refund has been requested for this payment yet.
-    sys_ms refund_requested_unix_ts;
+    sys_seconds refund_requested_unix_ts;
 
     /// When payment provider is set to Google Play Store, this is the platform-specific purchase
     /// token. This information should be considered as confidential and stored appropriately.
@@ -532,18 +532,18 @@ struct GetProDetailsResponse : public ResponseHeader {
     /// This timestamp may be in the past if the user no longer has active payments. Overtime the
     /// Pro Backend may prune user history and so after long lapses of activity, a user's
     /// subscription history may be deleted.
-    sys_ms expiry_unix_ts;
+    sys_seconds expiry_unix_ts;
 
     /// Duration that a user is entitled to for their grace period. This value is to be ignored if
     /// `auto_renewing` is false. It can be used to calculate the subscription expiry timestamp by
     /// subtracting `expiry_unix_ts_ms` from this value.
-    std::chrono::milliseconds grace_period_duration;
+    std::chrono::seconds grace_period_duration;
 
     /// UNIX timestamp at which a refund request was requested by this user. This timestamp comes
     /// from the latest payment that the backend has deemed to be active for the user (e.g. the
     /// payment associated with the `expiry_unix_ts_ms`). This value is 0 if no refund has been
     /// requested on the active payment.
-    sys_ms refund_requested_unix_ts;
+    sys_seconds refund_requested_unix_ts;
 
     /// Total number of payments known by the backend for the user. This may be greater than the
     /// length of items if the request, requested less than the number of payments the user has.
@@ -573,10 +573,10 @@ struct SetPaymentRefundRequestedRequest {
     array_uc64 master_sig;
 
     /// Unix timestamp of the current time
-    sys_ms unix_ts;
+    sys_seconds unix_ts;
 
     /// Unix timestamp to set as the timestamp that a refund was requested on this payment.
-    sys_ms refund_requested_unix_ts;
+    sys_seconds refund_requested_unix_ts;
 
     /// Payment details to set the refund request on
     AddProPaymentUserTransaction payment_tx;
@@ -607,8 +607,8 @@ struct SetPaymentRefundRequestedRequest {
     static array_uc64 build_sig(
             uint8_t version,
             std::span<const uint8_t> master_privkey,
-            sys_ms unix_ts,
-            sys_ms refund_requested_unix_ts,
+            sys_seconds unix_ts,
+            sys_seconds refund_requested_unix_ts,
             SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
             std::span<const uint8_t> payment_tx_payment_id,
             std::span<const uint8_t> payment_tx_order_id);
@@ -637,8 +637,8 @@ struct SetPaymentRefundRequestedRequest {
     static std::string build_to_json(
             std::uint8_t version,
             std::span<const uint8_t> master_privkey,
-            sys_ms unix_ts,
-            sys_ms refund_requested_unix_ts,
+            sys_seconds unix_ts,
+            sys_seconds refund_requested_unix_ts,
             SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
             std::span<const uint8_t> payment_tx_payment_id,
             std::span<const uint8_t> payment_tx_order_id);

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -83,9 +83,9 @@ constexpr std::string_view URL = "https://pro.session.codes";
 /// error (fail-closed) rather than passing it through. New categories/detail arrive via
 /// `error_code`, which IS open/extensible.
 enum class ResponseStatus {
-    Ok,    ///< Success; the response's payload fields are populated.
-    Fail,  ///< Request rejected on client input / a precondition; retrying the identical request
-           ///< won't help (except the `stale_request` error_code). See `error_code`.
+    Ok,     ///< Success; the response's payload fields are populated.
+    Fail,   ///< Request rejected on client input / a precondition; retrying the identical request
+            ///< won't help (except the `stale_request` error_code). See `error_code`.
     Error,  ///< Backend fault; the client did nothing wrong and the same request may succeed later.
 };
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -302,8 +302,8 @@ struct GenerateProProofRequest {
 };
 
 /// Retrieve the current list of revocations for currently active Session Pro proofs (because of
-/// refunds for example). The caller should maintain this list until the revocation has expiry and
-/// periodically retrieve this list from the backend every hour.
+/// refunds for example). The caller retains each returned item for the response's `retain_for`
+/// window after first seeing it (memory-only aging) and polls again after `retry_in`.
 struct GetProRevocationsRequest {
     /// Request version. The latest accepted version is 0
     std::uint8_t version;
@@ -326,14 +326,22 @@ struct ProRevocationItem {
     /// 32-byte opaque revocation tag identifying a proof
     array_uc32 revocation_tag;
 
-    /// Unix timestamp when the proof expires
-    sys_seconds expiry_unix_ts;
+    /// A matching proof is revoked once the client's clock reaches this unix timestamp (not before)
+    sys_seconds effective_unix_ts;
 };
 
 struct GetProRevocationsResponse : public ResponseHeader {
     /// 64-bit monotonic integer for the latest revocation list iteration.
     /// Update the caller's ticket to this value for subsequent requests.
     std::int64_t ticket;
+
+    /// Recommended interval to wait before polling the revocation list again.
+    std::chrono::seconds retry_in;
+
+    /// How long a client should retain each item after first seeing it, for memory-only local
+    /// aging (roughly the maximum proof-validity window). Applied as `seen + retain_for`; holding
+    /// an entry longer is harmless.
+    std::chrono::seconds retain_for;
 
     /// List of revoked Session Pro proofs
     std::vector<ProRevocationItem> items;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -106,17 +106,13 @@ struct MasterRotatingSignatures {
 };
 
 struct AddProPaymentUserTransaction {
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER provider;
+    /// Provider code string (see SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*)
+    std::string provider_code;
 
-    /// The payment ID to claim which is different per platform.
-    ///
-    ///   Google Play Store => purchase token
-    ///   iOS App Store     => transaction ID (note, not the original transaction id)
+    /// Opaque payment identifier from the provider's purchase flow. Multi-part providers fold their
+    /// parts into this one string per a backend-defined composite (e.g. Google "token|order_id");
+    /// libsession treats it as opaque bytes hashed verbatim.
     std::string payment_id;
-
-    /// Only for Google Play Store, set this to the purchase's order ID. Ignored for other payment
-    /// providers
-    std::string order_id;
 };
 
 /// Register a new Session Pro proof to the backend. The payment is registered under the
@@ -178,9 +174,8 @@ struct AddProPaymentRequest {
             std::uint8_t request_version,
             std::span<const uint8_t> master_privkey,
             std::span<const uint8_t> rotating_privkey,
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-            std::span<const uint8_t> payment_tx_payment_id,
-            std::span<const uint8_t> payment_tx_order_id);
+            std::string_view payment_tx_provider_code,
+            std::span<const uint8_t> payment_tx_payment_id);
 
     /// API: pro/AddProPaymentRequest::build_to_json
     ///
@@ -204,9 +199,8 @@ struct AddProPaymentRequest {
             std::uint8_t request_version,
             std::span<const uint8_t> master_privkey,
             std::span<const uint8_t> rotating_privkey,
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-            std::span<const uint8_t> payment_tx_payment_id,
-            std::span<const uint8_t> payment_tx_order_id);
+            std::string_view payment_tx_provider_code,
+            std::span<const uint8_t> payment_tx_payment_id);
 };
 
 /// The generated proof from the Session Pro backend that has been parsed from JSON. This structure
@@ -432,17 +426,13 @@ struct ProPaymentItem {
     /// book-keeping purposes.
     SESSION_PRO_BACKEND_PAYMENT_STATUS status;
 
-    /// Session Pro product/plan item that was purchased
-    SESSION_PRO_BACKEND_PLAN plan;
+    /// Billing-period code that was purchased (e.g. "1m"/"3m"/"1y"); opaque, may be free-form for
+    /// non-period plans. The client maps/parses it for display.
+    std::string plan;
 
-    /// Store front that this particular payment came from
-    SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_provider;
-
-    /// Strings associated with platform's payment provider from
-    /// `SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA`, provided for convenience. This pointer is
-    /// always pointing to valid memory.
-    const session_pro_backend_payment_provider_metadata* payment_provider_metadata =
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA;
+    /// Provider code this payment came from (e.g. "google_play"); opaque -- an unknown value passes
+    /// through as-is for the client to handle.
+    std::string payment_provider;
 
     /// Flag indicating whether or not this payment will automatically bill itself at the end of the
     /// billing cycle.
@@ -474,30 +464,10 @@ struct ProPaymentItem {
     /// if no refund has been requested for this payment yet.
     sys_seconds refund_requested_unix_ts;
 
-    /// When payment provider is set to Google Play Store, this is the platform-specific purchase
-    /// token. This information should be considered as confidential and stored appropriately.
-    std::string google_payment_token;
-
-    /// When payment provider is set to Google Play Store, this is the platform-specific order
-    /// id. This information should be considered as confidential and stored appropriately.
-    std::string google_order_id;
-
-    /// When payment provider is set to iOS App Store, this is the platform-specific original
-    /// transaction ID. This information should be considered as confidential and stored
-    /// appropriately.
-    std::string apple_original_tx_id;
-
-    /// When payment provider is set to iOS App Store, this is the platform-specific transaction ID
-    /// This information should be considered as confidential and stored appropriately.
-    std::string apple_tx_id;
-
-    /// When payment provider is set to iOS App Store, this is the platform-specific web line order
-    /// ID. This information should be considered as confidential and stored appropriately.
-    std::string apple_web_line_order_id;
-
-    /// When payment provider is set to Rangeproof, this is the platform-specific order ID.
-    /// This information should be considered as confidential and stored appropriately.
-    std::string rangeproof_order_id;
+    /// Opaque payment identifier (the value passed at add-payment; multi-part providers fold their
+    /// parts in per the backend-defined composite -- libsession does not interpret it).
+    /// Confidential; store appropriately.
+    std::string payment_id;
 };
 
 struct GetProDetailsResponse : public ResponseHeader {
@@ -617,9 +587,8 @@ struct SetPaymentRefundRequestedRequest {
             std::span<const uint8_t> master_privkey,
             sys_seconds unix_ts,
             sys_seconds refund_requested_unix_ts,
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-            std::span<const uint8_t> payment_tx_payment_id,
-            std::span<const uint8_t> payment_tx_order_id);
+            std::string_view payment_tx_provider_code,
+            std::span<const uint8_t> payment_tx_payment_id);
 
     /// API: pro/SetPaymentRefundRequested::build_to_json
     ///
@@ -647,9 +616,8 @@ struct SetPaymentRefundRequestedRequest {
             std::span<const uint8_t> master_privkey,
             sys_seconds unix_ts,
             sys_seconds refund_requested_unix_ts,
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-            std::span<const uint8_t> payment_tx_payment_id,
-            std::span<const uint8_t> payment_tx_order_id);
+            std::string_view payment_tx_provider_code,
+            std::span<const uint8_t> payment_tx_payment_id);
 
     /// API: pro/SetPaymentRefundRequested::to_json
     ///

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -401,9 +401,6 @@ ProRequest refund_request(
         std::span<const uint8_t> payment_id);
 
 struct SetPaymentRefundRequestedResponse : Response {
-    /// Version from the request
-    std::uint8_t version;
-
     /// True if a payment was found matching the given payment information and that the refund
     /// request unix timestamp was set
     bool updated;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -65,6 +65,11 @@ using namespace oxenc::literals;
 constexpr auto PUBKEY = "479ffca8bcec7b4a0f0f7afe48b8a6d15635a8c7ff15ad16add05752c19414d4"_hex_u;
 static_assert(PUBKEY.size() == 32);
 
+/// The Session Pro Backend's production base URL: POST a request body to `<URL>/<endpoint>` (see
+/// the SESSION_PRO_BACKEND_*_ENDPOINT paths). This is the canonical production value; a client may
+/// point at a different dev/test server if it chooses.
+constexpr std::string_view URL = "https://pro.session.codes";
+
 enum struct AddProPaymentResponseStatus {
     /// Payment was claimed and the pro proof was successfully generated
     Success = SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_RESPONSE_STATUS_SUCCESS,

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -318,8 +318,8 @@ ProRequest payment_details_request(
         uint32_t limit,
         std::string_view before);
 
-/// Unit of a billing period (the `unit` of a parsed `plan` code, pro-wire-protocol.md §1 / Delta
-/// #14). A closed set: the backend emits only these, so an unrecognized code is a protocol error.
+/// Unit of a billing period (the `unit` of a parsed `plan` code, pro-wire-protocol.md §1). A closed
+/// set: the backend emits only these, so an unrecognized code is a protocol error.
 enum class ProPlanUnit { second, day, week, month, year, lifetime };
 
 /// A parsed `plan` billing-period code. The `unit` is preserved exactly as transmitted and never
@@ -331,7 +331,7 @@ struct ProPlanPeriod {
     ProPlanUnit unit;
 };
 
-/// Parse a `plan` billing-period code (pro-wire-protocol.md §1, Delta #14): "<N><unit>" with N a
+/// Parse a `plan` billing-period code (pro-wire-protocol.md §1): "<N><unit>" with N a
 /// positive integer (no leading zeros) and unit one of s/d/w/m/y (second/day/week/month/year), or
 /// the literal "lifetime". Single-unit only ("1y6m" is invalid). Returns std::nullopt for any
 /// non-conforming code (the caller treats that as a protocol error).
@@ -347,7 +347,7 @@ struct ProPaymentItem {
     std::string status;
 
     /// The parsed billing period that was purchased (e.g. "1m" -> {1, month}, "lifetime" -> {0,
-    /// lifetime}). libsession parses the closed `plan` grammar (§1 / Delta #14); the client just
+    /// lifetime}). libsession parses the closed `plan` grammar (§1); the client just
     /// localizes the display. The unit is preserved as transmitted, never canonicalized.
     ProPlanPeriod plan;
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -323,8 +323,8 @@ struct GetProRevocationsRequest {
 };
 
 struct ProRevocationItem {
-    /// 32-byte hash of the generation index, identifying a proof
-    array_uc32 gen_index_hash;
+    /// 32-byte opaque revocation tag identifying a proof
+    array_uc32 revocation_tag;
 
     /// Unix timestamp when the proof expires
     sys_seconds expiry_unix_ts;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -25,7 +25,7 @@
 ///    response and filling in the relevant rotating private key that the proof was authorised for.
 ///
 ///    The server will only respond successfully if it can also independently verify the purchase
-///    otherwise an error is returned and can be read from the `Response` after parsing the
+///    otherwise an error is returned and can be read from the `ResponseBase` after parsing the
 ///    raw response.
 ///
 /// 2. Attach the `ProProof` constructed from (1) into their messages. Libsession has helper
@@ -78,15 +78,36 @@ static_assert(PUBKEY_X25519.size() == 32);
 /// point at a different dev/test server if it chooses.
 constexpr std::string_view URL = "https://pro.session.codes";
 
-struct Response {
-    /// Parsing or processing errors, from the backend or from libsession while parsing. Empty on
-    /// success; may hold several messages (one request can fail multiple checks at once). On
-    /// failure the parse may be partial, so always check `success()`/`errors` before using other
-    /// fields.
-    std::vector<std::string> errors;
+/// Response outcome category (the wire `status`, spec §5). CLOSED/exhaustive by design: the backend
+/// will never add a fourth value, so libsession treats any unrecognized wire status as a protocol
+/// error (fail-closed) rather than passing it through. New categories/detail arrive via
+/// `error_code`, which IS open/extensible.
+enum class ResponseStatus {
+    Ok,    ///< Success; the response's payload fields are populated.
+    Fail,  ///< Request rejected on client input / a precondition; retrying the identical request
+           ///< won't help (except the `stale_request` error_code). See `error_code`.
+    Error,  ///< Backend fault; the client did nothing wrong and the same request may succeed later.
+};
 
-    /// True iff the response came back without any errors.
-    [[nodiscard]] bool success() const { return errors.empty(); }
+struct ResponseBase {
+    /// Outcome category; `success()` is the usual check. See ResponseStatus.
+    ResponseStatus status = ResponseStatus::Ok;
+
+    /// On non-Ok, a stable machine-readable slug identifying the outcome (spec §5.1), e.g.
+    /// "unknown_payment", "expired", "stale_request". std::nullopt on success. Opaque and
+    /// forward-compatible: map known slugs to localized text; for an unrecognized one fall back to
+    /// `error` / the `status` category. (libsession synthesizes "invalid_response" if it cannot
+    /// parse the backend's reply at all.)
+    std::optional<std::string> error_code;
+
+    /// On non-Ok, an English diagnostic string. NOT user-facing text (that comes from mapping
+    /// `error_code` to a localized string); show it only when the slug is unrecognized, and it is
+    /// always safe to log. std::nullopt on success.
+    std::optional<std::string> error;
+
+    /// Contextually convertible to bool: `if (response) { ... }` is true iff the request succeeded
+    /// (status == Ok). Explicit, so it can't silently leak into arithmetic or comparisons.
+    explicit operator bool() const { return status == ResponseStatus::Ok; }
 };
 
 struct MasterRotatingSignatures {
@@ -164,7 +185,7 @@ ProRequest add_payment_request(
 /// `GenerateProProofResponse` are distinct types (each parsed by its own free function below) that
 /// share `proof` today but can diverge independently. `proof` is the raw parse result, convertible
 /// to a config::ProProof.
-struct ProProofResponse : Response {
+struct ProProofResponse : ResponseBase {
     ProProof proof;
 };
 
@@ -221,7 +242,7 @@ struct ProRevocationItem {
     sys_seconds effective_at;
 };
 
-struct GetProRevocationsResponse : Response {
+struct GetProRevocationsResponse : ResponseBase {
     /// 64-bit monotonic integer for the latest revocation list iteration.
     /// Update the caller's ticket to this value for subsequent requests.
     std::int64_t ticket;
@@ -314,7 +335,7 @@ struct ProPaymentItem {
     std::string payment_id;
 };
 
-struct GetProDetailsResponse : Response {
+struct GetProDetailsResponse : ResponseBase {
     /// List of payment items for the master public key
     std::vector<ProPaymentItem> items;
 
@@ -402,7 +423,7 @@ ProRequest refund_request(
         std::string_view provider_code,
         std::span<const uint8_t> payment_id);
 
-struct SetPaymentRefundRequestedResponse : Response {
+struct SetPaymentRefundRequestedResponse : ResponseBase {
     /// True if a payment was found matching the given payment information and that the refund
     /// request unix timestamp was set
     bool updated;

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -65,6 +65,14 @@ using namespace oxenc::literals;
 constexpr auto PUBKEY = "479ffca8bcec7b4a0f0f7afe48b8a6d15635a8c7ff15ad16add05752c19414d4"_hex_u;
 static_assert(PUBKEY.size() == 32);
 
+/// The X25519 form of `PUBKEY` (the same key converted via crypto_sign_ed25519_pk_to_curve25519),
+/// provided as a constant for clients that need the X25519 pubkey (e.g. to establish an encrypted
+/// channel to the backend) without doing the conversion themselves. A unit test asserts these bytes
+/// match the runtime conversion of `PUBKEY`, so the two cannot drift.
+constexpr auto PUBKEY_X25519 =
+        "ce5a75f64b6c43db6c1374d362c3ea9d85951c4f42a3d04cf94f87822d4f803b"_hex_u;
+static_assert(PUBKEY_X25519.size() == 32);
+
 /// The Session Pro Backend's production base URL: POST a request body to `<URL>/<endpoint>` (see
 /// the SESSION_PRO_BACKEND_*_ENDPOINT paths). This is the canonical production value; a client may
 /// point at a different dev/test server if it chooses.

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -90,7 +90,7 @@ struct session_protocol_pro_signed_message {
 typedef struct session_protocol_pro_proof session_protocol_pro_proof;
 struct session_protocol_pro_proof {
     uint8_t version;
-    bytes32 gen_index_hash;
+    bytes32 revocation_tag;
     bytes32 rotating_pubkey;
     int64_t expiry_ts;
     bytes64 sig;

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -31,16 +31,6 @@ enum {
     SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING = 160,
 };
 
-// clang-format off
-/// Session Pro personalisation bytes for hashing; must match the personalisation strings in
-/// pro-wire-protocol.md §2 (proof) and §3 (signed requests).
-static const char SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION[]               = "ProGenerateProof";
-static const char SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION[]                  = "ProProof_v0_____";
-static const char SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION[]              = "ProAddPayment___";
-static const char SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION[] = "ProSetRefundReq_";
-static const char SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION[]              = "ProGetProDetReq_";
-// clang-format on
-
 /// Bundle of hard-coded strings that an implementing application may use for various scenarios.
 typedef struct session_protocol_strings session_protocol_strings;
 struct session_protocol_strings {
@@ -262,20 +252,6 @@ LIBSESSION_EXPORT void session_protocol_pro_message_bitset_set(
 /// Unset the feature flag on the bitset
 LIBSESSION_EXPORT void session_protocol_pro_message_bitset_unset(
         session_protocol_pro_message_bitset* value, SESSION_PROTOCOL_PRO_MESSAGE_FEATURES features);
-
-/// API: session_protocol/session_protocol_pro_proof_hash
-///
-/// Generate the 32 byte hash that is to be signed by the rotating key or Session Pro Backend key to
-/// embed in the envelope or proof respectively which other clients use to authenticate the validity
-/// of a proof.
-///
-/// Inputs:
-/// - `proof` -- Proof to calculate the hash from
-///
-/// Outputs:
-/// - `bytes32` -- The 32 byte hash calculated from the proof
-LIBSESSION_EXPORT bytes32 session_protocol_pro_proof_hash(session_protocol_pro_proof const* proof)
-        NON_NULL_ARG(1);
 
 /// API: session_protocol/session_protocol_pro_proof_verify_signature
 ///

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -26,32 +26,33 @@ LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION
 LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING;
 
 /// Bundle of hard-coded strings that an implementing application may use for various scenarios.
+/// Each is a static, null-terminated C string.
 typedef struct session_protocol_strings {
-    string8 build_variant_apk;
-    string8 build_variant_fdroid;
-    string8 build_variant_huawei;
-    string8 build_variant_ipa;
-    string8 url_donations;
-    string8 url_donations_app;
-    string8 url_download;
-    string8 url_faq;
-    string8 url_feedback;
-    string8 url_network;
-    string8 url_privacy_policy;
-    string8 url_pro_access_not_found;
-    string8 url_pro_faq;
-    string8 url_pro_page;
-    string8 url_pro_privacy_policy;
-    string8 url_pro_roadmap;
-    string8 url_pro_support;
-    string8 url_pro_terms_of_service;
-    string8 url_pro_upgrade;
-    string8 url_staking;
-    string8 url_support;
-    string8 url_survey;
-    string8 url_terms_of_service;
-    string8 url_token;
-    string8 url_translate;
+    const char* build_variant_apk;
+    const char* build_variant_fdroid;
+    const char* build_variant_huawei;
+    const char* build_variant_ipa;
+    const char* url_donations;
+    const char* url_donations_app;
+    const char* url_download;
+    const char* url_faq;
+    const char* url_feedback;
+    const char* url_network;
+    const char* url_privacy_policy;
+    const char* url_pro_access_not_found;
+    const char* url_pro_faq;
+    const char* url_pro_page;
+    const char* url_pro_privacy_policy;
+    const char* url_pro_roadmap;
+    const char* url_pro_support;
+    const char* url_pro_terms_of_service;
+    const char* url_pro_upgrade;
+    const char* url_staking;
+    const char* url_support;
+    const char* url_survey;
+    const char* url_terms_of_service;
+    const char* url_token;
+    const char* url_translate;
 } session_protocol_strings;
 extern const session_protocol_strings SESSION_PROTOCOL_STRINGS;
 
@@ -361,7 +362,9 @@ LIBSESSION_EXPORT SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
 /// API: session_protocol/session_protocol_get_pro_features_for_msg
 typedef struct session_protocol_pro_features_for_msg {
     SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS status;
-    string8 error;
+    /// On error (status != OK), a static, null-terminated English diagnostic string; NULL when
+    /// there is no error.
+    const char* error;
     session_protocol_pro_message_bitset bitset;
     size_t codepoint_count;
 } session_protocol_pro_features_for_msg;

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -32,9 +32,8 @@ enum {
 };
 
 // clang-format off
-/// Session Pro personalisation bytes for hashing. Must match
-///  https://github.com/Doy-lee/session-pro-backend/blob/fca5e10c9c5014d394cf15934cd2af8e911607b9/backend.py#L21
-///  https://github.com/Doy-lee/session-pro-backend/blob/fca5e10c9c5014d394cf15934cd2af8e911607b9/server.py#L571
+/// Session Pro personalisation bytes for hashing; must match the personalisation strings in
+/// pro-wire-protocol.md §2 (proof) and §3 (signed requests).
 static const char SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION[]               = "ProGenerateProof";
 static const char SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION[]                  = "ProProof________";
 static const char SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION[]              = "ProAddPayment___";

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -92,7 +92,7 @@ struct session_protocol_pro_proof {
     uint8_t version;
     bytes32 gen_index_hash;
     bytes32 rotating_pubkey;
-    uint64_t expiry_unix_ts_ms;
+    uint64_t expiry_ts;
     bytes64 sig;
 };
 
@@ -321,22 +321,22 @@ LIBSESSION_EXPORT bool session_protocol_pro_proof_verify_message(
 
 /// API: session_protocol/session_protocol_pro_proof_is_active
 ///
-/// Check if the Pro proof is currently entitled to Pro given the `unix_ts_ms` with respect to the
+/// Check if the Pro proof is currently entitled to Pro given the `ts` with respect to the
 /// proof's `expiry_unix_ts`
 ///
 /// Inputs:
 /// - `proof` -- Proof to verify
-/// - `unix_ts_ms` -- The unix timestamp to check the proof expiry time against
+/// - `ts` -- The unix timestamp to check the proof expiry time against
 ///
 /// Outputs:
 /// - `bool` -- True if expired, false otherwise
 LIBSESSION_EXPORT bool session_protocol_pro_proof_is_active(
-        session_protocol_pro_proof const* proof, uint64_t unix_ts_ms) NON_NULL_ARG(1);
+        session_protocol_pro_proof const* proof, uint64_t ts) NON_NULL_ARG(1);
 
 /// API: session_protocol/session_protocol_pro_proof_status
 ///
 /// Evaluate the status of the pro proof by checking it is signed by the `verify_pubkey`, it has
-/// not expired via `unix_ts_ms` and optionally verify that the `signed_msg` was signed by the
+/// not expired via `ts` and optionally verify that the `signed_msg` was signed by the
 /// `rotating_pubkey` embedded in the proof.
 ///
 /// Internally this function calls `pro_proof_verify_signature`, `pro_proof_verify_message` and
@@ -350,7 +350,7 @@ LIBSESSION_EXPORT bool session_protocol_pro_proof_is_active(
 ///   they are the original signatory of the proof.
 /// - `verify_pubkey_len` -- Length of the `verify_pubkey` should be 32 bytes
 ///   they are the original signatory of the proof.
-/// - `unix_ts_ms` -- Unix timestamp to compared against the embedded `expiry_unix_ts`
+/// - `ts` -- Unix timestamp to compared against the embedded `expiry_unix_ts`
 ///   to determine if the proof has expired or not
 /// - `signed_msg` -- Optionally set the payload to the message with the signature to verify if
 ///   the embedded `rotating_pubkey` in the proof signed the given message.
@@ -363,7 +363,7 @@ LIBSESSION_EXPORT SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
         session_protocol_pro_proof const* proof,
         const uint8_t* verify_pubkey,
         size_t verify_pubkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         OPTIONAL const session_protocol_pro_signed_message* signed_msg) NON_NULL_ARG(1, 2);
 
 /// API: session_protocol/session_protocol_get_pro_features_for_msg
@@ -798,7 +798,7 @@ LIBSESSION_EXPORT void session_protocol_decode_envelope_free(
 /// Inputs:
 /// - `content_or_envelope_payload` -- the unencrypted content or envelope payload containing the
 ///   community message
-/// - `unix_ts_ms` -- pass in the current system time which is used to determine, whether or
+/// - `ts` -- pass in the current system time which is used to determine, whether or
 ///   not the Session Pro proof has expired or not if it is in the payload. Ignored if there's no
 ///   proof in the message.
 /// - `pro_backend_pubkey` -- the Session Pro backend public key to verify the signature embedded in
@@ -828,7 +828,7 @@ LIBSESSION_EXPORT void session_protocol_decode_envelope_free(
 LIBSESSION_EXPORT session_protocol_decoded_community_message session_protocol_decode_for_community(
         const void* content_or_envelope_payload,
         size_t content_or_envelope_payload_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         OPTIONAL const void* pro_backend_pubkey,
         size_t pro_backend_pubkey_len,
         OPTIONAL char* error,

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -12,28 +12,21 @@
 extern "C" {
 #endif
 
-enum {
-    /// Maximum number of UTF16 code points that a standard message can use. If the message exceeds
-    /// this then the message must activate the higher character limit feature provided by Session
-    /// Pro which allows messages up to 10k characters.
-    SESSION_PROTOCOL_PRO_STANDARD_CHARACTER_LIMIT = 2000,
-
-    /// Maximum number of UTF16 code points that a Session Pro entitled user can send in a message.
-    /// This is not used in the codebase, but is provided for convenience to centralise protocol
-    /// definitions for users of the library to consume.
-    SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT = 10000,
-
-    /// Amount of conversations that a user without Session Pro can pin
-    SESSION_PROTOCOL_PRO_STANDARD_PINNED_CONVERSATION_LIMIT = 5,
-
-    /// Amount of bytes that a community or 1o1 message `Content` must be padded by before wrapping
-    /// in an envelope.
-    SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING = 160,
-};
+/// Protocol limit/padding constants. Each points at the C++ `session::*` value (defined there --
+/// the primary; C references). Statically-initialized `const int`s (not compile-time constants).
+/// - `SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT` -- max UTF-16 code points in a standard
+///   (non-Pro) message; a longer one must activate the Session Pro higher-character-limit feature.
+/// - `SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT` -- max UTF-16 code points a Pro user can send.
+/// - `SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT` -- pins allowed without Session Pro.
+/// - `SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING` -- byte multiple a community/1o1 `Content` is
+///   padded up to before wrapping in an envelope.
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING;
 
 /// Bundle of hard-coded strings that an implementing application may use for various scenarios.
-typedef struct session_protocol_strings session_protocol_strings;
-struct session_protocol_strings {
+typedef struct session_protocol_strings {
     string8 build_variant_apk;
     string8 build_variant_fdroid;
     string8 build_variant_huawei;
@@ -59,7 +52,7 @@ struct session_protocol_strings {
     string8 url_terms_of_service;
     string8 url_token;
     string8 url_translate;
-};
+} session_protocol_strings;
 extern const session_protocol_strings SESSION_PROTOCOL_STRINGS;
 
 typedef enum SESSION_PROTOCOL_PRO_STATUS {  // See session::ProStatus
@@ -70,20 +63,18 @@ typedef enum SESSION_PROTOCOL_PRO_STATUS {  // See session::ProStatus
     SESSION_PROTOCOL_PRO_STATUS_EXPIRED,
 } SESSION_PROTOCOL_PRO_STATUS;
 
-typedef struct session_protocol_pro_signed_message session_protocol_pro_signed_message;
-struct session_protocol_pro_signed_message {
+typedef struct session_protocol_pro_signed_message {
     span_u8 sig;
     span_u8 msg;
-};
+} session_protocol_pro_signed_message;
 
-typedef struct session_protocol_pro_proof session_protocol_pro_proof;
-struct session_protocol_pro_proof {
+typedef struct session_protocol_pro_proof {
     uint8_t version;
     bytes32 revocation_tag;
     bytes32 rotating_pubkey;
     int64_t expiry_ts;
     bytes64 sig;
-};
+} session_protocol_pro_proof;
 
 // Feature flags for profile features where each enum value indicates the bit position in the
 // corresponding bitset, e.g. (1 << ENUM_VAL)
@@ -103,10 +94,9 @@ typedef enum SESSION_PROTOCOL_PRO_PROFILE_FEATURES {
 // bitsets are stored as sets which allows us to do diffs and deltas on the set of values. The
 // syncing scheme does not allow bit-level deltas which makes handling conflicts between competing
 // synced configurations, awkward.
-typedef struct session_protocol_pro_profile_bitset session_protocol_pro_profile_bitset;
-struct session_protocol_pro_profile_bitset {
+typedef struct session_protocol_pro_profile_bitset {
     uint64_t data;
-};
+} session_protocol_pro_profile_bitset;
 
 // Feature flags for message features where each enum value indicates the bit position in the
 // corresponding bitset.
@@ -116,10 +106,9 @@ typedef enum SESSION_PROTOCOL_PRO_MESSAGE_FEATURES {
 
 // Strongly typed bitset for Session Pro message features (see
 // `session_protocol_pro_profile_bitset`)
-typedef struct session_protocol_pro_message_bitset session_protocol_pro_message_bitset;
-struct session_protocol_pro_message_bitset {
+typedef struct session_protocol_pro_message_bitset {
     uint64_t data;
-};
+} session_protocol_pro_message_bitset;
 
 typedef enum SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS {  // See session::ProFeaturesForMsgStatus
     SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_SUCCESS,
@@ -134,8 +123,7 @@ typedef enum SESSION_PROTOCOL_DESTINATION_TYPE {  // See session::DestinationTyp
     SESSION_PROTOCOL_DESTINATION_TYPE_COMMUNITY,
 } SESSION_PROTOCOL_DESTINATION_TYPE;
 
-typedef struct session_protocol_destination session_protocol_destination;
-struct session_protocol_destination {  // See session::Destination
+typedef struct session_protocol_destination {  // See session::Destination
     SESSION_PROTOCOL_DESTINATION_TYPE type;
     const void* pro_rotating_ed25519_privkey;
     size_t pro_rotating_ed25519_privkey_len;
@@ -144,7 +132,7 @@ struct session_protocol_destination {  // See session::Destination
     bytes32 community_inbox_server_pubkey;
     bytes33 group_ed25519_pubkey;
     bytes32 group_enc_key;
-};
+} session_protocol_destination;
 
 // Indicates which optional fields in the envelope has been populated out of the optional fields in
 // an envelope after it has been parsed off the wire.
@@ -157,33 +145,29 @@ enum ENVELOPE_FLAGS_ {
     SESSION_PROTOCOL_ENVELOPE_FLAGS_TIMESTAMP = 1 << 4,
 };
 
-typedef struct session_protocol_envelope session_protocol_envelope;
-struct session_protocol_envelope {
+typedef struct session_protocol_envelope {
     SESSION_PROTOCOL_ENVELOPE_FLAGS flags;
     uint64_t timestamp_ms;
     bytes33 source;
     uint32_t source_device;
     uint64_t server_timestamp;
     bytes64 pro_sig;
-};
+} session_protocol_envelope;
 
-typedef struct session_protocol_decode_envelope_keys session_protocol_decode_envelope_keys;
-struct session_protocol_decode_envelope_keys {
+typedef struct session_protocol_decode_envelope_keys {
     span_u8 group_ed25519_pubkey;
     const span_u8* decrypt_keys;
     size_t decrypt_keys_len;
-};
+} session_protocol_decode_envelope_keys;
 
-typedef struct session_protocol_decoded_pro session_protocol_decoded_pro;
-struct session_protocol_decoded_pro {
+typedef struct session_protocol_decoded_pro {
     SESSION_PROTOCOL_PRO_STATUS status;
     session_protocol_pro_proof proof;
     session_protocol_pro_message_bitset msg_bitset;
     session_protocol_pro_profile_bitset profile_bitset;
-};
+} session_protocol_decoded_pro;
 
-typedef struct session_protocol_decoded_envelope session_protocol_decoded_envelope;
-struct session_protocol_decoded_envelope {
+typedef struct session_protocol_decoded_envelope {
     // Indicates if the decryption was successful. If the decryption step failed and threw an
     // exception, this is false.
     bool success;
@@ -193,20 +177,41 @@ struct session_protocol_decoded_envelope {
     bytes32 sender_x25519_pubkey;
     session_protocol_decoded_pro pro;
     size_t error_len_incl_null_terminator;
-};
+} session_protocol_decoded_envelope;
 
-typedef struct session_protocol_encoded_for_destination session_protocol_encoded_for_destination;
-struct session_protocol_encoded_for_destination {
+/// API: session_protocol/session_protocol_decode_envelope_free
+///
+/// Free the decoded result produced by `session_protocol_decode_envelope`. It is safe to pass a
+/// `NULL` or any result returned by the decode function irrespective of if the function succeeded
+/// or failed.
+///
+/// Inputs:
+/// - `envelope` -- decoded result to free. This object is zeroed out on free and should no
+///   longer be used after it is freed.
+LIBSESSION_EXPORT void session_protocol_decode_envelope_free(
+        session_protocol_decoded_envelope* envelope);
+
+typedef struct session_protocol_encoded_for_destination {
     // Indicates if the encryption was successful. If any step failed and threw an exception, this
     // is false.
     bool success;
     span_u8 ciphertext;
     size_t error_len_incl_null_terminator;
-};
+} session_protocol_encoded_for_destination;
 
-typedef struct session_protocol_decoded_community_message
-        session_protocol_decoded_community_message;
-struct session_protocol_decoded_community_message {
+/// API: session_protocol/session_protocol_encode_for_destination_free
+///
+/// Free the encryption result for a destination produced by
+/// `session_protocol_encrypt_for_destination`. It is safe to pass a `NULL` or any result returned
+/// by the encrypt function irrespective of if the function succeeded or failed.
+///
+/// Inputs:
+/// - `encrypt` -- Encryption result to free. This object is zeroed out on free and should no longer
+///   be used after it is freed.
+LIBSESSION_EXPORT void session_protocol_encode_for_destination_free(
+        session_protocol_encoded_for_destination* encrypt);
+
+typedef struct session_protocol_decoded_community_message {
     bool success;
     bool has_envelope;
     session_protocol_envelope envelope;
@@ -215,7 +220,19 @@ struct session_protocol_decoded_community_message {
     bytes64 pro_sig;
     session_protocol_decoded_pro pro;
     size_t error_len_incl_null_terminator;
-};
+} session_protocol_decoded_community_message;
+
+/// API: session_protocol/session_protocol_decode_for_community_free
+///
+/// Free the decoded result produced by `session_protocol_decode_for_community`. It is safe to pass
+/// a `NULL` or any result returned by the decode function irrespective of if the function
+/// succeeded or failed.
+///
+/// Inputs:
+/// - `community_msg` -- decoded result to free. This object is zeroed out on free and should no
+///   longer be used after it is freed.
+LIBSESSION_EXPORT void session_protocol_decode_for_community_free(
+        session_protocol_decoded_community_message* community_msg);
 
 /// API: session_protocol/session_protocol_pro_profile_bitset_is_set
 ///
@@ -354,9 +371,9 @@ typedef struct session_protocol_pro_features_for_msg {
 /// Determine the Pro features that are used in a given UTF8 message.
 ///
 /// Inputs:
-/// - `utf` -- the UTF8 string to count the number of codepoints in to determine if it needs the
+/// - `text` -- the UTF8 string to count the number of codepoints in to determine if it needs the
 ///   higher character limit available in Session Pro
-/// - `utf_size` -- the number of code units (aka. bytes) the string has
+/// - `text_size` -- the number of code units (aka. bytes) the string has
 ///
 /// Outputs:
 /// - `success` -- True if the message was evaluated successfully for PRO features false otherwise.
@@ -368,16 +385,16 @@ typedef struct session_protocol_pro_features_for_msg {
 /// - `codepoint_count` -- Counts the number of unicode codepoints that were in the message.
 LIBSESSION_EXPORT
 session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf8(
-        char const* utf, size_t utf_size) NON_NULL_ARG(1);
+        char const* text, size_t text_size) NON_NULL_ARG(1);
 
 /// API: session_protocol/session_protocol_get_pro_features_for_utf16
 ///
 /// Determine the Pro features that are used in a given UTF16 message.
 ///
 /// Inputs:
-/// - `utf` -- the UTF16 string to count the number of codepoints in to determine if it needs the
+/// - `text` -- the UTF16 string to count the number of codepoints in to determine if it needs the
 ///   higher character limit available in Session Pro
-/// - `utf_size` -- the number of code units (aka. bytes) the string has
+/// - `text_size` -- the number of code units (aka. bytes) the string has
 ///
 /// Outputs:
 /// - `success` -- True if the message was evaluated successfully for PRO features false otherwise.
@@ -389,7 +406,7 @@ session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf8(
 /// - `codepoint_count` -- Counts the number of unicode codepoints that were in the message.
 LIBSESSION_EXPORT
 session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf16(
-        uint16_t const* utf, size_t utf_size) NON_NULL_ARG(1);
+        uint16_t const* text, size_t text_size) NON_NULL_ARG(1);
 
 /// API: session_protocol_encode_for_1o1
 ///
@@ -674,18 +691,6 @@ session_protocol_encoded_for_destination session_protocol_encode_for_destination
         OPTIONAL char* error,
         size_t error_len) NON_NULL_ARG(1, 5);
 
-/// API: session_protocol/session_protocol_encrypt_for_destination_free
-///
-/// Free the encryption result for a destination produced by
-/// `session_protocol_encrypt_for_destination`. It is safe to pass a `NULL` or any result returned
-/// by the encrypt function irrespective of if the function succeeded or failed.
-///
-/// Inputs:
-/// - `encrypt` -- Encryption result to free. This object is zeroed out on free and should no longer
-///   be used after it is freed.
-LIBSESSION_EXPORT void session_protocol_encode_for_destination_free(
-        session_protocol_encoded_for_destination* encrypt);
-
 /// API: session_protocol/session_protocol_decode_envelope
 ///
 /// Given an envelope payload (i.e.: protobuf encoded stream of `WebsocketRequestMessage` which
@@ -753,18 +758,6 @@ session_protocol_decoded_envelope session_protocol_decode_envelope(
         OPTIONAL char* error,
         size_t error_len) NON_NULL_ARG(1, 2);
 
-/// API: session_protocol/session_protocol_decode_envelope_free
-///
-/// Free the decoded result produced by `session_protocol_decode_envelope`. It is safe to pass a
-/// `NULL` or any result returned by the decode function irrespective of if the function succeeded
-/// or failed.
-///
-/// Inputs:
-/// - `envelope` -- decoded result to free. This object is zeroed out on free and should no
-///   longer be used after it is freed.
-LIBSESSION_EXPORT void session_protocol_decode_envelope_free(
-        session_protocol_decoded_envelope* envelope);
-
 /// API: session_protocol/session_protocol_decode_for_community
 ///
 /// Given an unencrypted content or envelope payload extract the plaintext to the content and any
@@ -808,18 +801,6 @@ LIBSESSION_EXPORT session_protocol_decoded_community_message session_protocol_de
         size_t pro_backend_pubkey_len,
         OPTIONAL char* error,
         size_t error_len) NON_NULL_ARG(1);
-
-/// API: session_protocol/session_protocol_decode_for_community_free
-///
-/// Free the decoded result produced by `session_protocol_decode_for_community`. It is safe to pass
-/// a `NULL` or any result returned by the decode function irrespective of if the function
-/// succeeded or failed.
-///
-/// Inputs:
-/// - `community_msg` -- decoded result to free. This object is zeroed out on free and should no
-///   longer be used after it is freed.
-LIBSESSION_EXPORT void session_protocol_decode_for_community_free(
-        session_protocol_decoded_community_message* community_msg);
 
 #ifdef __cplusplus
 }

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -35,7 +35,7 @@ enum {
 /// Session Pro personalisation bytes for hashing; must match the personalisation strings in
 /// pro-wire-protocol.md §2 (proof) and §3 (signed requests).
 static const char SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION[]               = "ProGenerateProof";
-static const char SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION[]                  = "ProProof________";
+static const char SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION[]                  = "ProProof_v0_____";
 static const char SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION[]              = "ProAddPayment___";
 static const char SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION[] = "ProSetRefundReq_";
 static const char SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION[]              = "ProGetProDetReq_";

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -321,7 +321,7 @@ LIBSESSION_EXPORT bool session_protocol_pro_proof_verify_message(
 /// API: session_protocol/session_protocol_pro_proof_is_active
 ///
 /// Check if the Pro proof is currently entitled to Pro given the `ts` with respect to the
-/// proof's `expiry_unix_ts`
+/// proof's `expiry_at`
 ///
 /// Inputs:
 /// - `proof` -- Proof to verify
@@ -349,7 +349,7 @@ LIBSESSION_EXPORT bool session_protocol_pro_proof_is_active(
 ///   they are the original signatory of the proof.
 /// - `verify_pubkey_len` -- Length of the `verify_pubkey` should be 32 bytes
 ///   they are the original signatory of the proof.
-/// - `ts` -- Unix timestamp to compared against the embedded `expiry_unix_ts`
+/// - `ts` -- Unix timestamp to compared against the embedded `expiry_at`
 ///   to determine if the proof has expired or not
 /// - `signed_msg` -- Optionally set the payload to the message with the signature to verify if
 ///   the embedded `rotating_pubkey` in the proof signed the given message.

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -92,7 +92,7 @@ struct session_protocol_pro_proof {
     uint8_t version;
     bytes32 gen_index_hash;
     bytes32 rotating_pubkey;
-    uint64_t expiry_ts;
+    int64_t expiry_ts;
     bytes64 sig;
 };
 
@@ -331,7 +331,7 @@ LIBSESSION_EXPORT bool session_protocol_pro_proof_verify_message(
 /// Outputs:
 /// - `bool` -- True if expired, false otherwise
 LIBSESSION_EXPORT bool session_protocol_pro_proof_is_active(
-        session_protocol_pro_proof const* proof, uint64_t ts) NON_NULL_ARG(1);
+        session_protocol_pro_proof const* proof, int64_t ts) NON_NULL_ARG(1);
 
 /// API: session_protocol/session_protocol_pro_proof_status
 ///
@@ -363,7 +363,7 @@ LIBSESSION_EXPORT SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
         session_protocol_pro_proof const* proof,
         const uint8_t* verify_pubkey,
         size_t verify_pubkey_len,
-        uint64_t ts,
+        int64_t ts,
         OPTIONAL const session_protocol_pro_signed_message* signed_msg) NON_NULL_ARG(1, 2);
 
 /// API: session_protocol/session_protocol_get_pro_features_for_msg
@@ -828,7 +828,7 @@ LIBSESSION_EXPORT void session_protocol_decode_envelope_free(
 LIBSESSION_EXPORT session_protocol_decoded_community_message session_protocol_decode_for_community(
         const void* content_or_envelope_payload,
         size_t content_or_envelope_payload_len,
-        uint64_t ts,
+        int64_t ts,
         OPTIONAL const void* pro_backend_pubkey,
         size_t pro_backend_pubkey_len,
         OPTIONAL char* error,

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -75,8 +75,8 @@ class ProProof {
     /// Version of the proof set by the Session Pro Backend
     std::uint8_t version;
 
-    /// Hash of the generation index set by the Session Pro Backend
-    array_uc32 gen_index_hash;
+    /// Opaque revocation tag identifying this proof (from the Session Pro backend)
+    array_uc32 revocation_tag;
 
     /// The public key that the Session client registers their Session Pro entitlement under.
     /// Session clients must sign messages with this key along side the sending of this proof for
@@ -168,7 +168,7 @@ class ProProof {
     array_uc32 hash() const;
 
     bool operator==(const ProProof& other) const {
-        return version == other.version && gen_index_hash == other.gen_index_hash &&
+        return version == other.version && revocation_tag == other.revocation_tag &&
                rotating_pubkey == other.rotating_pubkey && expiry_unix_ts == other.expiry_unix_ts &&
                sig == other.sig;
     }

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -74,12 +74,14 @@ inline constexpr std::string_view GENERATE_PROOF_DOMAIN = "ProGenerateProof";
 inline constexpr std::string_view BUILD_PROOF_DOMAIN = "ProProof_v0_____";
 inline constexpr std::string_view ADD_PRO_PAYMENT_DOMAIN = "ProAddPayment___";
 inline constexpr std::string_view SET_PAYMENT_REFUND_REQUESTED_DOMAIN = "ProSetRefundReq_";
-inline constexpr std::string_view GET_PRO_DETAILS_DOMAIN = "ProGetProDetReq_";
+inline constexpr std::string_view GET_PRO_STATUS_DOMAIN = "ProGetProStatus_";
+inline constexpr std::string_view GET_PAYMENT_DETAILS_DOMAIN = "ProGetPayDetails";
 static_assert(GENERATE_PROOF_DOMAIN.size() == 16);
 static_assert(BUILD_PROOF_DOMAIN.size() == 16);
 static_assert(ADD_PRO_PAYMENT_DOMAIN.size() == 16);
 static_assert(SET_PAYMENT_REFUND_REQUESTED_DOMAIN.size() == 16);
-static_assert(GET_PRO_DETAILS_DOMAIN.size() == 16);
+static_assert(GET_PRO_STATUS_DOMAIN.size() == 16);
+static_assert(GET_PAYMENT_DETAILS_DOMAIN.size() == 16);
 
 enum ProProofVersion { ProProofVersion_v0 };
 

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -54,6 +54,19 @@
 
 namespace session {
 
+/// Maximum number of UTF-16 code points a standard (non-Pro) message can use; a longer message must
+/// activate the Session Pro higher-character-limit feature. (The C `SESSION_PROTOCOL_*` symbols
+/// point at these.)
+inline constexpr int STANDARD_CHARACTER_LIMIT = 2000;
+/// Maximum number of UTF-16 code points a Session Pro entitled user can send. Not used internally;
+/// provided to centralise the protocol definition for library consumers.
+inline constexpr int PRO_HIGHER_CHARACTER_LIMIT = 10000;
+/// Number of conversations a user without Session Pro can pin.
+inline constexpr int STANDARD_PINNED_CONVERSATION_LIMIT = 5;
+/// Byte multiple a community or 1o1 message `Content` is padded up to before wrapping in an
+/// envelope.
+inline constexpr int COMMUNITY_OR_1O1_MSG_PADDING = 160;
+
 // Session Pro 16-byte signing domain prefixes; each prefixes the Ed25519-signed message for its
 // endpoint (pro-wire-protocol.md §2 proof, §3 signed requests). ASCII, `_`-right-padded to 16
 // bytes (formerly the BLAKE2b personalisation, back when messages were pre-hashed).
@@ -356,9 +369,9 @@ struct DecodeEnvelopeKey {
 /// Determine the Pro features that are used in a given conversation message.
 ///
 /// Inputs:
-/// - `utf` -- the UTF8 string to count the number of codepoints in to determine if it needs the
+/// - `text` -- the UTF8 string to count the number of codepoints in to determine if it needs the
 ///   higher character limit available in Session Pro
-/// - `utf_size` -- the size of the message in UTF8 code units to determine if the message requires
+/// - `text_size` -- the size of the message in UTF8 code units to determine if the message requires
 ///   access to the higher character limit available in Session Pro
 ///
 /// Outputs:
@@ -369,16 +382,17 @@ struct DecodeEnvelopeKey {
 /// - `features` -- Feature flags suitable for writing directly into the protobuf
 ///   `ProMessage.messageFeatures`
 /// - `codepoint_count` -- Counts the number of unicode codepoints that were in the message.
-ProFeaturesForMsg pro_features_for_utf8(const char* utf, size_t utf_size);
+ProFeaturesForMsg pro_features_for_utf8(const char* text, size_t text_size);
 
 /// API: session_protocol/pro_features_for_utf16
 ///
 /// Determine the Pro features that are used in a given conversation message.
 ///
 /// Inputs:
-/// - `utf` -- the UTF16 string to count the number of codepoints in to determine if it needs the
+/// - `text` -- the UTF16 string to count the number of codepoints in to determine if it needs the
 ///   higher character limit available in Session Pro
-/// - `utf_size` -- the size of the message in UTF16 code units to determine if the message requires
+/// - `text_size` -- the size of the message in UTF16 code units to determine if the message
+/// requires
 ///   access to the higher character limit available in Session Pro
 ///
 /// Outputs:
@@ -389,7 +403,7 @@ ProFeaturesForMsg pro_features_for_utf8(const char* utf, size_t utf_size);
 /// - `bitset` -- Feature flags suitable for writing directly into the protobuf
 ///   `ProMessage.messageFeatures`
 /// - `codepoint_count` -- Counts the number of unicode codepoints that were in the message.
-ProFeaturesForMsg pro_features_for_utf16(const char16_t* utf, size_t utf_size);
+ProFeaturesForMsg pro_features_for_utf16(const char16_t* text, size_t text_size);
 
 /// API: session_protocol/pad_message
 ///

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -84,7 +84,7 @@ class ProProof {
     array_uc32 rotating_pubkey;
 
     /// Unix epoch timestamp to which this proof's entitlement to Session Pro features is valid to
-    sys_ms expiry_unix_ts;
+    sys_seconds expiry_unix_ts;
 
     /// Signature over the contents of the proof. It is signed by the Session Pro Backend key which
     /// is the entity responsible for issueing tamper-proof Sesison Pro certificates for Session
@@ -133,7 +133,7 @@ class ProProof {
     ///
     /// Outputs:
     /// - `bool` - True if proof is active (i.e. has not expired), false otherwise.
-    bool is_active(sys_ms unix_ts) const;
+    bool is_active(sys_seconds unix_ts) const;
 
     /// API: pro/Proof::status
     ///
@@ -159,7 +159,7 @@ class ProProof {
     ///   possible enum values. Otherwise this funtion can return all possible values.
     ProStatus status(
             std::span<const uint8_t> verify_pubkey,
-            sys_ms unix_ts,
+            sys_seconds unix_ts,
             const std::optional<ProSignedMessage>& signed_msg);
 
     /// API: pro/Proof::hash
@@ -637,7 +637,7 @@ DecodedEnvelope decode_envelope(
 ///   access to pro features if it's using any.
 DecodedCommunityMessage decode_for_community(
         std::span<const uint8_t> content_or_envelope_payload,
-        sys_ms unix_ts,
+        sys_seconds unix_ts,
         const array_uc32& pro_backend_pubkey);
 
 /// Initialiser the blake2b hashing context to generate 32 byte hashes for Session Pro features.

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -84,7 +84,7 @@ class ProProof {
     array_uc32 rotating_pubkey;
 
     /// Unix epoch timestamp to which this proof's entitlement to Session Pro features is valid to
-    sys_seconds expiry_unix_ts;
+    sys_seconds expiry_at;
 
     /// Signature over the contents of the proof. It is signed by the Session Pro Backend key which
     /// is the entity responsible for issueing tamper-proof Sesison Pro certificates for Session
@@ -125,10 +125,10 @@ class ProProof {
     /// API: pro/Proof::is_active
     ///
     /// Check if Pro proof is currently entitled to Pro given the `unix_ts` with respect to the
-    /// proof's `expiry_unix_ts`
+    /// proof's `expiry_at`
     ///
     /// Inputs:
-    /// - `unix_ts` -- Unix timestamp to compare against the embedded `expiry_unix_ts`
+    /// - `unix_ts` -- Unix timestamp to compare against the embedded `expiry_at`
     ///   to determine if the proof has expired or not
     ///
     /// Outputs:
@@ -148,7 +148,7 @@ class ProProof {
     /// Inputs:
     /// - `verify_pubkey` -- 32 byte Ed25519 public key of the corresponding secret key to check if
     ///   they are the original signatory of the proof.
-    /// - `unix_ts` -- Unix timestamp to compared against the embedded `expiry_unix_ts`
+    /// - `unix_ts` -- Unix timestamp to compared against the embedded `expiry_at`
     ///   to determine if the proof has expired or not
     /// - `signed_msg` -- Optionally set the payload to the message with the signature to verify if
     ///   the embedded `rotating_pubkey` in the proof signed the given message.
@@ -169,7 +169,7 @@ class ProProof {
 
     bool operator==(const ProProof& other) const {
         return version == other.version && revocation_tag == other.revocation_tag &&
-               rotating_pubkey == other.rotating_pubkey && expiry_unix_ts == other.expiry_unix_ts &&
+               rotating_pubkey == other.rotating_pubkey && expiry_at == other.expiry_at &&
                sig == other.sig;
     }
 };

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -54,6 +54,20 @@
 
 namespace session {
 
+// Session Pro 16-byte signing domain prefixes; each prefixes the Ed25519-signed message for its
+// endpoint (pro-wire-protocol.md §2 proof, §3 signed requests). ASCII, `_`-right-padded to 16
+// bytes (formerly the BLAKE2b personalisation, back when messages were pre-hashed).
+inline constexpr std::string_view GENERATE_PROOF_DOMAIN = "ProGenerateProof";
+inline constexpr std::string_view BUILD_PROOF_DOMAIN = "ProProof_v0_____";
+inline constexpr std::string_view ADD_PRO_PAYMENT_DOMAIN = "ProAddPayment___";
+inline constexpr std::string_view SET_PAYMENT_REFUND_REQUESTED_DOMAIN = "ProSetRefundReq_";
+inline constexpr std::string_view GET_PRO_DETAILS_DOMAIN = "ProGetProDetReq_";
+static_assert(GENERATE_PROOF_DOMAIN.size() == 16);
+static_assert(BUILD_PROOF_DOMAIN.size() == 16);
+static_assert(ADD_PRO_PAYMENT_DOMAIN.size() == 16);
+static_assert(SET_PAYMENT_REFUND_REQUESTED_DOMAIN.size() == 16);
+static_assert(GET_PRO_DETAILS_DOMAIN.size() == 16);
+
 enum ProProofVersion { ProProofVersion_v0 };
 
 enum class ProStatus {
@@ -162,10 +176,12 @@ class ProProof {
             sys_seconds unix_ts,
             const std::optional<ProSignedMessage>& signed_msg);
 
-    /// API: pro/Proof::hash
+    /// API: pro/Proof::signed_message
     ///
-    /// Create a 32-byte hash from the proof. This hash is the payload that is signed in the proof.
-    array_uc32 hash() const;
+    /// Build the exact byte string that the backend signs to produce this proof's `sig`, and that
+    /// verification reconstructs to check it (pro-wire-protocol.md §2, per §1.1). The message is
+    /// Ed25519-signed directly — there is no pre-hash.
+    std::vector<unsigned char> signed_message() const;
 
     bool operator==(const ProProof& other) const {
         return version == other.version && revocation_tag == other.revocation_tag &&
@@ -639,8 +655,4 @@ DecodedCommunityMessage decode_for_community(
         std::span<const uint8_t> content_or_envelope_payload,
         sys_seconds unix_ts,
         const array_uc32& pro_backend_pubkey);
-
-/// Initialiser the blake2b hashing context to generate 32 byte hashes for Session Pro features.
-void make_blake2b32_hasher(
-        struct crypto_generichash_blake2b_state* hasher, std::string_view personalization);
 }  // namespace session

--- a/include/session/types.h
+++ b/include/session/types.h
@@ -44,14 +44,6 @@ struct bytes64 {
     uint8_t data[64];
 };
 
-/// Basic bump allocating arena
-typedef struct arena_t arena_t;
-struct arena_t {
-    uint8_t* data;
-    size_t size;
-    size_t max;
-};
-
 /// A wrapper around snprintf that fixes a common bug in the value the printing function returns
 /// when a buffer is passed in. Irrespective of whether a buffer is passed in, snprintf is defined
 /// to return:
@@ -69,12 +61,6 @@ struct arena_t {
 /// NULL is passed in then this function returns the number of bytes actually needed to write the
 /// entire string (as per normal snprintf behaviour).
 int snprintf_clamped(char* buffer, size_t size, char const* fmt, ...);
-
-/// Allocate memory from the basic bump allocating arena. Returns a null pointer on failure.
-void* arena_alloc(arena_t* arena, size_t bytes);
-
-/// Create a string and allocate a copy of the data at pointer and size
-string8 arena_alloc_to_string8(arena_t* arena, void const* data, size_t size);
 
 #ifdef __cplusplus
 }

--- a/include/session/types.h
+++ b/include/session/types.h
@@ -21,14 +21,6 @@ struct span_u8 {
     size_t size;
 };
 
-typedef struct string8 string8;
-struct string8 {
-    char* data;
-    size_t size;
-};
-
-#define string8_literal(literal) {(char*)literal, sizeof(literal) - 1}
-
 typedef struct bytes32 bytes32;
 struct bytes32 {
     uint8_t data[32];

--- a/include/session/types.hpp
+++ b/include/session/types.hpp
@@ -38,9 +38,4 @@ span_u8 span_u8_alloc_or_throw(size_t size);
 /// is no longer needed.
 span_u8 span_u8_copy_or_throw(const void* data, size_t size);
 
-/// Allocate the string with the specific size. Throws on allocation failure.
-string8 string8_alloc_or_throw(size_t size);
-
-/// Create a string by copying the given pointer and size. Throws on allocation failure
-string8 string8_copy_or_throw(const void* data, size_t size);
 }  // namespace session

--- a/include/session/util.hpp
+++ b/include/session/util.hpp
@@ -142,6 +142,7 @@ inline std::chrono::sys_seconds sysclock_now_s() {
     return sysclock_now<std::chrono::seconds>();
 }
 using sys_ms = std::chrono::sys_time<std::chrono::milliseconds>;
+using sys_seconds = std::chrono::sys_seconds;
 // Shortcut for sysclock_now<std::chrono::sys_time<std::chrono::milliseconds>>();
 inline sys_ms sysclock_now_ms() {
     return sysclock_now<std::chrono::milliseconds>();

--- a/proto/SessionProtos.pb.cc
+++ b/proto/SessionProtos.pb.cc
@@ -483,7 +483,7 @@ PROTOBUF_CONSTEXPR ProProof::ProProof(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
   , /*decltype(_impl_._cached_size_)*/{}
-  , /*decltype(_impl_.genindexhash_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.revocationtag_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.rotatingpublickey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.sig_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.expiryunixts_)*/uint64_t{0u}
@@ -11002,7 +11002,7 @@ class ProProof::_Internal {
   static void set_has_version(HasBits* has_bits) {
     (*has_bits)[0] |= 16u;
   }
-  static void set_has_genindexhash(HasBits* has_bits) {
+  static void set_has_revocationtag(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
   static void set_has_rotatingpublickey(HasBits* has_bits) {
@@ -11028,19 +11028,19 @@ ProProof::ProProof(const ProProof& from)
   new (&_impl_) Impl_{
       decltype(_impl_._has_bits_){from._impl_._has_bits_}
     , /*decltype(_impl_._cached_size_)*/{}
-    , decltype(_impl_.genindexhash_){}
+    , decltype(_impl_.revocationtag_){}
     , decltype(_impl_.rotatingpublickey_){}
     , decltype(_impl_.sig_){}
     , decltype(_impl_.expiryunixts_){}
     , decltype(_impl_.version_){}};
 
   _internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
-  _impl_.genindexhash_.InitDefault();
+  _impl_.revocationtag_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.genindexhash_.Set("", GetArenaForAllocation());
+    _impl_.revocationtag_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (from._internal_has_genindexhash()) {
-    _this->_impl_.genindexhash_.Set(from._internal_genindexhash(), 
+  if (from._internal_has_revocationtag()) {
+    _this->_impl_.revocationtag_.Set(from._internal_revocationtag(), 
       _this->GetArenaForAllocation());
   }
   _impl_.rotatingpublickey_.InitDefault();
@@ -11072,15 +11072,15 @@ inline void ProProof::SharedCtor(
   new (&_impl_) Impl_{
       decltype(_impl_._has_bits_){}
     , /*decltype(_impl_._cached_size_)*/{}
-    , decltype(_impl_.genindexhash_){}
+    , decltype(_impl_.revocationtag_){}
     , decltype(_impl_.rotatingpublickey_){}
     , decltype(_impl_.sig_){}
     , decltype(_impl_.expiryunixts_){uint64_t{0u}}
     , decltype(_impl_.version_){0u}
   };
-  _impl_.genindexhash_.InitDefault();
+  _impl_.revocationtag_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.genindexhash_.Set("", GetArenaForAllocation());
+    _impl_.revocationtag_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   _impl_.rotatingpublickey_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
@@ -11103,7 +11103,7 @@ ProProof::~ProProof() {
 
 inline void ProProof::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  _impl_.genindexhash_.Destroy();
+  _impl_.revocationtag_.Destroy();
   _impl_.rotatingpublickey_.Destroy();
   _impl_.sig_.Destroy();
 }
@@ -11121,7 +11121,7 @@ void ProProof::Clear() {
   cached_has_bits = _impl_._has_bits_[0];
   if (cached_has_bits & 0x00000007u) {
     if (cached_has_bits & 0x00000001u) {
-      _impl_.genindexhash_.ClearNonDefaultToEmpty();
+      _impl_.revocationtag_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
       _impl_.rotatingpublickey_.ClearNonDefaultToEmpty();
@@ -11155,10 +11155,10 @@ const char* ProProof::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
         } else
           goto handle_unusual;
         continue;
-      // optional bytes genIndexHash = 2;
+      // optional bytes revocationTag = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
-          auto str = _internal_mutable_genindexhash();
+          auto str = _internal_mutable_revocationtag();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
         } else
@@ -11228,10 +11228,10 @@ uint8_t* ProProof::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(1, this->_internal_version(), target);
   }
 
-  // optional bytes genIndexHash = 2;
+  // optional bytes revocationTag = 2;
   if (cached_has_bits & 0x00000001u) {
     target = stream->WriteBytesMaybeAliased(
-        2, this->_internal_genindexhash(), target);
+        2, this->_internal_revocationtag(), target);
   }
 
   // optional bytes rotatingPublicKey = 3;
@@ -11270,11 +11270,11 @@ size_t ProProof::ByteSizeLong() const {
 
   cached_has_bits = _impl_._has_bits_[0];
   if (cached_has_bits & 0x0000001fu) {
-    // optional bytes genIndexHash = 2;
+    // optional bytes revocationTag = 2;
     if (cached_has_bits & 0x00000001u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
-          this->_internal_genindexhash());
+          this->_internal_revocationtag());
     }
 
     // optional bytes rotatingPublicKey = 3;
@@ -11326,7 +11326,7 @@ void ProProof::MergeFrom(const ProProof& from) {
   cached_has_bits = from._impl_._has_bits_[0];
   if (cached_has_bits & 0x0000001fu) {
     if (cached_has_bits & 0x00000001u) {
-      _this->_internal_set_genindexhash(from._internal_genindexhash());
+      _this->_internal_set_revocationtag(from._internal_revocationtag());
     }
     if (cached_has_bits & 0x00000002u) {
       _this->_internal_set_rotatingpublickey(from._internal_rotatingpublickey());
@@ -11363,8 +11363,8 @@ void ProProof::InternalSwap(ProProof* other) {
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.genindexhash_, lhs_arena,
-      &other->_impl_.genindexhash_, rhs_arena
+      &_impl_.revocationtag_, lhs_arena,
+      &other->_impl_.revocationtag_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.rotatingpublickey_, lhs_arena,

--- a/proto/SessionProtos.pb.h
+++ b/proto/SessionProtos.pb.h
@@ -6451,28 +6451,28 @@ class ProProof final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kGenIndexHashFieldNumber = 2,
+    kRevocationTagFieldNumber = 2,
     kRotatingPublicKeyFieldNumber = 3,
     kSigFieldNumber = 5,
     kExpiryUnixTsFieldNumber = 4,
     kVersionFieldNumber = 1,
   };
-  // optional bytes genIndexHash = 2;
-  bool has_genindexhash() const;
+  // optional bytes revocationTag = 2;
+  bool has_revocationtag() const;
   private:
-  bool _internal_has_genindexhash() const;
+  bool _internal_has_revocationtag() const;
   public:
-  void clear_genindexhash();
-  const std::string& genindexhash() const;
+  void clear_revocationtag();
+  const std::string& revocationtag() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_genindexhash(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_genindexhash();
-  PROTOBUF_NODISCARD std::string* release_genindexhash();
-  void set_allocated_genindexhash(std::string* genindexhash);
+  void set_revocationtag(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_revocationtag();
+  PROTOBUF_NODISCARD std::string* release_revocationtag();
+  void set_allocated_revocationtag(std::string* revocationtag);
   private:
-  const std::string& _internal_genindexhash() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_genindexhash(const std::string& value);
-  std::string* _internal_mutable_genindexhash();
+  const std::string& _internal_revocationtag() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_revocationtag(const std::string& value);
+  std::string* _internal_mutable_revocationtag();
   public:
 
   // optional bytes rotatingPublicKey = 3;
@@ -6547,7 +6547,7 @@ class ProProof final :
   struct Impl_ {
     ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr genindexhash_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr revocationtag_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rotatingpublickey_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr sig_;
     uint64_t expiryunixts_;
@@ -13565,72 +13565,72 @@ inline void ProProof::set_version(uint32_t value) {
   // @@protoc_insertion_point(field_set:SessionProtos.ProProof.version)
 }
 
-// optional bytes genIndexHash = 2;
-inline bool ProProof::_internal_has_genindexhash() const {
+// optional bytes revocationTag = 2;
+inline bool ProProof::_internal_has_revocationtag() const {
   bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
   return value;
 }
-inline bool ProProof::has_genindexhash() const {
-  return _internal_has_genindexhash();
+inline bool ProProof::has_revocationtag() const {
+  return _internal_has_revocationtag();
 }
-inline void ProProof::clear_genindexhash() {
-  _impl_.genindexhash_.ClearToEmpty();
+inline void ProProof::clear_revocationtag() {
+  _impl_.revocationtag_.ClearToEmpty();
   _impl_._has_bits_[0] &= ~0x00000001u;
 }
-inline const std::string& ProProof::genindexhash() const {
-  // @@protoc_insertion_point(field_get:SessionProtos.ProProof.genIndexHash)
-  return _internal_genindexhash();
+inline const std::string& ProProof::revocationtag() const {
+  // @@protoc_insertion_point(field_get:SessionProtos.ProProof.revocationTag)
+  return _internal_revocationtag();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void ProProof::set_genindexhash(ArgT0&& arg0, ArgT... args) {
+void ProProof::set_revocationtag(ArgT0&& arg0, ArgT... args) {
  _impl_._has_bits_[0] |= 0x00000001u;
- _impl_.genindexhash_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SessionProtos.ProProof.genIndexHash)
+ _impl_.revocationtag_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:SessionProtos.ProProof.revocationTag)
 }
-inline std::string* ProProof::mutable_genindexhash() {
-  std::string* _s = _internal_mutable_genindexhash();
-  // @@protoc_insertion_point(field_mutable:SessionProtos.ProProof.genIndexHash)
+inline std::string* ProProof::mutable_revocationtag() {
+  std::string* _s = _internal_mutable_revocationtag();
+  // @@protoc_insertion_point(field_mutable:SessionProtos.ProProof.revocationTag)
   return _s;
 }
-inline const std::string& ProProof::_internal_genindexhash() const {
-  return _impl_.genindexhash_.Get();
+inline const std::string& ProProof::_internal_revocationtag() const {
+  return _impl_.revocationtag_.Get();
 }
-inline void ProProof::_internal_set_genindexhash(const std::string& value) {
+inline void ProProof::_internal_set_revocationtag(const std::string& value) {
   _impl_._has_bits_[0] |= 0x00000001u;
-  _impl_.genindexhash_.Set(value, GetArenaForAllocation());
+  _impl_.revocationtag_.Set(value, GetArenaForAllocation());
 }
-inline std::string* ProProof::_internal_mutable_genindexhash() {
+inline std::string* ProProof::_internal_mutable_revocationtag() {
   _impl_._has_bits_[0] |= 0x00000001u;
-  return _impl_.genindexhash_.Mutable(GetArenaForAllocation());
+  return _impl_.revocationtag_.Mutable(GetArenaForAllocation());
 }
-inline std::string* ProProof::release_genindexhash() {
-  // @@protoc_insertion_point(field_release:SessionProtos.ProProof.genIndexHash)
-  if (!_internal_has_genindexhash()) {
+inline std::string* ProProof::release_revocationtag() {
+  // @@protoc_insertion_point(field_release:SessionProtos.ProProof.revocationTag)
+  if (!_internal_has_revocationtag()) {
     return nullptr;
   }
   _impl_._has_bits_[0] &= ~0x00000001u;
-  auto* p = _impl_.genindexhash_.Release();
+  auto* p = _impl_.revocationtag_.Release();
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.genindexhash_.IsDefault()) {
-    _impl_.genindexhash_.Set("", GetArenaForAllocation());
+  if (_impl_.revocationtag_.IsDefault()) {
+    _impl_.revocationtag_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   return p;
 }
-inline void ProProof::set_allocated_genindexhash(std::string* genindexhash) {
-  if (genindexhash != nullptr) {
+inline void ProProof::set_allocated_revocationtag(std::string* revocationtag) {
+  if (revocationtag != nullptr) {
     _impl_._has_bits_[0] |= 0x00000001u;
   } else {
     _impl_._has_bits_[0] &= ~0x00000001u;
   }
-  _impl_.genindexhash_.SetAllocated(genindexhash, GetArenaForAllocation());
+  _impl_.revocationtag_.SetAllocated(revocationtag, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.genindexhash_.IsDefault()) {
-    _impl_.genindexhash_.Set("", GetArenaForAllocation());
+  if (_impl_.revocationtag_.IsDefault()) {
+    _impl_.revocationtag_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SessionProtos.ProProof.genIndexHash)
+  // @@protoc_insertion_point(field_set_allocated:SessionProtos.ProProof.revocationTag)
 }
 
 // optional bytes rotatingPublicKey = 3;

--- a/proto/SessionProtos.proto
+++ b/proto/SessionProtos.proto
@@ -391,7 +391,7 @@ message GroupUpdateDeleteMemberContentMessage {
 
 message ProProof {
   optional uint32 version           = 1;
-  optional bytes  genIndexHash      = 2; // Opaque identifier of this proof produced by the Session Pro backend
+  optional bytes  revocationTag      = 2; // Opaque identifier of this proof produced by the Session Pro backend
   optional bytes  rotatingPublicKey = 3; // Public key whose signatures is authorised to entitle messages with Session Pro
   optional uint64 expiryUnixTs      = 4; // Epoch timestamps in milliseconds
   optional bytes  sig               = 5; // Signature produced by the Session Pro Backend signing over the hash of the proof

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -31,12 +31,12 @@ namespace convo {
     }
     one_to_one::one_to_one(const convo_info_volatile_1to1& c) :
             pro_base(c.last_read, c.unread), session_id{c.session_id, 66} {
-        if (c.has_pro_gen_index_hash) {
-            pro_gen_index_hash.emplace();
+        if (c.has_pro_revocation_tag) {
+            pro_revocation_tag.emplace();
             std::memcpy(
-                    pro_gen_index_hash->data(),
-                    c.pro_gen_index_hash.data,
-                    pro_gen_index_hash->size());
+                    pro_revocation_tag->data(),
+                    c.pro_revocation_tag.data,
+                    pro_revocation_tag->size());
             pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
         }
     }
@@ -46,16 +46,16 @@ namespace convo {
         c.last_read = last_read;
         c.unread = unread;
 
-        if (pro_gen_index_hash) {
-            c.has_pro_gen_index_hash = true;
+        if (pro_revocation_tag) {
+            c.has_pro_revocation_tag = true;
             std::memcpy(
-                    c.pro_gen_index_hash.data,
-                    pro_gen_index_hash->data(),
-                    pro_gen_index_hash->size());
+                    c.pro_revocation_tag.data,
+                    pro_revocation_tag->data(),
+                    pro_revocation_tag->size());
 
             c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
         } else {
-            c.has_pro_gen_index_hash = false;
+            c.has_pro_revocation_tag = false;
             c.pro_expiry_ts = 0;
         }
     }
@@ -126,12 +126,12 @@ namespace convo {
             pro_base(c.last_read, c.unread),
             blinded_session_id{c.blinded_session_id, 66},
             legacy_blinding{c.legacy_blinding} {
-        if (c.has_pro_gen_index_hash) {
-            pro_gen_index_hash.emplace();
+        if (c.has_pro_revocation_tag) {
+            pro_revocation_tag.emplace();
             std::memcpy(
-                    pro_gen_index_hash->data(),
-                    c.pro_gen_index_hash.data,
-                    pro_gen_index_hash->size());
+                    pro_revocation_tag->data(),
+                    c.pro_revocation_tag.data,
+                    pro_revocation_tag->size());
             pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
         }
     }
@@ -142,15 +142,15 @@ namespace convo {
         c.unread = unread;
         c.legacy_blinding = legacy_blinding;
 
-        if (pro_gen_index_hash) {
-            c.has_pro_gen_index_hash = true;
+        if (pro_revocation_tag) {
+            c.has_pro_revocation_tag = true;
             std::memcpy(
-                    c.pro_gen_index_hash.data,
-                    pro_gen_index_hash->data(),
-                    pro_gen_index_hash->size());
+                    c.pro_revocation_tag.data,
+                    pro_revocation_tag->data(),
+                    pro_revocation_tag->size());
             c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
         } else {
-            c.has_pro_gen_index_hash = false;
+            c.has_pro_revocation_tag = false;
             c.pro_expiry_ts = 0;
         }
     }
@@ -159,15 +159,15 @@ namespace convo {
         base::load(info_dict);
 
         auto pro_expiry = int_or_0(info_dict, "e");
-        std::optional<std::vector<unsigned char>> maybe_pro_gen_index_hash =
+        std::optional<std::vector<unsigned char>> maybe_pro_revocation_tag =
                 maybe_vector(info_dict, "g");
-        if (pro_expiry > 0 && maybe_pro_gen_index_hash && maybe_pro_gen_index_hash->size() == 32) {
+        if (pro_expiry > 0 && maybe_pro_revocation_tag && maybe_pro_revocation_tag->size() == 32) {
             pro_expiry_unix_ts = as_sys_seconds(pro_expiry);
-            pro_gen_index_hash.emplace();
+            pro_revocation_tag.emplace();
             std::memcpy(
-                    pro_gen_index_hash->data(),
-                    maybe_pro_gen_index_hash->data(),
-                    pro_gen_index_hash->size());
+                    pro_revocation_tag->data(),
+                    maybe_pro_revocation_tag->data(),
+                    pro_revocation_tag->size());
         }
     }
 
@@ -335,9 +335,9 @@ void ConvoInfoVolatile::set(const convo::one_to_one& c) {
     set_base(c, info);
 
     auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
-    if (pro_expiry > 0 && c.pro_gen_index_hash) {
+    if (pro_expiry > 0 && c.pro_revocation_tag) {
         set_nonzero_int(info["e"], pro_expiry);
-        info["g"] = *c.pro_gen_index_hash;
+        info["g"] = *c.pro_revocation_tag;
     }
 }
 
@@ -362,7 +362,7 @@ static bool is_stale(const C& c, std::chrono::system_clock::time_point cutoff) {
     if (c.unread)
         return false;
     if constexpr (std::derived_from<C, convo::pro_base>)
-        if (c.pro_gen_index_hash.has_value() && c.pro_expiry_unix_ts >= cutoff)
+        if (c.pro_revocation_tag.has_value() && c.pro_expiry_unix_ts >= cutoff)
             return false;
     return sys_ms{std::chrono::milliseconds{c.last_read}} < cutoff;
 }
@@ -441,9 +441,9 @@ void ConvoInfoVolatile::set(const convo::blinded_one_to_one& c) {
     set_nonzero_int(info["y"], c.legacy_blinding);
 
     auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
-    if (pro_expiry > 0 && c.pro_gen_index_hash) {
+    if (pro_expiry > 0 && c.pro_revocation_tag) {
         set_nonzero_int(info["e"], pro_expiry);
-        info["g"] = *c.pro_gen_index_hash;
+        info["g"] = *c.pro_revocation_tag;
     }
 }
 

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -37,7 +37,7 @@ namespace convo {
                     pro_revocation_tag->data(),
                     c.pro_revocation_tag.data,
                     pro_revocation_tag->size());
-            pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
+            pro_expiry_at = as_sys_seconds(c.pro_expiry_ts);
         }
     }
 
@@ -53,7 +53,7 @@ namespace convo {
                     pro_revocation_tag->data(),
                     pro_revocation_tag->size());
 
-            c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
+            c.pro_expiry_ts = epoch_seconds(pro_expiry_at);
         } else {
             c.has_pro_revocation_tag = false;
             c.pro_expiry_ts = 0;
@@ -132,7 +132,7 @@ namespace convo {
                     pro_revocation_tag->data(),
                     c.pro_revocation_tag.data,
                     pro_revocation_tag->size());
-            pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
+            pro_expiry_at = as_sys_seconds(c.pro_expiry_ts);
         }
     }
 
@@ -148,7 +148,7 @@ namespace convo {
                     c.pro_revocation_tag.data,
                     pro_revocation_tag->data(),
                     pro_revocation_tag->size());
-            c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
+            c.pro_expiry_ts = epoch_seconds(pro_expiry_at);
         } else {
             c.has_pro_revocation_tag = false;
             c.pro_expiry_ts = 0;
@@ -162,7 +162,7 @@ namespace convo {
         std::optional<std::vector<unsigned char>> maybe_pro_revocation_tag =
                 maybe_vector(info_dict, "g");
         if (pro_expiry > 0 && maybe_pro_revocation_tag && maybe_pro_revocation_tag->size() == 32) {
-            pro_expiry_unix_ts = as_sys_seconds(pro_expiry);
+            pro_expiry_at = as_sys_seconds(pro_expiry);
             pro_revocation_tag.emplace();
             std::memcpy(
                     pro_revocation_tag->data(),
@@ -334,7 +334,7 @@ void ConvoInfoVolatile::set(const convo::one_to_one& c) {
     auto info = data["1"][session_id_to_bytes(c.session_id)];
     set_base(c, info);
 
-    auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
+    auto pro_expiry = epoch_seconds(c.pro_expiry_at);
     if (pro_expiry > 0 && c.pro_revocation_tag) {
         set_nonzero_int(info["e"], pro_expiry);
         info["g"] = *c.pro_revocation_tag;
@@ -362,7 +362,7 @@ static bool is_stale(const C& c, std::chrono::system_clock::time_point cutoff) {
     if (c.unread)
         return false;
     if constexpr (std::derived_from<C, convo::pro_base>)
-        if (c.pro_revocation_tag.has_value() && c.pro_expiry_unix_ts >= cutoff)
+        if (c.pro_revocation_tag.has_value() && c.pro_expiry_at >= cutoff)
             return false;
     return sys_ms{std::chrono::milliseconds{c.last_read}} < cutoff;
 }
@@ -440,7 +440,7 @@ void ConvoInfoVolatile::set(const convo::blinded_one_to_one& c) {
 
     set_nonzero_int(info["y"], c.legacy_blinding);
 
-    auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
+    auto pro_expiry = epoch_seconds(c.pro_expiry_at);
     if (pro_expiry > 0 && c.pro_revocation_tag) {
         set_nonzero_int(info["e"], pro_expiry);
         info["g"] = *c.pro_revocation_tag;

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -37,8 +37,7 @@ namespace convo {
                     pro_gen_index_hash->data(),
                     c.pro_gen_index_hash.data,
                     pro_gen_index_hash->size());
-            pro_expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(c.pro_expiry_unix_ts_ms));
+            pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
         }
     }
 
@@ -54,10 +53,10 @@ namespace convo {
                     pro_gen_index_hash->data(),
                     pro_gen_index_hash->size());
 
-            c.pro_expiry_unix_ts_ms = epoch_ms(pro_expiry_unix_ts);
+            c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
         } else {
             c.has_pro_gen_index_hash = false;
-            c.pro_expiry_unix_ts_ms = 0;
+            c.pro_expiry_ts = 0;
         }
     }
 
@@ -133,8 +132,7 @@ namespace convo {
                     pro_gen_index_hash->data(),
                     c.pro_gen_index_hash.data,
                     pro_gen_index_hash->size());
-            pro_expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(c.pro_expiry_unix_ts_ms));
+            pro_expiry_unix_ts = as_sys_seconds(c.pro_expiry_ts);
         }
     }
 
@@ -150,10 +148,10 @@ namespace convo {
                     c.pro_gen_index_hash.data,
                     pro_gen_index_hash->data(),
                     pro_gen_index_hash->size());
-            c.pro_expiry_unix_ts_ms = epoch_ms(pro_expiry_unix_ts);
+            c.pro_expiry_ts = epoch_seconds(pro_expiry_unix_ts);
         } else {
             c.has_pro_gen_index_hash = false;
-            c.pro_expiry_unix_ts_ms = 0;
+            c.pro_expiry_ts = 0;
         }
     }
 
@@ -164,8 +162,7 @@ namespace convo {
         std::optional<std::vector<unsigned char>> maybe_pro_gen_index_hash =
                 maybe_vector(info_dict, "g");
         if (pro_expiry > 0 && maybe_pro_gen_index_hash && maybe_pro_gen_index_hash->size() == 32) {
-            pro_expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(pro_expiry));
+            pro_expiry_unix_ts = as_sys_seconds(pro_expiry);
             pro_gen_index_hash.emplace();
             std::memcpy(
                     pro_gen_index_hash->data(),
@@ -337,7 +334,7 @@ void ConvoInfoVolatile::set(const convo::one_to_one& c) {
     auto info = data["1"][session_id_to_bytes(c.session_id)];
     set_base(c, info);
 
-    auto pro_expiry = epoch_ms(c.pro_expiry_unix_ts);
+    auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
     if (pro_expiry > 0 && c.pro_gen_index_hash) {
         set_nonzero_int(info["e"], pro_expiry);
         info["g"] = *c.pro_gen_index_hash;
@@ -443,7 +440,7 @@ void ConvoInfoVolatile::set(const convo::blinded_one_to_one& c) {
 
     set_nonzero_int(info["y"], c.legacy_blinding);
 
-    auto pro_expiry = epoch_ms(c.pro_expiry_unix_ts);
+    auto pro_expiry = epoch_seconds(c.pro_expiry_unix_ts);
     if (pro_expiry > 0 && c.pro_gen_index_hash) {
         set_nonzero_int(info["e"], pro_expiry);
         info["g"] = *c.pro_gen_index_hash;

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -29,8 +29,7 @@ bool ProConfig::load(const dict& root) {
     {
         std::optional<uint8_t> version = maybe_int(*p, "@");
         std::optional<std::vector<unsigned char>> maybe_gen_index_hash = maybe_vector(*p, "g");
-        std::optional<std::chrono::sys_time<std::chrono::milliseconds>> maybe_expiry_unix_ts_ms =
-                maybe_ts_ms(*p, "e");
+        std::optional<std::chrono::sys_seconds> maybe_expiry = maybe_ts(*p, "e");
         std::optional<std::vector<unsigned char>> maybe_sig = maybe_vector(*p, "s");
 
         if (!version)
@@ -39,7 +38,7 @@ bool ProConfig::load(const dict& root) {
             return false;
         if (!maybe_sig || maybe_sig->size() != proof.sig.max_size())
             return false;
-        if (!maybe_expiry_unix_ts_ms)
+        if (!maybe_expiry)
             return false;
 
         proof.version = *version;
@@ -47,7 +46,7 @@ bool ProConfig::load(const dict& root) {
                 proof.gen_index_hash.data(),
                 maybe_gen_index_hash->data(),
                 proof.gen_index_hash.size());
-        proof.expiry_unix_ts = *maybe_expiry_unix_ts_ms;
+        proof.expiry_unix_ts = *maybe_expiry;
         std::memcpy(proof.sig.data(), maybe_sig->data(), proof.sig.size());
     }
 

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -46,7 +46,7 @@ bool ProConfig::load(const dict& root) {
                 proof.revocation_tag.data(),
                 maybe_revocation_tag->data(),
                 proof.revocation_tag.size());
-        proof.expiry_unix_ts = *maybe_expiry;
+        proof.expiry_at = *maybe_expiry;
         std::memcpy(proof.sig.data(), maybe_sig->data(), proof.sig.size());
     }
 

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -28,13 +28,13 @@ bool ProConfig::load(const dict& root) {
     // NOTE: Load into the proof object
     {
         std::optional<uint8_t> version = maybe_int(*p, "@");
-        std::optional<std::vector<unsigned char>> maybe_gen_index_hash = maybe_vector(*p, "g");
+        std::optional<std::vector<unsigned char>> maybe_revocation_tag = maybe_vector(*p, "g");
         std::optional<std::chrono::sys_seconds> maybe_expiry = maybe_ts(*p, "e");
         std::optional<std::vector<unsigned char>> maybe_sig = maybe_vector(*p, "s");
 
         if (!version)
             return false;
-        if (!maybe_gen_index_hash || maybe_gen_index_hash->size() != proof.gen_index_hash.size())
+        if (!maybe_revocation_tag || maybe_revocation_tag->size() != proof.revocation_tag.size())
             return false;
         if (!maybe_sig || maybe_sig->size() != proof.sig.max_size())
             return false;
@@ -43,9 +43,9 @@ bool ProConfig::load(const dict& root) {
 
         proof.version = *version;
         std::memcpy(
-                proof.gen_index_hash.data(),
-                maybe_gen_index_hash->data(),
-                proof.gen_index_hash.size());
+                proof.revocation_tag.data(),
+                maybe_revocation_tag->data(),
+                proof.revocation_tag.size());
         proof.expiry_unix_ts = *maybe_expiry;
         std::memcpy(proof.sig.data(), maybe_sig->data(), proof.sig.size());
     }

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -169,7 +169,7 @@ void UserProfile::set_pro_config(const ProConfig& pro) {
 
         auto proof_dict = root["p"];
         proof_dict["@"] = pro.proof.version;
-        proof_dict["g"] = pro.proof.gen_index_hash;
+        proof_dict["g"] = pro.proof.revocation_tag;
         proof_dict["e"] = epoch_seconds(pro.proof.expiry_unix_ts);
         proof_dict["s"] = pro.proof.sig;
 
@@ -333,14 +333,14 @@ LIBSESSION_C_API int64_t user_profile_get_profile_updated(config_object* conf) {
 
 LIBSESSION_C_API bool user_profile_get_pro_config(const config_object* conf, pro_pro_config* pro) {
     if (auto val = unbox<UserProfile>(conf)->get_pro_config(); val) {
-        static_assert(sizeof pro->proof.gen_index_hash == sizeof(val->proof.gen_index_hash));
+        static_assert(sizeof pro->proof.revocation_tag == sizeof(val->proof.revocation_tag));
         static_assert(sizeof pro->proof.rotating_pubkey == sizeof(val->proof.rotating_pubkey));
         static_assert(sizeof pro->proof.sig == sizeof(val->proof.sig));
         pro->proof.version = val->proof.version;
         std::memcpy(
-                pro->proof.gen_index_hash.data,
-                val->proof.gen_index_hash.data(),
-                val->proof.gen_index_hash.size());
+                pro->proof.revocation_tag.data,
+                val->proof.revocation_tag.data(),
+                val->proof.revocation_tag.size());
         std::memcpy(
                 pro->proof.rotating_pubkey.data,
                 val->proof.rotating_pubkey.data(),
@@ -360,9 +360,9 @@ LIBSESSION_C_API void user_profile_set_pro_config(config_object* conf, const pro
     ProConfig val = {};
     val.proof.version = pro->proof.version;
     std::memcpy(
-            val.proof.gen_index_hash.data(),
-            pro->proof.gen_index_hash.data,
-            val.proof.gen_index_hash.size());
+            val.proof.revocation_tag.data(),
+            pro->proof.revocation_tag.data,
+            val.proof.revocation_tag.size());
     std::memcpy(
             val.proof.rotating_pubkey.data(),
             pro->proof.rotating_pubkey.data,

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -170,7 +170,7 @@ void UserProfile::set_pro_config(const ProConfig& pro) {
         auto proof_dict = root["p"];
         proof_dict["@"] = pro.proof.version;
         proof_dict["g"] = pro.proof.gen_index_hash;
-        proof_dict["e"] = pro.proof.expiry_unix_ts.time_since_epoch().count();
+        proof_dict["e"] = epoch_seconds(pro.proof.expiry_unix_ts);
         proof_dict["s"] = pro.proof.sig;
 
         const auto target_timestamp =
@@ -212,17 +212,15 @@ void UserProfile::set_animated_avatar(bool enabled) {
     }
 }
 
-std::optional<std::chrono::sys_time<std::chrono::milliseconds>> UserProfile::get_pro_access_expiry()
-        const {
+std::optional<std::chrono::sys_seconds> UserProfile::get_pro_access_expiry() const {
     if (auto* E = data["E"].integer(); E)
-        return std::chrono::sys_time<std::chrono::milliseconds>{std::chrono::milliseconds{*E}};
+        return std::chrono::sys_seconds{std::chrono::seconds{*E}};
     return std::nullopt;
 }
 
-void UserProfile::set_pro_access_expiry(
-        std::optional<std::chrono::sys_time<std::chrono::milliseconds>> access_expiry_ts_ms) {
-    if (access_expiry_ts_ms)
-        data["E"] = epoch_ms(*access_expiry_ts_ms);
+void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> access_expiry_ts) {
+    if (access_expiry_ts)
+        data["E"] = epoch_seconds(*access_expiry_ts);
     else
         data["E"].erase();
 }
@@ -347,7 +345,7 @@ LIBSESSION_C_API bool user_profile_get_pro_config(const config_object* conf, pro
                 pro->proof.rotating_pubkey.data,
                 val->proof.rotating_pubkey.data(),
                 val->proof.rotating_pubkey.size());
-        pro->proof.expiry_unix_ts_ms = epoch_ms(val->proof.expiry_unix_ts);
+        pro->proof.expiry_ts = epoch_seconds(val->proof.expiry_unix_ts);
         std::memcpy(pro->proof.sig.data, val->proof.sig.data(), val->proof.sig.size());
         std::memcpy(
                 pro->rotating_privkey.data,
@@ -369,8 +367,7 @@ LIBSESSION_C_API void user_profile_set_pro_config(config_object* conf, const pro
             val.proof.rotating_pubkey.data(),
             pro->proof.rotating_pubkey.data,
             val.proof.rotating_pubkey.size());
-    val.proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-            std::chrono::milliseconds(pro->proof.expiry_unix_ts_ms));
+    val.proof.expiry_unix_ts = as_sys_seconds(pro->proof.expiry_ts);
     std::memcpy(val.proof.sig.data(), pro->proof.sig.data, val.proof.sig.size());
     std::memcpy(
             val.rotating_privkey.data(), pro->rotating_privkey.data, val.rotating_privkey.size());
@@ -396,20 +393,18 @@ LIBSESSION_C_API void user_profile_set_animated_avatar(config_object* conf, bool
     unbox<UserProfile>(conf)->set_animated_avatar(enabled);
 }
 
-LIBSESSION_C_API uint64_t user_profile_get_pro_access_expiry_ms(const config_object* conf) {
+LIBSESSION_C_API int64_t user_profile_get_pro_access_expiry(const config_object* conf) {
     if (auto expiry = unbox<UserProfile>(conf)->get_pro_access_expiry())
-        return epoch_ms(*expiry);
+        return epoch_seconds(*expiry);
     return 0;
 }
 
-LIBSESSION_C_API void user_profile_set_pro_access_expiry_ms(
-        config_object* conf, uint64_t access_expiry_ts_ms) {
-    if (access_expiry_ts_ms <= 0)
+LIBSESSION_C_API void user_profile_set_pro_access_expiry(
+        config_object* conf, int64_t access_expiry_ts) {
+    if (access_expiry_ts <= 0)
         unbox<UserProfile>(conf)->set_pro_access_expiry(std::nullopt);
     else
-        unbox<UserProfile>(conf)->set_pro_access_expiry(
-                std::chrono::sys_time<std::chrono::milliseconds>{
-                        std::chrono::milliseconds{access_expiry_ts_ms}});
+        unbox<UserProfile>(conf)->set_pro_access_expiry(as_sys_seconds(access_expiry_ts));
 }
 
 }  // extern "C"

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -170,7 +170,7 @@ void UserProfile::set_pro_config(const ProConfig& pro) {
         auto proof_dict = root["p"];
         proof_dict["@"] = pro.proof.version;
         proof_dict["g"] = pro.proof.revocation_tag;
-        proof_dict["e"] = epoch_seconds(pro.proof.expiry_unix_ts);
+        proof_dict["e"] = epoch_seconds(pro.proof.expiry_at);
         proof_dict["s"] = pro.proof.sig;
 
         const auto target_timestamp =
@@ -345,7 +345,7 @@ LIBSESSION_C_API bool user_profile_get_pro_config(const config_object* conf, pro
                 pro->proof.rotating_pubkey.data,
                 val->proof.rotating_pubkey.data(),
                 val->proof.rotating_pubkey.size());
-        pro->proof.expiry_ts = epoch_seconds(val->proof.expiry_unix_ts);
+        pro->proof.expiry_ts = epoch_seconds(val->proof.expiry_at);
         std::memcpy(pro->proof.sig.data, val->proof.sig.data(), val->proof.sig.size());
         std::memcpy(
                 pro->rotating_privkey.data,
@@ -367,7 +367,7 @@ LIBSESSION_C_API void user_profile_set_pro_config(config_object* conf, const pro
             val.proof.rotating_pubkey.data(),
             pro->proof.rotating_pubkey.data,
             val.proof.rotating_pubkey.size());
-    val.proof.expiry_unix_ts = as_sys_seconds(pro->proof.expiry_ts);
+    val.proof.expiry_at = as_sys_seconds(pro->proof.expiry_ts);
     std::memcpy(val.proof.sig.data(), pro->proof.sig.data, val.proof.sig.size());
     std::memcpy(
             val.rotating_privkey.data(), pro->rotating_privkey.data, val.rotating_privkey.size());

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -342,7 +342,7 @@ namespace {
         // Parse payload
         result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
         auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
-        result.proof.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
+        result.proof.expiry_at = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
         json_require_fixed_bytes_from_hex(
                 result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
         json_require_fixed_bytes_from_hex(
@@ -490,7 +490,7 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
         auto effective_ts = json_require<int64_t>(obj, "effective_ts", result.errors);
 
         ProRevocationItem item = {};
-        item.effective_unix_ts = as_sys_seconds(effective_ts);
+        item.effective_at = as_sys_seconds(effective_ts);
         json_require_fixed_bytes_from_hex(
                 obj, "revocation_tag", result.errors, item.revocation_tag);
 
@@ -604,11 +604,11 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
 
     result.payments_total = json_require<uint32_t>(result_obj, "payments_total", result.errors);
 
-    result.expiry_unix_ts = std::chrono::sys_seconds(
+    result.expiry_at = std::chrono::sys_seconds(
             std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", result.errors)));
     result.grace_period_duration = std::chrono::seconds(
             json_require<int64_t>(result_obj, "grace_period_duration", result.errors));
-    result.refund_requested_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(
+    result.refund_requested_at = std::chrono::sys_seconds(std::chrono::seconds(
             json_require<int64_t>(result_obj, "refund_requested_ts", result.errors)));
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
@@ -648,14 +648,14 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         item.payment_id = std::move(payment_id);
 
         item.auto_renewing = auto_renewing;
-        item.purchased_unix_ts = sys_ms_from_seconds(purchased_ts);
-        item.redeemed_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(redeemed_ts));
-        item.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
+        item.purchased_at = sys_ms_from_seconds(purchased_ts);
+        item.redeemed_at = std::chrono::sys_seconds(std::chrono::seconds(redeemed_ts));
+        item.expiry_at = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
         item.grace_period_duration = std::chrono::seconds(grace_period_duration);
-        item.platform_refund_expiry_unix_ts =
+        item.platform_refund_expiry_at =
                 std::chrono::sys_seconds(std::chrono::seconds(platform_refund_expiry_ts));
-        item.revoked_unix_ts = sys_ms_from_seconds(revoked_ts);
-        item.refund_requested_unix_ts =
+        item.revoked_at = sys_ms_from_seconds(revoked_ts);
+        item.refund_requested_at =
                 std::chrono::sys_seconds(std::chrono::seconds(refund_requested_ts));
 
         // Handle parsing result
@@ -674,13 +674,13 @@ namespace {
     array_uc32 refund_hash(
             std::span<const uint8_t> master_pubkey,
             std::chrono::sys_seconds unix_ts,
-            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
         // Must match the set-payment-refund-requested signed-request hash in pro-wire-protocol.md
         // §3.3 (+ §3.5 for payment_id).
         int64_t ts = epoch_seconds(unix_ts);
-        int64_t refund_requested_ts = epoch_seconds(refund_requested_unix_ts);
+        int64_t refund_requested_ts = epoch_seconds(refund_requested_at);
         array_uc32 hash = {};
         crypto_generichash_blake2b_state state = {};
         make_blake2b32_hasher(
@@ -708,11 +708,11 @@ namespace {
     array_uc64 refund_sign(
             const cleared_uc64& master,
             std::chrono::sys_seconds unix_ts,
-            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
         auto hash = refund_hash(
-                pubkey_of(master), unix_ts, refund_requested_unix_ts, provider_code, payment_id);
+                pubkey_of(master), unix_ts, refund_requested_at, provider_code, payment_id);
         array_uc64 sig = {};
         crypto_sign_ed25519_detached(sig.data(), nullptr, hash.data(), hash.size(), master.data());
         return sig;
@@ -721,14 +721,14 @@ namespace {
     std::string refund_body(
             std::span<const uint8_t> master_pubkey,
             std::chrono::sys_seconds unix_ts,
-            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::string_view payment_id,
             std::span<const uint8_t> master_sig) {
         return nlohmann::json{
                 {"master_pkey", oxenc::to_hex(master_pubkey)},
                 {"ts", epoch_seconds(unix_ts)},
-                {"refund_requested_ts", epoch_seconds(refund_requested_unix_ts)},
+                {"refund_requested_ts", epoch_seconds(refund_requested_at)},
                 {"payment_tx", {{"provider", provider_code}, {"payment_id", payment_id}}},
                 {"master_sig", oxenc::to_hex(master_sig)}}
                 .dump();
@@ -739,26 +739,26 @@ namespace {
 array_uc64 refund_sig(
         std::span<const uint8_t> master_privkey,
         std::chrono::sys_seconds unix_ts,
-        std::chrono::sys_seconds refund_requested_unix_ts,
+        std::chrono::sys_seconds refund_requested_at,
         std::string_view provider_code,
         std::span<const uint8_t> payment_id) {
     auto master = normalize_privkey(master_privkey, "master_privkey");
-    return refund_sign(master, unix_ts, refund_requested_unix_ts, provider_code, payment_id);
+    return refund_sign(master, unix_ts, refund_requested_at, provider_code, payment_id);
 }
 
 ProRequest refund_request(
         std::span<const uint8_t> master_privkey,
         std::chrono::sys_seconds unix_ts,
-        std::chrono::sys_seconds refund_requested_unix_ts,
+        std::chrono::sys_seconds refund_requested_at,
         std::string_view provider_code,
         std::span<const uint8_t> payment_id) {
     auto master = normalize_privkey(master_privkey, "master_privkey");
-    auto sig = refund_sign(master, unix_ts, refund_requested_unix_ts, provider_code, payment_id);
+    auto sig = refund_sign(master, unix_ts, refund_requested_at, provider_code, payment_id);
     return {set_refund_endpoint,
             refund_body(
                     pubkey_of(master),
                     unix_ts,
-                    refund_requested_unix_ts,
+                    refund_requested_at,
                     provider_code,
                     payment_id_view(payment_id),
                     sig)};
@@ -1034,7 +1034,7 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
     // error response returns the same struct just with different fields populated.
     result.header.status = cpp.status;
     result.proof.version = cpp.proof.version;
-    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_unix_ts);
+    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_at);
     std::memcpy(
             result.proof.revocation_tag.data,
             cpp.proof.revocation_tag.data(),
@@ -1118,7 +1118,7 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
         const ProRevocationItem& src = cpp.items[index];
         session_pro_backend_pro_revocation_item& dest = result.items[index];
         std::memcpy(dest.revocation_tag.data, src.revocation_tag.data(), src.revocation_tag.size());
-        dest.effective_ts = session::epoch_seconds(src.effective_unix_ts);
+        dest.effective_ts = session::epoch_seconds(src.effective_at);
     }
     return result;
 }
@@ -1168,9 +1168,9 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     result.items = (session_pro_backend_pro_payment_item*)arena_alloc(
             &arena, result.items_count * sizeof(*result.items));
     result.auto_renewing = cpp.auto_renewing;
-    result.expiry_ts = epoch_seconds(cpp.expiry_unix_ts);
+    result.expiry_ts = epoch_seconds(cpp.expiry_at);
     result.grace_period_duration = cpp.grace_period_duration.count();
-    result.refund_requested_ts = epoch_seconds(cpp.refund_requested_unix_ts);
+    result.refund_requested_ts = epoch_seconds(cpp.refund_requested_at);
     result.payments_total = cpp.payments_total;
 
     for (size_t index = 0; index < result.items_count; ++index) {
@@ -1184,13 +1184,13 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
                 sizeof(dest.payment_provider),
                 "%s",
                 src.payment_provider.c_str());
-        dest.purchased_ts = epoch_seconds_double(src.purchased_unix_ts);
-        dest.redeemed_ts = epoch_seconds(src.redeemed_unix_ts);
-        dest.expiry_ts = epoch_seconds(src.expiry_unix_ts);
+        dest.purchased_ts = epoch_seconds_double(src.purchased_at);
+        dest.redeemed_ts = epoch_seconds(src.redeemed_at);
+        dest.expiry_ts = epoch_seconds(src.expiry_at);
         dest.grace_period_duration = src.grace_period_duration.count();
-        dest.platform_refund_expiry_ts = epoch_seconds(src.platform_refund_expiry_unix_ts);
-        dest.revoked_ts = epoch_seconds_double(src.revoked_unix_ts);
-        dest.refund_requested_ts = epoch_seconds(src.refund_requested_unix_ts);
+        dest.platform_refund_expiry_ts = epoch_seconds(src.platform_refund_expiry_at);
+        dest.revoked_ts = epoch_seconds_double(src.revoked_at);
+        dest.refund_requested_ts = epoch_seconds(src.refund_requested_at);
 
         dest.payment_id_count = snprintf_clamped(
                 dest.payment_id, sizeof(dest.payment_id), "%s", src.payment_id.c_str());
@@ -1220,7 +1220,7 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
     std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
-    std::chrono::sys_seconds refund_requested_unix_ts =
+    std::chrono::sys_seconds refund_requested_at =
             session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
@@ -1230,7 +1230,7 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         auto sig = refund_sig(
                 master_span,
                 unix_ts,
-                refund_requested_unix_ts,
+                refund_requested_at,
                 payment_tx_provider_code,
                 payment_tx_payment_id_span);
         std::memcpy(result.sig.data, sig.data(), sig.size());

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -173,8 +173,9 @@ namespace {
     }
 
     // Public-key view (bytes [32, 64)) of a normalised 64-byte private key.
-    std::span<const uint8_t> pubkey_of(const cleared_uc64& priv64) {
-        return {priv64.data() + crypto_sign_ed25519_SEEDBYTES, crypto_sign_ed25519_PUBLICKEYBYTES};
+    std::span<const uint8_t, 32> pubkey_of(const cleared_uc64& priv64) {
+        return std::span<const uint8_t, 32>(
+                priv64.data() + crypto_sign_ed25519_SEEDBYTES, crypto_sign_ed25519_PUBLICKEYBYTES);
     }
 
     std::string_view payment_id_view(std::span<const uint8_t> payment_id) {
@@ -184,8 +185,8 @@ namespace {
     // --- add-payment (endpoint add_pro_payment) ---
 
     array_uc32 add_payment_hash(
-            std::span<const uint8_t> master_pubkey,
-            std::span<const uint8_t> rotating_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 32> rotating_pubkey,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
         // Must match the add-payment signed-request hash in pro-wire-protocol.md §3.2 (+ §3.5).
@@ -224,12 +225,12 @@ namespace {
     // Serialise an add-payment request body from already-computed fields (shared by the C++
     // add_payment_request and the C ..._request_build wrapper).
     std::string add_payment_body(
-            std::span<const uint8_t> master_pubkey,
-            std::span<const uint8_t> rotating_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 32> rotating_pubkey,
             std::string_view provider_code,
             std::string_view payment_id,
-            std::span<const uint8_t> master_sig,
-            std::span<const uint8_t> rotating_sig) {
+            std::span<const uint8_t, 64> master_sig,
+            std::span<const uint8_t, 64> rotating_sig) {
         return nlohmann::json{
                 {"master_pkey", oxenc::to_hex(master_pubkey)},
                 {"rotating_pkey", oxenc::to_hex(rotating_pubkey)},
@@ -374,8 +375,8 @@ namespace {
     // --- generate-proof (endpoint generate_pro_proof) ---
 
     array_uc32 generate_proof_hash(
-            std::span<const uint8_t> master_pubkey,
-            std::span<const uint8_t> rotating_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 32> rotating_pubkey,
             std::chrono::sys_seconds unix_ts) {
         // Must match the generate-proof signed-request hash in pro-wire-protocol.md §3.1.
         int64_t ts = epoch_seconds(unix_ts);
@@ -407,11 +408,11 @@ namespace {
     }
 
     std::string generate_proof_body(
-            std::span<const uint8_t> master_pubkey,
-            std::span<const uint8_t> rotating_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 32> rotating_pubkey,
             std::chrono::sys_seconds unix_ts,
-            std::span<const uint8_t> master_sig,
-            std::span<const uint8_t> rotating_sig) {
+            std::span<const uint8_t, 64> master_sig,
+            std::span<const uint8_t, 64> rotating_sig) {
         return nlohmann::json{
                 {"master_pkey", oxenc::to_hex(master_pubkey)},
                 {"rotating_pkey", oxenc::to_hex(rotating_pubkey)},
@@ -515,7 +516,7 @@ namespace {
     // --- payment-details / get-pro-details (endpoint get_pro_details) ---
 
     array_uc32 payment_details_hash(
-            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
             uint32_t count) {
         // Must match the get-pro-details signed-request hash in pro-wire-protocol.md §3.4.
@@ -546,8 +547,8 @@ namespace {
     }
 
     std::string payment_details_body(
-            std::span<const uint8_t> master_pubkey,
-            std::span<const uint8_t> master_sig,
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 64> master_sig,
             std::chrono::sys_seconds unix_ts,
             uint32_t count) {
         return nlohmann::json{
@@ -681,7 +682,7 @@ namespace {
     // --- refund / set-payment-refund-requested (endpoint set_payment_refund_requested) ---
 
     array_uc32 refund_hash(
-            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
             std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
@@ -728,12 +729,12 @@ namespace {
     }
 
     std::string refund_body(
-            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
             std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::string_view payment_id,
-            std::span<const uint8_t> master_sig) {
+            std::span<const uint8_t, 64> master_sig) {
         return nlohmann::json{
                 {"master_pkey", oxenc::to_hex(master_pubkey)},
                 {"ts", epoch_seconds(unix_ts)},
@@ -809,204 +810,90 @@ using namespace session::pro_backend;
 static string8 C_PARSE_ERROR_OUT_OF_MEMORY = STRING8_LIT("Ran out-of-memory creating C response");
 static string8 C_PARSE_ERROR_INVALID_ARGS = STRING8_LIT("One or more C arguments were NULL");
 
-LIBSESSION_C_API session_pro_backend_master_rotating_signatures
-session_pro_backend_add_pro_payment_request_build_sigs(
+// Wrap a freshly-built C++ ProRequest as an owning C session_pro_backend_request: heap-own the
+// ProRequest and point endpoint/content_type/data into it (zero copy). Released by
+// session_pro_backend_request_free.
+static session_pro_backend_request c_own_request(ProRequest&& req) {
+    auto* owned = new ProRequest(std::move(req));
+    session_pro_backend_request result = {};
+    result.internal_ = owned;
+    result.endpoint = owned->endpoint.data();
+    result.content_type = owned->content_type.data();
+    result.data = string8{owned->data.data(), owned->data.size()};
+    result.success = true;
+    return result;
+}
+
+// Fill a session_pro_backend_request's error buffer from a caught exception.
+static void c_request_error(session_pro_backend_request& result, const std::exception& e) {
+    const std::string& error = e.what();
+    result.error_count = snprintf_clamped(
+            result.error,
+            sizeof(result.error),
+            "%.*s",
+            static_cast<int>(error.size()),
+            error.data());
+}
+
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) {
-
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
-    std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    std::span<const uint8_t> payment_tx_payment_id_span(
-            payment_tx_payment_id, payment_tx_payment_id_len);
-
-    session_pro_backend_master_rotating_signatures result = {};
+        const char* provider_code,
+        const uint8_t* payment_id,
+        size_t payment_id_len) {
+    session_pro_backend_request result = {};
     try {
-        auto sigs = add_payment_sigs(
-                master_span, rotating_span, payment_tx_provider_code, payment_tx_payment_id_span);
-        std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
-        std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
-        result.success = true;
+        result = c_own_request(add_payment_request(
+                {master_privkey, master_privkey_len},
+                {rotating_privkey, rotating_privkey_len},
+                provider_code,
+                {payment_id, payment_id_len}));
     } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
+        c_request_error(result, e);
     }
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_master_rotating_signatures
-session_pro_backend_generate_pro_proof_request_build_sigs(
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
         int64_t ts) {
-
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
-    std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    session_pro_backend_master_rotating_signatures result = {};
-    try {
-        auto sigs = pro_proof_sigs(master_span, rotating_span, session::as_sys_seconds(ts));
-        std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
-        std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_signature
-session_pro_backend_get_pro_details_request_build_sig(
-        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count) {
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    session_pro_backend_signature result = {};
-    try {
-        auto sig = payment_details_sig(master_span, session::as_sys_seconds(ts), count);
-        std::memcpy(result.sig.data, sig.data(), sig.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
-        const session_pro_backend_add_pro_payment_request* request) {
     session_pro_backend_request result = {};
-    if (!request)
-        return result;
-
     try {
-        result.endpoint = add_payment_endpoint;
-        std::string json = add_payment_body(
-                {request->master_pkey.data, sizeof(request->master_pkey.data)},
-                {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
-                {request->payment_tx.provider_code, request->payment_tx.provider_code_count},
-                {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
-                {request->master_sig.data, sizeof(request->master_sig.data)},
-                {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
-        result.content_type = application_json;
-        result.data = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
+        result = c_own_request(pro_proof_request(
+                {master_privkey, master_privkey_len},
+                {rotating_privkey, rotating_privkey_len},
+                session::as_sys_seconds(ts)));
     } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
+        c_request_error(result, e);
     }
-
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
-        const session_pro_backend_generate_pro_proof_request* request) {
+LIBSESSION_C_API session_pro_backend_request
+session_pro_backend_get_pro_revocations_request_build(int64_t ticket) {
     session_pro_backend_request result = {};
-    if (!request)
-        return result;
-
     try {
-        result.endpoint = generate_proof_endpoint;
-        std::string json = generate_proof_body(
-                {request->master_pkey.data, sizeof(request->master_pkey.data)},
-                {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
-                session::as_sys_seconds(request->ts),
-                {request->master_sig.data, sizeof(request->master_sig.data)},
-                {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
-        result.content_type = application_json;
-        result.data = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
+        result = c_own_request(revocations_request(ticket));
     } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
+        c_request_error(result, e);
     }
-
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(
-        const session_pro_backend_get_pro_revocations_request* request) {
-    session_pro_backend_request result = {};
-    if (!request)
-        return result;
-
-    try {
-        result.endpoint = get_pro_revocations_endpoint;
-        std::string json = revocations_request(request->ticket).data;
-        result.content_type = application_json;
-        result.data = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-
     return result;
 }
 
 LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_details_request_build(
-        const session_pro_backend_get_pro_details_request* request) {
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count) {
     session_pro_backend_request result = {};
-    if (!request)
-        return result;
-
     try {
-        result.endpoint = get_pro_details_endpoint;
-        std::string json = payment_details_body(
-                {request->master_pkey.data, sizeof(request->master_pkey.data)},
-                {request->master_sig.data, sizeof(request->master_sig.data)},
-                session::as_sys_seconds(request->ts),
-                request->count);
-        result.content_type = application_json;
-        result.data = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
+        result = c_own_request(payment_details_request(
+                {master_privkey, master_privkey_len}, session::as_sys_seconds(ts), count));
     } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
+        c_request_error(result, e);
     }
-
     return result;
 }
 
@@ -1225,73 +1112,26 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     return result;
 }
 
-LIBSESSION_C_API
-session_pro_backend_signature session_pro_backend_set_payment_refund_requested_request_build_sigs(
+LIBSESSION_C_API session_pro_backend_request
+session_pro_backend_set_payment_refund_requested_request_build(
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) {
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
-    std::chrono::sys_seconds refund_requested_at = session::as_sys_seconds(refund_requested_ts);
-    std::span<const uint8_t> payment_tx_payment_id_span(
-            payment_tx_payment_id, payment_tx_payment_id_len);
-
-    session_pro_backend_signature result = {};
-    try {
-        auto sig = refund_sig(
-                master_span,
-                unix_ts,
-                refund_requested_at,
-                payment_tx_provider_code,
-                payment_tx_payment_id_span);
-        std::memcpy(result.sig.data, sig.data(), sig.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_request
-session_pro_backend_set_payment_refund_requested_request_build(
-        const session_pro_backend_set_payment_refund_requested_request* request) {
+        const char* provider_code,
+        const uint8_t* payment_id,
+        size_t payment_id_len) {
     session_pro_backend_request result = {};
-    if (!request)
-        return result;
-
     try {
-        result.endpoint = set_refund_endpoint;
-        std::string json = refund_body(
-                {request->master_pkey.data, sizeof(request->master_pkey.data)},
-                session::as_sys_seconds(request->ts),
-                session::as_sys_seconds(request->refund_requested_ts),
-                {request->payment_tx.provider_code, request->payment_tx.provider_code_count},
-                {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
-                {request->master_sig.data, sizeof(request->master_sig.data)});
-        result.content_type = application_json;
-        result.data = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
+        result = c_own_request(refund_request(
+                {master_privkey, master_privkey_len},
+                session::as_sys_seconds(ts),
+                session::as_sys_seconds(refund_requested_ts),
+                provider_code,
+                {payment_id, payment_id_len}));
     } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
+        c_request_error(result, e);
     }
-
     return result;
 }
 
@@ -1346,7 +1186,8 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
 
 LIBSESSION_C_API void session_pro_backend_request_free(session_pro_backend_request* request) {
     if (request) {
-        free(request->data.data);
+        if (request->internal_)
+            delete static_cast<ProRequest*>(request->internal_);
         *request = {};
     }
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -516,6 +516,10 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
 
     // Parse payload
     result.ticket = json_require<int64_t>(result_obj, "ticket", result.errors);
+    result.retry_in =
+            std::chrono::seconds(json_require<int64_t>(result_obj, "retry_in", result.errors));
+    result.retain_for =
+            std::chrono::seconds(json_require<int64_t>(result_obj, "retain_for", result.errors));
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
     result.items.reserve(array.size());
@@ -529,10 +533,10 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
 
         // Parse revocation item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto expiry_unix_ts = json_require<int64_t>(obj, "expiry_ts", result.errors);
+        auto effective_ts = json_require<int64_t>(obj, "effective_ts", result.errors);
 
         ProRevocationItem item = {};
-        item.expiry_unix_ts = as_sys_seconds(expiry_unix_ts);
+        item.effective_unix_ts = as_sys_seconds(effective_ts);
         json_require_fixed_bytes_from_hex(
                 obj, "revocation_tag", result.errors, item.revocation_tag);
 
@@ -1400,6 +1404,8 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
     result.header.status = cpp.status;
     result.ticket = cpp.ticket;
+    result.retry_in = cpp.retry_in.count();
+    result.retain_for = cpp.retain_for.count();
 
     // Copy errors
     result.header.errors_count = cpp.errors.size();
@@ -1419,7 +1425,7 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
         const ProRevocationItem& src = cpp.items[index];
         session_pro_backend_pro_revocation_item& dest = result.items[index];
         std::memcpy(dest.revocation_tag.data, src.revocation_tag.data(), src.revocation_tag.size());
-        dest.expiry_ts = session::epoch_seconds(src.expiry_unix_ts);
+        dest.effective_ts = session::epoch_seconds(src.effective_unix_ts);
     }
     return result;
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -1,4 +1,5 @@
 #include <fmt/core.h>
+#include <oxenc/endian.h>
 #include <oxenc/hex.h>
 #include <session/export.h>
 #include <session/pro_backend.h>
@@ -415,6 +416,7 @@ MasterRotatingSignatures GenerateProProofRequest::build_sigs(
             &state, master_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
     crypto_generichash_blake2b_update(
             &state, rotating_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
+    oxenc::host_to_little_inplace(unix_ts_ms);
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<uint8_t*>(&unix_ts_ms), sizeof(unix_ts_ms));
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
@@ -583,6 +585,8 @@ array_uc64 GetProDetailsRequest::build_sig(
             &state,
             master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
             crypto_sign_ed25519_PUBLICKEYBYTES);
+    oxenc::host_to_little_inplace(unix_ts_ms);
+    oxenc::host_to_little_inplace(count);
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<unsigned char*>(&unix_ts_ms), sizeof(unix_ts_ms));
     crypto_generichash_blake2b_update(
@@ -828,6 +832,8 @@ array_uc64 SetPaymentRefundRequestedRequest::build_sig(
     // Timestamps
     uint64_t unix_ts_ms = epoch_ms(unix_ts);
     uint64_t refund_requested_unix_ts_ms = epoch_ms(refund_requested_unix_ts);
+    oxenc::host_to_little_inplace(unix_ts_ms);
+    oxenc::host_to_little_inplace(refund_requested_unix_ts_ms);
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<const uint8_t*>(&unix_ts_ms), sizeof(unix_ts_ms));
     crypto_generichash_blake2b_update(

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -225,14 +225,13 @@ namespace {
             std::string_view payment_id,
             std::span<const uint8_t> master_sig,
             std::span<const uint8_t> rotating_sig) {
-        nlohmann::json j;
-        j["master_pkey"] = oxenc::to_hex(master_pubkey);
-        j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
-        j["payment_tx"]["provider"] = provider_code;
-        j["payment_tx"]["payment_id"] = payment_id;
-        j["master_sig"] = oxenc::to_hex(master_sig);
-        j["rotating_sig"] = oxenc::to_hex(rotating_sig);
-        return j.dump();
+        return nlohmann::json{
+                {"master_pkey", oxenc::to_hex(master_pubkey)},
+                {"rotating_pkey", oxenc::to_hex(rotating_pubkey)},
+                {"payment_tx", {{"provider", provider_code}, {"payment_id", payment_id}}},
+                {"master_sig", oxenc::to_hex(master_sig)},
+                {"rotating_sig", oxenc::to_hex(rotating_sig)}}
+                .dump();
     }
 
 }  // namespace
@@ -403,13 +402,13 @@ namespace {
             std::chrono::sys_seconds unix_ts,
             std::span<const uint8_t> master_sig,
             std::span<const uint8_t> rotating_sig) {
-        nlohmann::json j;
-        j["master_pkey"] = oxenc::to_hex(master_pubkey);
-        j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
-        j["ts"] = epoch_seconds(unix_ts);
-        j["master_sig"] = oxenc::to_hex(master_sig);
-        j["rotating_sig"] = oxenc::to_hex(rotating_sig);
-        return j.dump();
+        return nlohmann::json{
+                {"master_pkey", oxenc::to_hex(master_pubkey)},
+                {"rotating_pkey", oxenc::to_hex(rotating_pubkey)},
+                {"ts", epoch_seconds(unix_ts)},
+                {"master_sig", oxenc::to_hex(master_sig)},
+                {"rotating_sig", oxenc::to_hex(rotating_sig)}}
+                .dump();
     }
 
 }  // namespace
@@ -540,12 +539,12 @@ namespace {
             std::span<const uint8_t> master_sig,
             std::chrono::sys_seconds unix_ts,
             uint32_t count) {
-        nlohmann::json j;
-        j["master_pkey"] = oxenc::to_hex(master_pubkey);
-        j["master_sig"] = oxenc::to_hex(master_sig);
-        j["ts"] = epoch_seconds(unix_ts);
-        j["count"] = count;
-        return j.dump();
+        return nlohmann::json{
+                {"master_pkey", oxenc::to_hex(master_pubkey)},
+                {"master_sig", oxenc::to_hex(master_sig)},
+                {"ts", epoch_seconds(unix_ts)},
+                {"count", count}}
+                .dump();
     }
 
 }  // namespace
@@ -732,14 +731,13 @@ namespace {
             std::string_view provider_code,
             std::string_view payment_id,
             std::span<const uint8_t> master_sig) {
-        nlohmann::json j;
-        j["master_pkey"] = oxenc::to_hex(master_pubkey);
-        j["ts"] = epoch_seconds(unix_ts);
-        j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
-        j["payment_tx"]["provider"] = provider_code;
-        j["payment_tx"]["payment_id"] = payment_id;
-        j["master_sig"] = oxenc::to_hex(master_sig);
-        return j.dump();
+        return nlohmann::json{
+                {"master_pkey", oxenc::to_hex(master_pubkey)},
+                {"ts", epoch_seconds(unix_ts)},
+                {"refund_requested_ts", epoch_seconds(refund_requested_unix_ts)},
+                {"payment_tx", {{"provider", provider_code}, {"payment_id", payment_id}}},
+                {"master_sig", oxenc::to_hex(master_sig)}}
+                .dump();
     }
 
 }  // namespace

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -14,54 +14,6 @@
 #include <session/sodium_array.hpp>
 #include <session/types.hpp>
 
-// clang-format off
-const session_pro_backend_payment_provider_metadata SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA[SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT] = {
-    /*SESSION_PRO_PAYMENT_PROVIDER_NIL*/ {
-        .device                             = string8_literal(""),
-        .store                              = string8_literal(""),
-        .platform                           = string8_literal(""),
-        .platform_account                   = string8_literal(""),
-        .refund_platform_url                = string8_literal(""),
-        .refund_support_url                 = string8_literal(""),
-        .refund_status_url                  = string8_literal(""),
-        .update_subscription_url            = string8_literal(""),
-        .cancel_subscription_url            = string8_literal(""),
-    },
-    /*SESSION_PRO_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE*/ {
-        .device                             = string8_literal("Android"),
-        .store                              = string8_literal("Google Play Store"),
-        .platform                           = string8_literal("Google"),
-        .platform_account                   = string8_literal("Google account"),
-        .refund_platform_url                = string8_literal("https://support.google.com/googleplay/workflow/9813244?"),
-        .refund_support_url                 = string8_literal("https://getsession.org/android-refund"),
-        .refund_status_url                  = string8_literal("https://getsession.org/android-refund"),
-        .update_subscription_url            = string8_literal("https://play.google.com/store/account/subscriptions?package=network.loki.messenger"),
-        .cancel_subscription_url            = string8_literal("https://play.google.com/store/account/subscriptions?package=network.loki.messenger"),
-    },
-    /*SESSION_PRO_PAYMENT_PROVIDER_IOS_APP_STORE*/ {
-        .device                             = string8_literal("iOS"),
-        .store                              = string8_literal("Apple App Store"),
-        .platform                           = string8_literal("Apple"),
-        .platform_account                   = string8_literal("Apple account"),
-        .refund_platform_url                = string8_literal("https://support.apple.com/118223"),
-        .refund_support_url                 = string8_literal("https://support.apple.com/118223"),
-        .refund_status_url                  = string8_literal("https://support.apple.com/118224"),
-        .update_subscription_url            = string8_literal("https://apps.apple.com/account/subscriptions"),
-        .cancel_subscription_url            = string8_literal("https://account.apple.com/account/manage/section/subscriptions"),
-    },
-    /*SESSION_PRO_PAYMENT_PROVIDER_RANGEPROOF*/ {
-        .device                             = string8_literal(""),
-        .store                              = string8_literal(""),
-        .platform                           = string8_literal(""),
-        .platform_account                   = string8_literal(""),
-        .refund_platform_url                = string8_literal(""),
-        .refund_support_url                 = string8_literal(""),
-        .refund_status_url                  = string8_literal(""),
-        .update_subscription_url            = string8_literal(""),
-        .cancel_subscription_url            = string8_literal(""),
-    }
-};
-
 namespace {
 const nlohmann::json json_parse(std::string_view json, std::vector<std::string>& errors) {
     nlohmann::json result;
@@ -165,19 +117,8 @@ std::string AddProPaymentRequest::to_json() const {
     j["version"] = version;
     j["master_pkey"] = oxenc::to_hex(master_pkey);
     j["rotating_pkey"] = oxenc::to_hex(rotating_pkey);
-    j["payment_tx"]["provider"] = payment_tx.provider;
-    switch (payment_tx.provider) {
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: [[fallthrough]];
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT: break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF: {assert(false && "Unimplemented");} break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE: {
-            j["payment_tx"]["google_payment_token"] = payment_tx.payment_id;
-            j["payment_tx"]["google_order_id"] = payment_tx.order_id;
-        } break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_IOS_APP_STORE: {
-            j["payment_tx"]["apple_tx_id"] = payment_tx.payment_id;
-        } break;
-    }
+    j["payment_tx"]["provider"] = payment_tx.provider_code;
+    j["payment_tx"]["payment_id"] = payment_tx.payment_id;
     j["master_sig"] = oxenc::to_hex(master_sig);
     j["rotating_sig"] = oxenc::to_hex(rotating_sig);
     std::string result = j.dump();
@@ -188,9 +129,8 @@ MasterRotatingSignatures AddProPaymentRequest::build_sigs(
         std::uint8_t version,
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-        std::span<const uint8_t> payment_tx_payment_id,
-        std::span<const uint8_t> payment_tx_order_id) {
+        std::string_view payment_tx_provider_code,
+        std::span<const uint8_t> payment_tx_payment_id) {
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
         array_uc32 master_pubkey;
@@ -211,18 +151,6 @@ MasterRotatingSignatures AddProPaymentRequest::build_sigs(
         throw std::invalid_argument{"Invalid rotating_privkey: expected 32 or 64 bytes"};
     }
 
-    if (payment_tx_provider == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE) {
-        if (payment_tx_order_id.empty())
-            throw std::invalid_argument{
-                    "Invalid payment_tx_order_id: order ID must be set for a Google Play store "
-                    "payment"};
-    } else {
-        if (payment_tx_order_id.size())
-            throw std::invalid_argument{
-                    "Invalid payment_tx_order_id: order ID must not be set for an iOS App store "
-                    "payment"};
-    }
-
     // Hash components to 32 bytes, must match:
     //   https://github.com/Doy-lee/session-pro-backend/blob/5b66b1a4a64dc8da0225507019cbe21d7642fa78/backend.py#L171
     array_uc32 hash_to_sign = {};
@@ -241,18 +169,14 @@ MasterRotatingSignatures AddProPaymentRequest::build_sigs(
             rotating_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
             crypto_sign_ed25519_PUBLICKEYBYTES);
 
-    uint8_t provider_u8 = payment_tx_provider;
-    crypto_generichash_blake2b_update(&state, &provider_u8, sizeof(provider_u8));
+    crypto_generichash_blake2b_update(
+            &state,
+            reinterpret_cast<const uint8_t*>(payment_tx_provider_code.data()),
+            payment_tx_provider_code.size());
     crypto_generichash_blake2b_update(
             &state,
             reinterpret_cast<const uint8_t*>(payment_tx_payment_id.data()),
             payment_tx_payment_id.size());
-    if (payment_tx_order_id.size()) {
-        crypto_generichash_blake2b_update(
-                &state,
-                reinterpret_cast<const uint8_t*>(payment_tx_order_id.data()),
-                payment_tx_order_id.size());
-    }
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
 
     // Sign the hash with both keys
@@ -276,9 +200,8 @@ std::string AddProPaymentRequest::build_to_json(
         std::uint8_t version,
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-        std::span<const uint8_t> payment_tx_payment_id,
-        std::span<const uint8_t> payment_tx_order_id) {
+        std::string_view payment_tx_provider_code,
+        std::span<const uint8_t> payment_tx_payment_id) {
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
         array_uc32 master_pubkey;
@@ -303,9 +226,8 @@ std::string AddProPaymentRequest::build_to_json(
             version,
             master_privkey,
             rotating_privkey,
-            payment_tx_provider,
-            payment_tx_payment_id,
-            payment_tx_order_id);
+            payment_tx_provider_code,
+            payment_tx_payment_id);
 
     AddProPaymentRequest request = {};
     request.version = version;
@@ -317,12 +239,10 @@ std::string AddProPaymentRequest::build_to_json(
             request.rotating_pkey.data(),
             rotating_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
             crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.payment_tx.provider = payment_tx_provider;
+    request.payment_tx.provider_code = std::string(payment_tx_provider_code);
     request.payment_tx.payment_id = std::string(
             reinterpret_cast<const char*>(payment_tx_payment_id.data()),
             payment_tx_payment_id.size());
-    request.payment_tx.order_id = std::string(
-            reinterpret_cast<const char*>(payment_tx_order_id.data()), payment_tx_order_id.size());
     request.master_sig = sigs.master_sig;
     request.rotating_sig = sigs.rotating_sig;
 
@@ -354,8 +274,7 @@ AddProPaymentOrGenerateProProofResponse AddProPaymentOrGenerateProProofResponse:
     // Parse payload
     result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
     auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
-    result.proof.expiry_unix_ts = std::chrono::sys_seconds(
-            std::chrono::seconds(expiry_ts));
+    result.proof.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
     json_require_fixed_bytes_from_hex(
             result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
     json_require_fixed_bytes_from_hex(
@@ -418,8 +337,7 @@ MasterRotatingSignatures GenerateProProofRequest::build_sigs(
     crypto_generichash_blake2b_update(
             &state, rotating_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
     oxenc::host_to_little_inplace(ts);
-    crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
+    crypto_generichash_blake2b_update(&state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
 
     // Sign the hash with both keys
@@ -591,8 +509,7 @@ array_uc64 GetProDetailsRequest::build_sig(
             crypto_sign_ed25519_PUBLICKEYBYTES);
     oxenc::host_to_little_inplace(ts);
     oxenc::host_to_little_inplace(count);
-    crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
+    crypto_generichash_blake2b_update(&state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<unsigned char*>(&count), sizeof(count));
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
@@ -678,13 +595,12 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
 
     result.payments_total = json_require<uint32_t>(result_obj, "payments_total", result.errors);
 
-    result.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(
-            json_require<int64_t>(result_obj, "expiry_ts", result.errors)));
+    result.expiry_unix_ts = std::chrono::sys_seconds(
+            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", result.errors)));
     result.grace_period_duration = std::chrono::seconds(
             json_require<int64_t>(result_obj, "grace_period_duration", result.errors));
-    result.refund_requested_unix_ts = std::chrono::sys_seconds(
-            std::chrono::seconds(
-                    json_require<int64_t>(result_obj, "refund_requested_ts", result.errors)));
+    result.refund_requested_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(
+            json_require<int64_t>(result_obj, "refund_requested_ts", result.errors)));
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
     result.items.reserve(array.size());
@@ -699,8 +615,9 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
         // Parse payment item
         auto obj = it.get<nlohmann::json::object_t>();
         auto status = json_require<uint64_t>(obj, "status", result.errors);
-        auto plan = json_require<uint64_t>(obj, "plan", result.errors);
-        auto payment_provider = json_require<uint32_t>(obj, "payment_provider", result.errors);
+        auto plan = json_require<std::string>(obj, "plan", result.errors);
+        auto payment_provider = json_require<std::string>(obj, "payment_provider", result.errors);
+        auto payment_id = json_require<std::string>(obj, "payment_id", result.errors);
         auto auto_renewing = json_require<bool>(obj, "auto_renewing", result.errors);
         auto unredeemed_ts = json_require<int64_t>(obj, "unredeemed_ts", result.errors);
         auto redeemed_ts = json_require<int64_t>(obj, "redeemed_ts", result.errors);
@@ -710,8 +627,7 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
         auto platform_refund_expiry_ts =
                 json_require<int64_t>(obj, "platform_refund_expiry_ts", result.errors);
         auto revoked_ts = json_require<int64_t>(obj, "revoked_ts", result.errors);
-        auto refund_requested_ts =
-                json_require<int64_t>(obj, "refund_requested_ts", result.errors);
+        auto refund_requested_ts = json_require<int64_t>(obj, "refund_requested_ts", result.errors);
 
         ProPaymentItem item = {};
         if (status > SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL &&
@@ -721,72 +637,20 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
             result.errors.push_back(fmt::format("Status value was out-of-bounds: {}", status));
         }
 
-        if (plan > SESSION_PRO_BACKEND_PLAN_NIL && plan < SESSION_PRO_BACKEND_PLAN_COUNT) {
-            item.plan = static_cast<SESSION_PRO_BACKEND_PLAN>(plan);
-        } else {
-            result.errors.push_back(fmt::format("Plan value was out-of-bounds: {}", plan));
-        }
-
-        if (payment_provider > SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL &&
-            payment_provider < SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT) {
-            item.payment_provider =
-                    static_cast<SESSION_PRO_BACKEND_PAYMENT_PROVIDER>(payment_provider);
-            item.payment_provider_metadata =
-                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_METADATA + payment_provider;
-        } else {
-            result.errors.push_back(
-                    fmt::format("Payment provider value was out-of-bounds: {}", payment_provider));
-        }
+        item.plan = std::move(plan);
+        item.payment_provider = std::move(payment_provider);
+        item.payment_id = std::move(payment_id);
 
         item.auto_renewing = auto_renewing;
-        item.unredeemed_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(unredeemed_ts));
-        item.redeemed_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(redeemed_ts));
-        item.expiry_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(expiry_ts));
+        item.unredeemed_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(unredeemed_ts));
+        item.redeemed_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(redeemed_ts));
+        item.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
         item.grace_period_duration = std::chrono::seconds(grace_period_duration);
-        item.platform_refund_expiry_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(platform_refund_expiry_ts));
-        item.revoked_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(revoked_ts));
-        item.refund_requested_unix_ts = std::chrono::sys_seconds(
-                std::chrono::seconds(refund_requested_ts));
-        switch (item.payment_provider) {
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT: [[fallthrough]];
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: {
-            } break;
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE: {
-                item.google_payment_token =
-                        json_require<std::string>(obj, "google_payment_token", result.errors);
-                assert(item.google_payment_token.size() <
-                       sizeof(((session_pro_backend_pro_payment_item*)0)->google_payment_token));
-                item.google_order_id =
-                        json_require<std::string>(obj, "google_order_id", result.errors);
-                assert(item.google_order_id.size() <
-                       sizeof(((session_pro_backend_pro_payment_item*)0)->google_order_id));
-            } break;
-
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_IOS_APP_STORE: {
-                item.apple_original_tx_id =
-                        json_require<std::string>(obj, "apple_original_tx_id", result.errors);
-                item.apple_tx_id = json_require<std::string>(obj, "apple_tx_id", result.errors);
-                item.apple_web_line_order_id =
-                        json_require<std::string>(obj, "apple_web_line_order_id", result.errors);
-                assert(item.apple_original_tx_id.size() <
-                       sizeof(((session_pro_backend_pro_payment_item*)0)->apple_original_tx_id));
-                assert(item.apple_tx_id.size() <
-                       sizeof(((session_pro_backend_pro_payment_item*)0)->apple_tx_id));
-                assert(item.apple_web_line_order_id.size() <
-                       sizeof(((session_pro_backend_pro_payment_item*)0)->apple_web_line_order_id));
-            } break;
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF: {
-                item.rangeproof_order_id =
-                          json_require<std::string>(obj, "rangeproof_order_id", result.errors);
-                assert(item.rangeproof_order_id.size() <
-                        sizeof(((session_pro_backend_pro_payment_item*)0)->rangeproof_order_id));
-            } break;
-        }
+        item.platform_refund_expiry_unix_ts =
+                std::chrono::sys_seconds(std::chrono::seconds(platform_refund_expiry_ts));
+        item.revoked_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(revoked_ts));
+        item.refund_requested_unix_ts =
+                std::chrono::sys_seconds(std::chrono::seconds(refund_requested_ts));
 
         // Handle parsing result
         if (result.errors.size())
@@ -802,9 +666,8 @@ array_uc64 SetPaymentRefundRequestedRequest::build_sig(
         std::span<const uint8_t> master_privkey,
         std::chrono::sys_seconds unix_ts,
         std::chrono::sys_seconds refund_requested_unix_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-        std::span<const uint8_t> payment_tx_payment_id,
-        std::span<const uint8_t> payment_tx_order_id) {
+        std::string_view payment_tx_provider_code,
+        std::span<const uint8_t> payment_tx_payment_id) {
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
         array_uc32 master_pubkey;
@@ -834,26 +697,21 @@ array_uc64 SetPaymentRefundRequestedRequest::build_sig(
     int64_t refund_requested_ts = epoch_seconds(refund_requested_unix_ts);
     oxenc::host_to_little_inplace(ts);
     oxenc::host_to_little_inplace(refund_requested_ts);
-    crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
+    crypto_generichash_blake2b_update(&state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_update(
             &state,
             reinterpret_cast<const uint8_t*>(&refund_requested_ts),
             sizeof(refund_requested_ts));
 
     // Payment provider
-    uint8_t provider_u8 = payment_tx_provider;
-    crypto_generichash_blake2b_update(&state, &provider_u8, sizeof(provider_u8));
+    crypto_generichash_blake2b_update(
+            &state,
+            reinterpret_cast<const uint8_t*>(payment_tx_provider_code.data()),
+            payment_tx_provider_code.size());
     crypto_generichash_blake2b_update(
             &state,
             reinterpret_cast<const uint8_t*>(payment_tx_payment_id.data()),
             payment_tx_payment_id.size());
-    if (payment_tx_order_id.size()) {
-        crypto_generichash_blake2b_update(
-                &state,
-                reinterpret_cast<const uint8_t*>(payment_tx_order_id.data()),
-                payment_tx_order_id.size());
-    }
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
 
     // Sign the hash
@@ -872,17 +730,15 @@ std::string SetPaymentRefundRequestedRequest::build_to_json(
         std::span<const uint8_t> master_privkey,
         std::chrono::sys_seconds unix_ts,
         std::chrono::sys_seconds refund_requested_unix_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
-        std::span<const uint8_t> payment_tx_payment_id,
-        std::span<const uint8_t> payment_tx_order_id) {
+        std::string_view payment_tx_provider_code,
+        std::span<const uint8_t> payment_tx_payment_id) {
     array_uc64 sig = SetPaymentRefundRequestedRequest::build_sig(
             version,
             master_privkey,
             unix_ts,
             refund_requested_unix_ts,
-            payment_tx_provider,
-            payment_tx_payment_id,
-            payment_tx_order_id);
+            payment_tx_provider_code,
+            payment_tx_payment_id);
 
     SetPaymentRefundRequestedRequest request = {};
     request.version = version;
@@ -890,12 +746,10 @@ std::string SetPaymentRefundRequestedRequest::build_to_json(
             request.master_pkey.data(),
             master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
             crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.payment_tx.provider = payment_tx_provider;
+    request.payment_tx.provider_code = std::string(payment_tx_provider_code);
     request.payment_tx.payment_id = std::string(
             reinterpret_cast<const char*>(payment_tx_payment_id.data()),
             payment_tx_payment_id.size());
-    request.payment_tx.order_id = std::string(
-            reinterpret_cast<const char*>(payment_tx_order_id.data()), payment_tx_order_id.size());
     request.master_sig = sig;
     request.unix_ts = unix_ts;
     request.refund_requested_unix_ts = refund_requested_unix_ts;
@@ -910,19 +764,8 @@ std::string SetPaymentRefundRequestedRequest::to_json() const {
     j["master_pkey"] = oxenc::to_hex(master_pkey);
     j["ts"] = epoch_seconds(unix_ts);
     j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
-    j["payment_tx"]["provider"] = payment_tx.provider;
-    switch (payment_tx.provider) {
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: [[fallthrough]];
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT: break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF: {assert(false && "Unimplemented");} break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE: {
-            j["payment_tx"]["google_payment_token"] = payment_tx.payment_id;
-            j["payment_tx"]["google_order_id"] = payment_tx.order_id;
-        } break;
-        case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_IOS_APP_STORE: {
-            j["payment_tx"]["apple_tx_id"] = payment_tx.payment_id;
-        } break;
-    }
+    j["payment_tx"]["provider"] = payment_tx.provider_code;
+    j["payment_tx"]["payment_id"] = payment_tx.payment_id;
     j["master_sig"] = oxenc::to_hex(master_sig);
     std::string result = j.dump();
     return result;
@@ -971,18 +814,15 @@ session_pro_backend_add_pro_payment_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) {
+        size_t payment_tx_payment_id_len) {
 
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
-    std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
 
     session_pro_backend_master_rotating_signatures result = {};
     try {
@@ -990,9 +830,8 @@ session_pro_backend_add_pro_payment_request_build_sigs(
                 request_version,
                 master_span,
                 rotating_span,
-                payment_tx_provider,
-                payment_tx_payment_id_span,
-                payment_tx_order_id_span);
+                payment_tx_provider_code,
+                payment_tx_payment_id_span);
         std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
         std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
         result.success = true;
@@ -1015,11 +854,9 @@ session_pro_backend_add_pro_payment_request_build_to_json(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) {
+        size_t payment_tx_payment_id_len) {
     session_pro_backend_to_json result = {};
 
     // Convert C inputs to C++ types
@@ -1027,16 +864,14 @@ session_pro_backend_add_pro_payment_request_build_to_json(
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
-    std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
 
     try {
         std::string json = AddProPaymentRequest::build_to_json(
                 request_version,
                 master_span,
                 rotating_span,
-                payment_tx_provider,
-                payment_tx_payment_id_span,
-                payment_tx_order_id_span);
+                payment_tx_provider_code,
+                payment_tx_payment_id_span);
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1067,10 +902,7 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
     session_pro_backend_master_rotating_signatures result = {};
     try {
         auto sigs = GenerateProProofRequest::build_sigs(
-                request_version,
-                master_span,
-                rotating_span,
-                session::as_sys_seconds(ts));
+                request_version, master_span, rotating_span, session::as_sys_seconds(ts));
         std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
         std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
         result.success = true;
@@ -1100,10 +932,7 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
     session_pro_backend_to_json result = {};
     try {
         auto json = GenerateProProofRequest::build_to_json(
-                request_version,
-                master_span,
-                rotating_span,
-                session::as_sys_seconds(ts));
+                request_version, master_span, rotating_span, session::as_sys_seconds(ts));
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1183,11 +1012,10 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_add_pro_payment
     cpp.version = request->version;
     std::memcpy(cpp.master_pkey.data(), request->master_pkey.data, cpp.master_pkey.size());
     std::memcpy(cpp.rotating_pkey.data(), request->rotating_pkey.data, cpp.rotating_pkey.size());
-    cpp.payment_tx.provider = request->payment_tx.provider;
+    cpp.payment_tx.provider_code =
+            std::string(request->payment_tx.provider_code, request->payment_tx.provider_code_count);
     cpp.payment_tx.payment_id =
             std::string(request->payment_tx.payment_id, request->payment_tx.payment_id_count);
-    cpp.payment_tx.order_id =
-            std::string(request->payment_tx.order_id, request->payment_tx.order_id_count);
     std::memcpy(cpp.master_sig.data(), request->master_sig.data, cpp.master_sig.size());
     std::memcpy(cpp.rotating_sig.data(), request->rotating_sig.data, cpp.rotating_sig.size());
 
@@ -1483,9 +1311,12 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         const ProPaymentItem& src = cpp.items[index];
         session_pro_backend_pro_payment_item& dest = result.items[index];
         dest.status = src.status;
-        dest.plan = src.plan;
-        dest.payment_provider = src.payment_provider;
-        dest.payment_provider_metadata = src.payment_provider_metadata;
+        dest.plan_count = snprintf_clamped(dest.plan, sizeof(dest.plan), "%s", src.plan.c_str());
+        dest.payment_provider_count = snprintf_clamped(
+                dest.payment_provider,
+                sizeof(dest.payment_provider),
+                "%s",
+                src.payment_provider.c_str());
         dest.unredeemed_ts = epoch_seconds(src.unredeemed_unix_ts);
         dest.redeemed_ts = epoch_seconds(src.redeemed_unix_ts);
         dest.expiry_ts = epoch_seconds(src.expiry_unix_ts);
@@ -1494,41 +1325,8 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         dest.revoked_ts = epoch_seconds(src.revoked_unix_ts);
         dest.refund_requested_ts = epoch_seconds(src.refund_requested_unix_ts);
 
-        switch (dest.payment_provider) {
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: [[fallthrough]];
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT: break;
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE: {
-                dest.google_payment_token_count = snprintf_clamped(
-                        dest.google_payment_token,
-                        sizeof(dest.google_payment_token),
-                        src.google_payment_token.data());
-                dest.google_order_id_count = snprintf_clamped(
-                        dest.google_order_id,
-                        sizeof(dest.google_order_id),
-                        src.google_order_id.data());
-            } break;
-
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_IOS_APP_STORE: {
-                dest.apple_original_tx_id_count = snprintf_clamped(
-                        dest.apple_original_tx_id,
-                        sizeof(dest.apple_original_tx_id),
-                        src.apple_original_tx_id.data());
-                dest.apple_tx_id_count = snprintf_clamped(
-                        dest.apple_tx_id, sizeof(dest.apple_tx_id), src.apple_tx_id.data());
-                dest.apple_web_line_order_id_count = snprintf_clamped(
-                        dest.apple_web_line_order_id,
-                        sizeof(dest.apple_web_line_order_id),
-                        src.apple_web_line_order_id.data());
-            } break;
-            case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF: {
-                dest.rangeproof_order_id_count = snprintf_clamped(
-                        dest.rangeproof_order_id,
-                        sizeof(dest.rangeproof_order_id),
-                        src.rangeproof_order_id.data());
-
-            } break;
-
-        }
+        dest.payment_id_count = snprintf_clamped(
+                dest.payment_id, sizeof(dest.payment_id), "%s", src.payment_id.c_str());
     }
 
     // Copy errors
@@ -1550,11 +1348,9 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) {
+        size_t payment_tx_payment_id_len) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
     std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
@@ -1562,7 +1358,6 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
             session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
-    std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
 
     session_pro_backend_signature result = {};
     try {
@@ -1571,9 +1366,8 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
                 master_span,
                 unix_ts,
                 refund_requested_unix_ts,
-                payment_tx_provider,
-                payment_tx_payment_id_span,
-                payment_tx_order_id_span);
+                payment_tx_provider_code,
+                payment_tx_payment_id_span);
         std::memcpy(result.sig.data, sig.data(), sig.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1595,11 +1389,9 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
         size_t master_privkey_len,
         int64_t ts,
         int64_t refund_requested_ts,
-        SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
+        const char* payment_tx_provider_code,
         const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len,
-        const uint8_t* payment_tx_order_id,
-        size_t payment_tx_order_id_len) {
+        size_t payment_tx_payment_id_len) {
 
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
@@ -1608,7 +1400,6 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
             session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
-    std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
 
     session_pro_backend_to_json result = {};
     try {
@@ -1617,9 +1408,8 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
                 master_span,
                 unix_ts,
                 refund_requested_unix_ts,
-                payment_tx_provider,
-                payment_tx_payment_id_span,
-                payment_tx_order_id_span);
+                payment_tx_provider_code,
+                payment_tx_payment_id_span);
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1649,11 +1439,10 @@ session_pro_backend_set_payment_refund_requested_request_to_json(
     std::memcpy(cpp.master_sig.data(), request->master_sig.data, sizeof(request->master_sig.data));
     cpp.unix_ts = session::as_sys_seconds(request->ts);
     cpp.refund_requested_unix_ts = session::as_sys_seconds(request->refund_requested_ts);
-    cpp.payment_tx.provider = request->payment_tx.provider;
+    cpp.payment_tx.provider_code =
+            std::string(request->payment_tx.provider_code, request->payment_tx.provider_code_count);
     cpp.payment_tx.payment_id =
             std::string(request->payment_tx.payment_id, request->payment_tx.payment_id_count);
-    cpp.payment_tx.order_id =
-            std::string(request->payment_tx.order_id, request->payment_tx.order_id_count);
 
     try {
         std::string json = cpp.to_json();

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -1,9 +1,7 @@
 #include <fmt/core.h>
-#include <oxenc/endian.h>
 #include <oxenc/hex.h>
 #include <session/export.h>
 #include <session/pro_backend.h>
-#include <sodium/crypto_generichash_blake2b.h>
 #include <sodium/crypto_sign_ed25519.h>
 
 #include <chrono>
@@ -13,6 +11,9 @@
 #include <session/session_encrypt.hpp>
 #include <session/sodium_array.hpp>
 #include <session/types.hpp>
+#include <session/util.hpp>
+
+#include "pro_message.hpp"
 
 namespace {
 const nlohmann::json json_parse(std::string_view json, std::vector<std::string>& errors) {
@@ -160,33 +161,21 @@ namespace {
                 priv64.data() + crypto_sign_ed25519_SEEDBYTES, crypto_sign_ed25519_PUBLICKEYBYTES);
     }
 
-    std::string_view payment_id_view(std::span<const uint8_t> payment_id) {
-        return {reinterpret_cast<const char*>(payment_id.data()), payment_id.size()};
-    }
-
     // --- add-payment (endpoint add_pro_payment) ---
 
-    array_uc32 add_payment_hash(
+    std::vector<unsigned char> add_payment_message(
             std::span<const uint8_t, 32> master_pubkey,
             std::span<const uint8_t, 32> rotating_pubkey,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
-        // Must match the add-payment signed-request hash in pro-wire-protocol.md §3.2 (+ §3.5).
-        array_uc32 hash = {};
-        crypto_generichash_blake2b_state state = {};
-        make_blake2b32_hasher(
-                &state,
-                {SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION,
-                 sizeof(SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
-        crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
-        crypto_generichash_blake2b_update(
-                &state,
-                reinterpret_cast<const uint8_t*>(provider_code.data()),
-                provider_code.size());
-        crypto_generichash_blake2b_update(&state, payment_id.data(), payment_id.size());
-        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
-        return hash;
+        // Must match the add-payment signed-request message in pro-wire-protocol.md §3.2
+        // (+ §3.5), built per §1.1.
+        return session::pro::signed_message(
+                session::ADD_PRO_PAYMENT_DOMAIN,
+                master_pubkey,
+                rotating_pubkey,
+                provider_code,
+                to_string_view(payment_id));
     }
 
     MasterRotatingSignatures add_payment_sign(
@@ -194,13 +183,13 @@ namespace {
             const cleared_uc64& rotating,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
-        auto hash =
-                add_payment_hash(pubkey_of(master), pubkey_of(rotating), provider_code, payment_id);
+        auto msg = add_payment_message(
+                pubkey_of(master), pubkey_of(rotating), provider_code, payment_id);
         MasterRotatingSignatures result = {};
         crypto_sign_ed25519_detached(
-                result.master_sig.data(), nullptr, hash.data(), hash.size(), master.data());
+                result.master_sig.data(), nullptr, msg.data(), msg.size(), master.data());
         crypto_sign_ed25519_detached(
-                result.rotating_sig.data(), nullptr, hash.data(), hash.size(), rotating.data());
+                result.rotating_sig.data(), nullptr, msg.data(), msg.size(), rotating.data());
         return result;
     }
 
@@ -302,7 +291,7 @@ ProRequest add_payment_request(
                     pubkey_of(master),
                     pubkey_of(rotating),
                     provider_code,
-                    payment_id_view(payment_id),
+                    to_string_view(payment_id),
                     sigs.master_sig,
                     sigs.rotating_sig)};
 }
@@ -396,36 +385,29 @@ namespace {
 
     // --- generate-proof (endpoint generate_pro_proof) ---
 
-    array_uc32 generate_proof_hash(
+    std::vector<unsigned char> generate_proof_message(
             std::span<const uint8_t, 32> master_pubkey,
             std::span<const uint8_t, 32> rotating_pubkey,
             std::chrono::sys_seconds unix_ts) {
-        // Must match the generate-proof signed-request hash in pro-wire-protocol.md §3.1.
-        int64_t ts = epoch_seconds(unix_ts);
-        array_uc32 hash = {};
-        crypto_generichash_blake2b_state state = {};
-        make_blake2b32_hasher(
-                &state,
-                {SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION,
-                 sizeof(SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
-        crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
-        oxenc::host_to_little_inplace(ts);
-        crypto_generichash_blake2b_update(&state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
-        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
-        return hash;
+        // Must match the generate-proof signed-request message in pro-wire-protocol.md §3.1,
+        // built per §1.1.
+        return session::pro::signed_message(
+                session::GENERATE_PROOF_DOMAIN,
+                master_pubkey,
+                rotating_pubkey,
+                epoch_seconds(unix_ts));
     }
 
     MasterRotatingSignatures generate_proof_sign(
             const cleared_uc64& master,
             const cleared_uc64& rotating,
             std::chrono::sys_seconds unix_ts) {
-        auto hash = generate_proof_hash(pubkey_of(master), pubkey_of(rotating), unix_ts);
+        auto msg = generate_proof_message(pubkey_of(master), pubkey_of(rotating), unix_ts);
         MasterRotatingSignatures result = {};
         crypto_sign_ed25519_detached(
-                result.master_sig.data(), nullptr, hash.data(), hash.size(), master.data());
+                result.master_sig.data(), nullptr, msg.data(), msg.size(), master.data());
         crypto_sign_ed25519_detached(
-                result.rotating_sig.data(), nullptr, hash.data(), hash.size(), rotating.data());
+                result.rotating_sig.data(), nullptr, msg.data(), msg.size(), rotating.data());
         return result;
     }
 
@@ -526,34 +508,21 @@ namespace {
 
     // --- payment-details / get-pro-details (endpoint get_pro_details) ---
 
-    array_uc32 payment_details_hash(
+    std::vector<unsigned char> payment_details_message(
             std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
-            uint32_t count) {
-        // Must match the get-pro-details signed-request hash in pro-wire-protocol.md §3.4.
-        int64_t ts = epoch_seconds(unix_ts);
-        array_uc32 hash = {};
-        crypto_generichash_blake2b_state state = {};
-        make_blake2b32_hasher(
-                &state,
-                {SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION,
-                 sizeof(SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
-        oxenc::host_to_little_inplace(ts);
-        oxenc::host_to_little_inplace(count);
-        crypto_generichash_blake2b_update(
-                &state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
-        crypto_generichash_blake2b_update(
-                &state, reinterpret_cast<unsigned char*>(&count), sizeof(count));
-        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
-        return hash;
+            int64_t count) {
+        // Must match the get-pro-details signed-request message in pro-wire-protocol.md §3.4,
+        // built per §1.1. `count` is a signed integer (a decimal-ASCII -1 requests "all").
+        return session::pro::signed_message(
+                session::GET_PRO_DETAILS_DOMAIN, master_pubkey, epoch_seconds(unix_ts), count);
     }
 
     array_uc64 payment_details_sign(
             const cleared_uc64& master, std::chrono::sys_seconds unix_ts, uint32_t count) {
-        auto hash = payment_details_hash(pubkey_of(master), unix_ts, count);
+        auto msg = payment_details_message(pubkey_of(master), unix_ts, count);
         array_uc64 sig = {};
-        crypto_sign_ed25519_detached(sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        crypto_sign_ed25519_detached(sig.data(), nullptr, msg.data(), msg.size(), master.data());
         return sig;
     }
 
@@ -684,38 +653,21 @@ namespace {
 
     // --- refund / set-payment-refund-requested (endpoint set_payment_refund_requested) ---
 
-    array_uc32 refund_hash(
+    std::vector<unsigned char> refund_message(
             std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
             std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
-        // Must match the set-payment-refund-requested signed-request hash in pro-wire-protocol.md
-        // §3.3 (+ §3.5 for payment_id).
-        int64_t ts = epoch_seconds(unix_ts);
-        int64_t refund_requested_ts = epoch_seconds(refund_requested_at);
-        array_uc32 hash = {};
-        crypto_generichash_blake2b_state state = {};
-        make_blake2b32_hasher(
-                &state,
-                {SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION,
-                 sizeof(SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
-        oxenc::host_to_little_inplace(ts);
-        oxenc::host_to_little_inplace(refund_requested_ts);
-        crypto_generichash_blake2b_update(
-                &state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
-        crypto_generichash_blake2b_update(
-                &state,
-                reinterpret_cast<const uint8_t*>(&refund_requested_ts),
-                sizeof(refund_requested_ts));
-        crypto_generichash_blake2b_update(
-                &state,
-                reinterpret_cast<const uint8_t*>(provider_code.data()),
-                provider_code.size());
-        crypto_generichash_blake2b_update(&state, payment_id.data(), payment_id.size());
-        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
-        return hash;
+        // Must match the set-payment-refund-requested signed-request message in
+        // pro-wire-protocol.md §3.3 (+ §3.5 for payment_id), built per §1.1.
+        return session::pro::signed_message(
+                session::SET_PAYMENT_REFUND_REQUESTED_DOMAIN,
+                master_pubkey,
+                epoch_seconds(unix_ts),
+                epoch_seconds(refund_requested_at),
+                provider_code,
+                to_string_view(payment_id));
     }
 
     array_uc64 refund_sign(
@@ -724,10 +676,10 @@ namespace {
             std::chrono::sys_seconds refund_requested_at,
             std::string_view provider_code,
             std::span<const uint8_t> payment_id) {
-        auto hash = refund_hash(
+        auto msg = refund_message(
                 pubkey_of(master), unix_ts, refund_requested_at, provider_code, payment_id);
         array_uc64 sig = {};
-        crypto_sign_ed25519_detached(sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        crypto_sign_ed25519_detached(sig.data(), nullptr, msg.data(), msg.size(), master.data());
         return sig;
     }
 
@@ -774,7 +726,7 @@ ProRequest refund_request(
                     unix_ts,
                     refund_requested_at,
                     provider_code,
-                    payment_id_view(payment_id),
+                    to_string_view(payment_id),
                     sig)};
 }
 

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -4,6 +4,7 @@
 #include <session/pro_backend.h>
 #include <sodium/crypto_sign_ed25519.h>
 
+#include <charconv>
 #include <chrono>
 #include <concepts>
 #include <nlohmann/json.hpp>
@@ -272,6 +273,36 @@ std::span<const std::string_view> visible_platforms() {
             SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
             SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE};
     return platforms;
+}
+
+std::optional<ProPlanPeriod> parse_plan_period(std::string_view code) {
+    // pro-wire-protocol.md §1 / Delta #14: closed grammar. "lifetime", or "<N><unit>" with N a
+    // positive integer (no leading zeros) and unit one of s/d/w/m/y. Single-unit only.
+    if (code == "lifetime")
+        return ProPlanPeriod{0, ProPlanUnit::lifetime};
+
+    if (code.size() < 2)
+        return std::nullopt;
+    ProPlanUnit unit;
+    switch (code.back()) {
+        case 's': unit = ProPlanUnit::second; break;
+        case 'd': unit = ProPlanUnit::day; break;
+        case 'w': unit = ProPlanUnit::week; break;
+        case 'm': unit = ProPlanUnit::month; break;
+        case 'y': unit = ProPlanUnit::year; break;
+        default: return std::nullopt;
+    }
+
+    // N = [1-9][0-9]*: reject a leading zero (or sign) up front, then require from_chars to consume
+    // every remaining digit into a positive int (this also rejects overflow).
+    std::string_view digits = code.substr(0, code.size() - 1);
+    if (digits.empty() || digits.front() < '1' || digits.front() > '9')
+        return std::nullopt;
+    int count = 0;
+    auto [ptr, ec] = std::from_chars(digits.data(), digits.data() + digits.size(), count);
+    if (ec != std::errc{} || ptr != digits.data() + digits.size())
+        return std::nullopt;
+    return ProPlanPeriod{count, unit};
 }
 
 LIBSESSION_C_API const char* const* session_pro_backend_visible_platforms(size_t* count) {
@@ -625,7 +656,11 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         // Parse payment item
         auto obj = it.get<nlohmann::json::object_t>();
         auto status = json_require<std::string>(obj, "status", errs);
-        auto plan = json_require<std::string>(obj, "plan", errs);
+        auto plan_code = json_require<std::string>(obj, "plan", errs);
+        auto plan = parse_plan_period(plan_code);
+        if (!plan)
+            errs.push_back(
+                    fmt::format("'plan' is not a recognized billing-period code: '{}'", plan_code));
         auto payment_provider = json_require<std::string>(obj, "payment_provider", errs);
         auto payment_id = json_require<std::string>(obj, "payment_id", errs);
         auto auto_renewing = json_require<bool>(obj, "auto_renewing", errs);
@@ -643,7 +678,8 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
 
         ProPaymentItem item = {};
         item.status = std::move(status);
-        item.plan = std::move(plan);
+        if (plan)
+            item.plan = *plan;
         item.payment_provider = std::move(payment_provider);
         item.payment_id = std::move(payment_id);
 
@@ -1066,7 +1102,8 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         session_pro_backend_pro_payment_item& dest = result.items[index];
         dest.status_count =
                 snprintf_clamped(dest.status, sizeof(dest.status), "%s", src.status.c_str());
-        dest.plan_count = snprintf_clamped(dest.plan, sizeof(dest.plan), "%s", src.plan.c_str());
+        dest.plan_count = src.plan.count;
+        dest.plan_unit = static_cast<SESSION_PRO_BACKEND_PLAN_UNIT>(src.plan.unit);
         dest.payment_provider_count = snprintf_clamped(
                 dest.payment_provider,
                 sizeof(dest.payment_provider),

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -151,14 +151,6 @@ namespace {
     constexpr char get_pro_revocations_endpoint[] = "get_pro_revocations";
     constexpr char set_refund_endpoint[] = "set_payment_refund_requested";
 
-    // Wire-format version emitted per request type (library-owned; not caller-settable). Kept
-    // independent so a future bump of one request type doesn't drag the others along.
-    constexpr uint8_t add_payment_version = 0;
-    constexpr uint8_t generate_proof_version = 0;
-    constexpr uint8_t get_pro_details_version = 0;
-    constexpr uint8_t get_pro_revocations_version = 0;
-    constexpr uint8_t set_refund_version = 0;
-
     // Normalise an Ed25519 private key to libsodium's 64-byte form (seed(32) || pubkey(32)): a
     // 32-byte seed is expanded, a 64-byte key copied, anything else throws. The public key is then
     // available at bytes [32, 64) so callers never need a second derivation.
@@ -198,8 +190,6 @@ namespace {
                 &state,
                 {SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION,
                  sizeof(SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(
-                &state, &add_payment_version, sizeof(add_payment_version));
         crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
         crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
         crypto_generichash_blake2b_update(
@@ -236,7 +226,6 @@ namespace {
             std::span<const uint8_t> master_sig,
             std::span<const uint8_t> rotating_sig) {
         nlohmann::json j;
-        j["version"] = add_payment_version;
         j["master_pkey"] = oxenc::to_hex(master_pubkey);
         j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
         j["payment_tx"]["provider"] = provider_code;
@@ -387,8 +376,6 @@ namespace {
                 &state,
                 {SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION,
                  sizeof(SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(
-                &state, &generate_proof_version, sizeof(generate_proof_version));
         crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
         crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
         oxenc::host_to_little_inplace(ts);
@@ -417,7 +404,6 @@ namespace {
             std::span<const uint8_t> master_sig,
             std::span<const uint8_t> rotating_sig) {
         nlohmann::json j;
-        j["version"] = generate_proof_version;
         j["master_pkey"] = oxenc::to_hex(master_pubkey);
         j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
         j["ts"] = epoch_seconds(unix_ts);
@@ -455,7 +441,6 @@ ProRequest pro_proof_request(
 
 ProRequest revocations_request(std::int64_t ticket) {
     nlohmann::json j;
-    j["version"] = get_pro_revocations_version;
     j["ticket"] = ticket;
     return {get_pro_revocations_endpoint, j.dump()};
 }
@@ -531,8 +516,6 @@ namespace {
                 &state,
                 {SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION,
                  sizeof(SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(
-                &state, &get_pro_details_version, sizeof(get_pro_details_version));
         crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
         oxenc::host_to_little_inplace(ts);
         oxenc::host_to_little_inplace(count);
@@ -558,7 +541,6 @@ namespace {
             std::chrono::sys_seconds unix_ts,
             uint32_t count) {
         nlohmann::json j;
-        j["version"] = get_pro_details_version;
         j["master_pkey"] = oxenc::to_hex(master_pubkey);
         j["master_sig"] = oxenc::to_hex(master_sig);
         j["ts"] = epoch_seconds(unix_ts);
@@ -712,7 +694,6 @@ namespace {
                 &state,
                 {SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION,
                  sizeof(SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION) - 1});
-        crypto_generichash_blake2b_update(&state, &set_refund_version, sizeof(set_refund_version));
         crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
         oxenc::host_to_little_inplace(ts);
         oxenc::host_to_little_inplace(refund_requested_ts);
@@ -752,7 +733,6 @@ namespace {
             std::string_view payment_id,
             std::span<const uint8_t> master_sig) {
         nlohmann::json j;
-        j["version"] = set_refund_version;
         j["master_pkey"] = oxenc::to_hex(master_pubkey);
         j["ts"] = epoch_seconds(unix_ts);
         j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
@@ -813,7 +793,6 @@ SetPaymentRefundRequestedResponse parse_refund(std::string_view json) {
         return result;
 
     // Parse payload
-    result.version = json_require<uint8_t>(result_obj, "version", result.errors);
     result.updated = json_require<bool>(result_obj, "updated", result.errors);
     return result;
 }
@@ -1339,7 +1318,6 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
 
     // Copy to C struct
     result.header.status = cpp.status;
-    result.version = cpp.version;
     result.updated = cpp.updated;
 
     // Copy errors

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -7,6 +7,7 @@
 #include <sodium/crypto_sign_ed25519.h>
 
 #include <chrono>
+#include <concepts>
 #include <nlohmann/json.hpp>
 #include <session/pro_backend.hpp>
 #include <session/session_encrypt.hpp>
@@ -81,24 +82,24 @@ const T json_require(
         errors.push_back(fmt::format("Key '{}' is missing", key));
     } else {
         bool success = false;
-        std::string_view type = {};
-        if constexpr (session::is_one_of<T, double, float>) {
+        std::string_view type;
+        if constexpr (std::floating_point<T>) {
             type = "a float";
             success = it->is_number_float();
-        } else if constexpr (session::is_one_of<T, uint64_t, uint32_t, uint16_t, uint8_t>) {
+        } else if constexpr (std::same_as<T, bool>) {
+            type = "a boolean";
+            success = it->is_boolean();
+        } else if constexpr (std::integral<T>) {
             type = "a number";
             success = it->is_number();
         } else if constexpr (session::is_one_of<T, std::string, std::string_view>) {
             type = "a string";
             success = it->is_string();
-        } else if constexpr (session::is_one_of<T, nlohmann::json::array_t>) {
+        } else if constexpr (std::same_as<T, nlohmann::json::array_t>) {
             type = "an array";
             success = it->is_array();
-        } else if constexpr (session::is_one_of<T, bool>) {
-            type = "a boolean";
-            success = it->is_boolean();
         } else {
-            static_assert(session::is_one_of<T, nlohmann::json::object_t>);
+            static_assert(std::same_as<T, nlohmann::json::object_t>);
             type = "an object";
             success = it->is_object();
         }
@@ -514,7 +515,7 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
         return result;
 
     // Parse payload
-    result.ticket = json_require<uint32_t>(result_obj, "ticket", result.errors);
+    result.ticket = json_require<int64_t>(result_obj, "ticket", result.errors);
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
     result.items.reserve(array.size());

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -249,6 +249,10 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIO
         get_pro_revocations_endpoint;
 LIBSESSION_EXPORT extern const char* const
         SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT = set_refund_endpoint;
+
+// Backend base URL + Ed25519 pubkey: C symbols pointing at the single C++ definitions above.
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_URL = URL.data();
+LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY = PUBKEY.data();
 }
 
 std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -582,19 +582,15 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
     if (result.errors.size())
         return result;
 
-    // Parse payload
-    uint32_t user_status = json_require<uint32_t>(result_obj, "status", result.errors);
-    if (user_status >= SESSION_PRO_BACKEND_USER_PRO_STATUS_COUNT) {
-        result.errors.push_back(
-                fmt::format("User pro status value was out-of-bounds: {}", user_status));
-        return result;
-    }
-    result.user_status = static_cast<SESSION_PRO_BACKEND_USER_PRO_STATUS>(user_status);
+    // Parse payload. The account Pro status is an opaque string code ("never"/"active"/"expired");
+    // an unknown value passes through unchanged (§1: enums are codes) rather than failing the
+    // parse.
+    result.user_status = json_require<std::string>(result_obj, "status", result.errors);
 
     uint32_t error_report = json_require<uint32_t>(result_obj, "error_report", result.errors);
     if (error_report >= SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT) {
         result.errors.push_back(
-                fmt::format("Error report value was out-of-bounds: {}", user_status));
+                fmt::format("Error report value was out-of-bounds: {}", error_report));
         return result;
     }
     result.error_report =
@@ -623,7 +619,7 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
 
         // Parse payment item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto status = json_require<uint64_t>(obj, "status", result.errors);
+        auto status = json_require<std::string>(obj, "status", result.errors);
         auto plan = json_require<std::string>(obj, "plan", result.errors);
         auto payment_provider = json_require<std::string>(obj, "payment_provider", result.errors);
         auto payment_id = json_require<std::string>(obj, "payment_id", result.errors);
@@ -642,13 +638,7 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         auto refund_requested_ts = json_require<int64_t>(obj, "refund_requested_ts", result.errors);
 
         ProPaymentItem item = {};
-        if (status > SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL &&
-            status < SESSION_PRO_BACKEND_PAYMENT_STATUS_COUNT) {
-            item.status = static_cast<SESSION_PRO_BACKEND_PAYMENT_STATUS>(status);
-        } else {
-            result.errors.push_back(fmt::format("Status value was out-of-bounds: {}", status));
-        }
-
+        item.status = std::move(status);
         item.plan = std::move(plan);
         item.payment_provider = std::move(payment_provider);
         item.payment_id = std::move(payment_id);
@@ -1167,7 +1157,8 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
     result.header.status = cpp.status;
-    result.status = cpp.user_status;
+    result.status_count =
+            snprintf_clamped(result.status, sizeof(result.status), "%s", cpp.user_status.c_str());
     result.error_report = cpp.error_report;
     result.items_count = cpp.items.size();
     result.items = (session_pro_backend_pro_payment_item*)arena_alloc(
@@ -1181,7 +1172,8 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     for (size_t index = 0; index < result.items_count; ++index) {
         const ProPaymentItem& src = cpp.items[index];
         session_pro_backend_pro_payment_item& dest = result.items[index];
-        dest.status = src.status;
+        dest.status_count =
+                snprintf_clamped(dest.status, sizeof(dest.status), "%s", src.status.c_str());
         dest.plan_count = snprintf_clamped(dest.plan, sizeof(dest.plan), "%s", src.plan.c_str());
         dest.payment_provider_count = snprintf_clamped(
                 dest.payment_provider,

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -913,7 +913,7 @@ static session_pro_backend_request c_own_request(ProRequest&& req) {
     result.internal_ = owned;
     result.endpoint = owned->endpoint.data();
     result.content_type = owned->content_type.data();
-    result.data = string8{owned->data.data(), owned->data.size()};
+    result.data = span_u8{reinterpret_cast<uint8_t*>(owned->data.data()), owned->data.size()};
     result.success = true;
     return result;
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -353,7 +353,7 @@ AddProPaymentOrGenerateProProofResponse AddProPaymentOrGenerateProProofResponse:
 
     // Parse payload
     result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
-    auto expiry_ts = json_require<uint64_t>(result_obj, "expiry_ts", result.errors);
+    auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
     result.proof.expiry_unix_ts = std::chrono::sys_seconds(
             std::chrono::seconds(expiry_ts));
     json_require_fixed_bytes_from_hex(
@@ -529,7 +529,7 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
 
         // Parse revocation item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto expiry_unix_ts = json_require<uint64_t>(obj, "expiry_ts", result.errors);
+        auto expiry_unix_ts = json_require<int64_t>(obj, "expiry_ts", result.errors);
 
         ProRevocationItem item = {};
         item.expiry_unix_ts = as_sys_seconds(expiry_unix_ts);
@@ -675,12 +675,12 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
     result.payments_total = json_require<uint32_t>(result_obj, "payments_total", result.errors);
 
     result.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(
-            json_require<uint64_t>(result_obj, "expiry_ts", result.errors)));
+            json_require<int64_t>(result_obj, "expiry_ts", result.errors)));
     result.grace_period_duration = std::chrono::seconds(
-            json_require<uint64_t>(result_obj, "grace_period_duration", result.errors));
+            json_require<int64_t>(result_obj, "grace_period_duration", result.errors));
     result.refund_requested_unix_ts = std::chrono::sys_seconds(
             std::chrono::seconds(
-                    json_require<uint64_t>(result_obj, "refund_requested_ts", result.errors)));
+                    json_require<int64_t>(result_obj, "refund_requested_ts", result.errors)));
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
     result.items.reserve(array.size());
@@ -698,16 +698,16 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
         auto plan = json_require<uint64_t>(obj, "plan", result.errors);
         auto payment_provider = json_require<uint32_t>(obj, "payment_provider", result.errors);
         auto auto_renewing = json_require<bool>(obj, "auto_renewing", result.errors);
-        auto unredeemed_ts = json_require<uint64_t>(obj, "unredeemed_ts", result.errors);
-        auto redeemed_ts = json_require<uint64_t>(obj, "redeemed_ts", result.errors);
-        auto expiry_ts = json_require<uint64_t>(obj, "expiry_ts", result.errors);
+        auto unredeemed_ts = json_require<int64_t>(obj, "unredeemed_ts", result.errors);
+        auto redeemed_ts = json_require<int64_t>(obj, "redeemed_ts", result.errors);
+        auto expiry_ts = json_require<int64_t>(obj, "expiry_ts", result.errors);
         auto grace_period_duration =
-                json_require<uint64_t>(obj, "grace_period_duration", result.errors);
+                json_require<int64_t>(obj, "grace_period_duration", result.errors);
         auto platform_refund_expiry_ts =
-                json_require<uint64_t>(obj, "platform_refund_expiry_ts", result.errors);
-        auto revoked_ts = json_require<uint64_t>(obj, "revoked_ts", result.errors);
+                json_require<int64_t>(obj, "platform_refund_expiry_ts", result.errors);
+        auto revoked_ts = json_require<int64_t>(obj, "revoked_ts", result.errors);
         auto refund_requested_ts =
-                json_require<uint64_t>(obj, "refund_requested_ts", result.errors);
+                json_require<int64_t>(obj, "refund_requested_ts", result.errors);
 
         ProPaymentItem item = {};
         if (status > SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL &&
@@ -1055,7 +1055,7 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t ts) {
+        int64_t ts) {
 
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
@@ -1089,7 +1089,7 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t ts) {
+        int64_t ts) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
@@ -1119,7 +1119,7 @@ session_pro_backend_get_pro_details_request_build_sig(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
+        int64_t ts,
         uint32_t count) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
@@ -1146,7 +1146,7 @@ session_pro_backend_get_pro_details_request_build_to_json(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
+        int64_t ts,
         uint32_t count) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
@@ -1542,8 +1542,8 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
-        uint64_t refund_requested_ts,
+        int64_t ts,
+        int64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,
@@ -1587,8 +1587,8 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t ts,
-        uint64_t refund_requested_ts,
+        int64_t ts,
+        int64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -353,9 +353,9 @@ AddProPaymentOrGenerateProProofResponse AddProPaymentOrGenerateProProofResponse:
 
     // Parse payload
     result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
-    auto expiry_unix_ts_ms = json_require<uint64_t>(result_obj, "expiry_unix_ts_ms", result.errors);
-    result.proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-            std::chrono::milliseconds(expiry_unix_ts_ms));
+    auto expiry_ts = json_require<uint64_t>(result_obj, "expiry_ts", result.errors);
+    result.proof.expiry_unix_ts = std::chrono::sys_seconds(
+            std::chrono::seconds(expiry_ts));
     json_require_fixed_bytes_from_hex(
             result_obj, "gen_index_hash", result.errors, result.proof.gen_index_hash);
     json_require_fixed_bytes_from_hex(
@@ -369,7 +369,7 @@ std::string GenerateProProofRequest::to_json() const {
     j["version"] = version;
     j["master_pkey"] = oxenc::to_hex(master_pkey);
     j["rotating_pkey"] = oxenc::to_hex(rotating_pkey);
-    j["unix_ts_ms"] = epoch_ms(unix_ts);
+    j["ts"] = epoch_seconds(unix_ts);
     j["master_sig"] = oxenc::to_hex(master_sig);
     j["rotating_sig"] = oxenc::to_hex(rotating_sig);
     std::string result = j.dump();
@@ -380,7 +380,7 @@ MasterRotatingSignatures GenerateProProofRequest::build_sigs(
         std::uint8_t request_version,
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts) {
+        std::chrono::sys_seconds unix_ts) {
 
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == 32) {
@@ -405,7 +405,7 @@ MasterRotatingSignatures GenerateProProofRequest::build_sigs(
     // Hash components to 32 bytes, must match:
     //   https://github.com/Doy-lee/session-pro-backend/blob/5b66b1a4a64dc8da0225507019cbe21d7642fa78/backend.py#L631
     uint8_t version = 0;
-    uint64_t unix_ts_ms = epoch_ms(unix_ts);
+    int64_t ts = epoch_seconds(unix_ts);
     array_uc32 hash_to_sign = {};
     crypto_generichash_blake2b_state state = {};
     make_blake2b32_hasher(
@@ -417,9 +417,9 @@ MasterRotatingSignatures GenerateProProofRequest::build_sigs(
             &state, master_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
     crypto_generichash_blake2b_update(
             &state, rotating_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
-    oxenc::host_to_little_inplace(unix_ts_ms);
+    oxenc::host_to_little_inplace(ts);
     crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<uint8_t*>(&unix_ts_ms), sizeof(unix_ts_ms));
+            &state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
 
     // Sign the hash with both keys
@@ -443,7 +443,7 @@ std::string GenerateProProofRequest::build_to_json(
         std::uint8_t request_version,
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts) {
+        std::chrono::sys_seconds unix_ts) {
     // Rederive keys from 32 byte seed if given
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == 32) {
@@ -529,11 +529,10 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
 
         // Parse revocation item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto expiry_unix_ts = json_require<uint64_t>(obj, "expiry_unix_ts_ms", result.errors);
+        auto expiry_unix_ts = json_require<uint64_t>(obj, "expiry_ts", result.errors);
 
         ProRevocationItem item = {};
-        item.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(expiry_unix_ts));
+        item.expiry_unix_ts = as_sys_seconds(expiry_unix_ts);
         json_require_fixed_bytes_from_hex(
                 obj, "gen_index_hash", result.errors, item.gen_index_hash);
 
@@ -551,7 +550,7 @@ std::string GetProDetailsRequest::to_json() const {
     j["version"] = version;
     j["master_pkey"] = oxenc::to_hex(master_pkey);
     j["master_sig"] = oxenc::to_hex(master_sig);
-    j["unix_ts_ms"] = epoch_ms(unix_ts);
+    j["ts"] = epoch_seconds(unix_ts);
     j["count"] = count;
     std::string result = j.dump();
     return result;
@@ -560,7 +559,7 @@ std::string GetProDetailsRequest::to_json() const {
 array_uc64 GetProDetailsRequest::build_sig(
         uint8_t version,
         std::span<const uint8_t> master_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
+        std::chrono::sys_seconds unix_ts,
         uint32_t count) {
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
@@ -576,7 +575,7 @@ array_uc64 GetProDetailsRequest::build_sig(
     //   https://github.com/Doy-lee/session-pro-backend/blob/635b14fc93302658de6c07c017f705673fc7c57f/server.py#L395
     array_uc32 hash_to_sign = {};
     crypto_generichash_blake2b_state state = {};
-    uint64_t unix_ts_ms = epoch_ms(unix_ts);
+    int64_t ts = epoch_seconds(unix_ts);
     make_blake2b32_hasher(
             &state,
             {SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION,
@@ -586,10 +585,10 @@ array_uc64 GetProDetailsRequest::build_sig(
             &state,
             master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
             crypto_sign_ed25519_PUBLICKEYBYTES);
-    oxenc::host_to_little_inplace(unix_ts_ms);
+    oxenc::host_to_little_inplace(ts);
     oxenc::host_to_little_inplace(count);
     crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<unsigned char*>(&unix_ts_ms), sizeof(unix_ts_ms));
+            &state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<unsigned char*>(&count), sizeof(count));
     crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
@@ -608,7 +607,7 @@ array_uc64 GetProDetailsRequest::build_sig(
 std::string GetProDetailsRequest::build_to_json(
         uint8_t version,
         std::span<const uint8_t> master_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
+        std::chrono::sys_seconds unix_ts,
         uint32_t count) {
     cleared_uc64 master_from_seed;
     if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
@@ -675,17 +674,13 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
 
     result.payments_total = json_require<uint32_t>(result_obj, "payments_total", result.errors);
 
-    uint64_t expiry_unix_ts_ms =
-            json_require<uint64_t>(result_obj, "expiry_unix_ts_ms", result.errors);
-    uint64_t grace_period_duration_ms =
-            json_require<uint64_t>(result_obj, "grace_period_duration_ms", result.errors);
-    uint64_t refund_requested_unix_ts_ms =
-            json_require<uint64_t>(result_obj, "refund_requested_unix_ts_ms", result.errors);
-    result.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-            std::chrono::milliseconds(expiry_unix_ts_ms));
-    result.grace_period_duration = std::chrono::milliseconds(grace_period_duration_ms);
-    result.refund_requested_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-            std::chrono::milliseconds(refund_requested_unix_ts_ms));
+    result.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(
+            json_require<uint64_t>(result_obj, "expiry_ts", result.errors)));
+    result.grace_period_duration = std::chrono::seconds(
+            json_require<uint64_t>(result_obj, "grace_period_duration", result.errors));
+    result.refund_requested_unix_ts = std::chrono::sys_seconds(
+            std::chrono::seconds(
+                    json_require<uint64_t>(result_obj, "refund_requested_ts", result.errors)));
 
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
     result.items.reserve(array.size());
@@ -703,16 +698,16 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
         auto plan = json_require<uint64_t>(obj, "plan", result.errors);
         auto payment_provider = json_require<uint32_t>(obj, "payment_provider", result.errors);
         auto auto_renewing = json_require<bool>(obj, "auto_renewing", result.errors);
-        auto unredeemed_ts = json_require<uint64_t>(obj, "unredeemed_unix_ts_ms", result.errors);
-        auto redeemed_ts = json_require<uint64_t>(obj, "redeemed_unix_ts_ms", result.errors);
-        auto expiry_ts = json_require<uint64_t>(obj, "expiry_unix_ts_ms", result.errors);
-        auto grace_period_duration_ms =
-                json_require<uint64_t>(obj, "grace_period_duration_ms", result.errors);
+        auto unredeemed_ts = json_require<uint64_t>(obj, "unredeemed_ts", result.errors);
+        auto redeemed_ts = json_require<uint64_t>(obj, "redeemed_ts", result.errors);
+        auto expiry_ts = json_require<uint64_t>(obj, "expiry_ts", result.errors);
+        auto grace_period_duration =
+                json_require<uint64_t>(obj, "grace_period_duration", result.errors);
         auto platform_refund_expiry_ts =
-                json_require<uint64_t>(obj, "platform_refund_expiry_unix_ts_ms", result.errors);
-        auto revoked_ts = json_require<uint64_t>(obj, "revoked_unix_ts_ms", result.errors);
+                json_require<uint64_t>(obj, "platform_refund_expiry_ts", result.errors);
+        auto revoked_ts = json_require<uint64_t>(obj, "revoked_ts", result.errors);
         auto refund_requested_ts =
-                json_require<uint64_t>(obj, "refund_requested_unix_ts_ms", result.errors);
+                json_require<uint64_t>(obj, "refund_requested_ts", result.errors);
 
         ProPaymentItem item = {};
         if (status > SESSION_PRO_BACKEND_PAYMENT_STATUS_NIL &&
@@ -740,19 +735,19 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
         }
 
         item.auto_renewing = auto_renewing;
-        item.unredeemed_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(unredeemed_ts));
-        item.redeemed_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(redeemed_ts));
-        item.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(expiry_ts));
-        item.grace_period_duration_ms = std::chrono::milliseconds(grace_period_duration_ms);
-        item.platform_refund_expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(platform_refund_expiry_ts));
-        item.revoked_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(revoked_ts));
-        item.refund_requested_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(refund_requested_ts));
+        item.unredeemed_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(unredeemed_ts));
+        item.redeemed_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(redeemed_ts));
+        item.expiry_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(expiry_ts));
+        item.grace_period_duration = std::chrono::seconds(grace_period_duration);
+        item.platform_refund_expiry_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(platform_refund_expiry_ts));
+        item.revoked_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(revoked_ts));
+        item.refund_requested_unix_ts = std::chrono::sys_seconds(
+                std::chrono::seconds(refund_requested_ts));
         switch (item.payment_provider) {
             case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_COUNT: [[fallthrough]];
             case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: {
@@ -801,8 +796,8 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
 array_uc64 SetPaymentRefundRequestedRequest::build_sig(
         uint8_t version,
         std::span<const uint8_t> master_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
-        std::chrono::sys_time<std::chrono::milliseconds> refund_requested_unix_ts,
+        std::chrono::sys_seconds unix_ts,
+        std::chrono::sys_seconds refund_requested_unix_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         std::span<const uint8_t> payment_tx_payment_id,
         std::span<const uint8_t> payment_tx_order_id) {
@@ -831,16 +826,16 @@ array_uc64 SetPaymentRefundRequestedRequest::build_sig(
             crypto_sign_ed25519_PUBLICKEYBYTES);
 
     // Timestamps
-    uint64_t unix_ts_ms = epoch_ms(unix_ts);
-    uint64_t refund_requested_unix_ts_ms = epoch_ms(refund_requested_unix_ts);
-    oxenc::host_to_little_inplace(unix_ts_ms);
-    oxenc::host_to_little_inplace(refund_requested_unix_ts_ms);
+    int64_t ts = epoch_seconds(unix_ts);
+    int64_t refund_requested_ts = epoch_seconds(refund_requested_unix_ts);
+    oxenc::host_to_little_inplace(ts);
+    oxenc::host_to_little_inplace(refund_requested_ts);
     crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<const uint8_t*>(&unix_ts_ms), sizeof(unix_ts_ms));
+            &state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
     crypto_generichash_blake2b_update(
             &state,
-            reinterpret_cast<const uint8_t*>(&refund_requested_unix_ts_ms),
-            sizeof(refund_requested_unix_ts_ms));
+            reinterpret_cast<const uint8_t*>(&refund_requested_ts),
+            sizeof(refund_requested_ts));
 
     // Payment provider
     uint8_t provider_u8 = payment_tx_provider;
@@ -871,8 +866,8 @@ array_uc64 SetPaymentRefundRequestedRequest::build_sig(
 std::string SetPaymentRefundRequestedRequest::build_to_json(
         uint8_t version,
         std::span<const uint8_t> master_privkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
-        std::chrono::sys_time<std::chrono::milliseconds> refund_requested_unix_ts,
+        std::chrono::sys_seconds unix_ts,
+        std::chrono::sys_seconds refund_requested_unix_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         std::span<const uint8_t> payment_tx_payment_id,
         std::span<const uint8_t> payment_tx_order_id) {
@@ -909,8 +904,8 @@ std::string SetPaymentRefundRequestedRequest::to_json() const {
     nlohmann::json j;
     j["version"] = version;
     j["master_pkey"] = oxenc::to_hex(master_pkey);
-    j["unix_ts_ms"] = epoch_ms(unix_ts);
-    j["refund_requested_unix_ts_ms"] = epoch_ms(refund_requested_unix_ts);
+    j["ts"] = epoch_seconds(unix_ts);
+    j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
     j["payment_tx"]["provider"] = payment_tx.provider;
     switch (payment_tx.provider) {
         case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: [[fallthrough]];
@@ -1060,20 +1055,18 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t unix_ts_ms) {
+        uint64_t ts) {
 
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    std::chrono::milliseconds ts{unix_ts_ms};
-
     session_pro_backend_master_rotating_signatures result = {};
     try {
         auto sigs = GenerateProProofRequest::build_sigs(
                 request_version,
                 master_span,
                 rotating_span,
-                std::chrono::sys_time<std::chrono::milliseconds>(ts));
+                session::as_sys_seconds(ts));
         std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
         std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
         result.success = true;
@@ -1096,19 +1089,17 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
         size_t rotating_privkey_len,
-        uint64_t unix_ts_ms) {
+        uint64_t ts) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    std::chrono::milliseconds ts{unix_ts_ms};
-
     session_pro_backend_to_json result = {};
     try {
         auto json = GenerateProProofRequest::build_to_json(
                 request_version,
                 master_span,
                 rotating_span,
-                std::chrono::sys_time<std::chrono::milliseconds>(ts));
+                session::as_sys_seconds(ts));
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1128,15 +1119,14 @@ session_pro_backend_get_pro_details_request_build_sig(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         uint32_t count) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_time<std::chrono::milliseconds> ts{std::chrono::milliseconds(unix_ts_ms)};
-
     session_pro_backend_signature result = {};
     try {
-        auto sig = GetProDetailsRequest::build_sig(request_version, master_span, ts, count);
+        auto sig = GetProDetailsRequest::build_sig(
+                request_version, master_span, session::as_sys_seconds(ts), count);
         std::memcpy(result.sig.data, sig.data(), sig.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1156,15 +1146,14 @@ session_pro_backend_get_pro_details_request_build_to_json(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         uint32_t count) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_time<std::chrono::milliseconds> ts{std::chrono::milliseconds(unix_ts_ms)};
-
     session_pro_backend_to_json result = {};
     try {
-        auto json = GetProDetailsRequest::build_to_json(request_version, master_span, ts, count);
+        auto json = GetProDetailsRequest::build_to_json(
+                request_version, master_span, session::as_sys_seconds(ts), count);
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1226,8 +1215,7 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_generate_pro_pr
     cpp.version = request->version;
     std::memcpy(cpp.master_pkey.data(), request->master_pkey.data, cpp.master_pkey.size());
     std::memcpy(cpp.rotating_pkey.data(), request->rotating_pkey.data, cpp.rotating_pkey.size());
-    cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>{
-            std::chrono::milliseconds(request->unix_ts_ms)};
+    cpp.unix_ts = session::as_sys_seconds(request->ts);
     std::memcpy(cpp.master_sig.data(), request->master_sig.data, cpp.master_sig.size());
     std::memcpy(cpp.rotating_sig.data(), request->rotating_sig.data, cpp.rotating_sig.size());
 
@@ -1289,8 +1277,7 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_get_pro_details
     std::memcpy(
             cpp.master_pkey.data(), request->master_pkey.data, sizeof(request->master_pkey.data));
     std::memcpy(cpp.master_sig.data(), request->master_sig.data, sizeof(request->master_sig.data));
-    cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>{
-            std::chrono::milliseconds{request->unix_ts_ms}};
+    cpp.unix_ts = session::as_sys_seconds(request->ts);
     cpp.count = request->count;
 
     try {
@@ -1350,7 +1337,7 @@ session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
     // error response returns the same struct just with different fields populated.
     result.header.status = cpp.status;
     result.proof.version = cpp.proof.version;
-    result.proof.expiry_unix_ts_ms = session::epoch_ms(cpp.proof.expiry_unix_ts);
+    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_unix_ts);
     std::memcpy(
             result.proof.gen_index_hash.data,
             cpp.proof.gen_index_hash.data(),
@@ -1432,7 +1419,7 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
         const ProRevocationItem& src = cpp.items[index];
         session_pro_backend_pro_revocation_item& dest = result.items[index];
         std::memcpy(dest.gen_index_hash.data, src.gen_index_hash.data(), src.gen_index_hash.size());
-        dest.expiry_unix_ts_ms = session::epoch_ms(src.expiry_unix_ts);
+        dest.expiry_ts = session::epoch_seconds(src.expiry_unix_ts);
     }
     return result;
 }
@@ -1471,7 +1458,7 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         result.header.internal_arena_buf_ = arena.data;
     }
 
-    using session::epoch_ms;
+    using session::epoch_seconds;
 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
     result.header.status = cpp.status;
@@ -1481,9 +1468,9 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     result.items = (session_pro_backend_pro_payment_item*)arena_alloc(
             &arena, result.items_count * sizeof(*result.items));
     result.auto_renewing = cpp.auto_renewing;
-    result.expiry_unix_ts_ms = epoch_ms(cpp.expiry_unix_ts);
-    result.grace_period_duration_ms = cpp.grace_period_duration.count();
-    result.refund_requested_unix_ts_ms = epoch_ms(cpp.refund_requested_unix_ts);
+    result.expiry_ts = epoch_seconds(cpp.expiry_unix_ts);
+    result.grace_period_duration = cpp.grace_period_duration.count();
+    result.refund_requested_ts = epoch_seconds(cpp.refund_requested_unix_ts);
     result.payments_total = cpp.payments_total;
 
     for (size_t index = 0; index < result.items_count; ++index) {
@@ -1493,13 +1480,13 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         dest.plan = src.plan;
         dest.payment_provider = src.payment_provider;
         dest.payment_provider_metadata = src.payment_provider_metadata;
-        dest.unredeemed_unix_ts_ms = epoch_ms(src.unredeemed_unix_ts);
-        dest.redeemed_unix_ts_ms = epoch_ms(src.redeemed_unix_ts);
-        dest.expiry_unix_ts_ms = epoch_ms(src.expiry_unix_ts);
-        dest.grace_period_duration_ms = session::duration_ms(src.grace_period_duration_ms);
-        dest.platform_refund_expiry_unix_ts_ms = epoch_ms(src.platform_refund_expiry_unix_ts);
-        dest.revoked_unix_ts_ms = epoch_ms(src.revoked_unix_ts);
-        dest.refund_requested_unix_ts_ms = epoch_ms(src.refund_requested_unix_ts);
+        dest.unredeemed_ts = epoch_seconds(src.unredeemed_unix_ts);
+        dest.redeemed_ts = epoch_seconds(src.redeemed_unix_ts);
+        dest.expiry_ts = epoch_seconds(src.expiry_unix_ts);
+        dest.grace_period_duration = src.grace_period_duration.count();
+        dest.platform_refund_expiry_ts = epoch_seconds(src.platform_refund_expiry_unix_ts);
+        dest.revoked_ts = epoch_seconds(src.revoked_unix_ts);
+        dest.refund_requested_ts = epoch_seconds(src.refund_requested_unix_ts);
 
         switch (dest.payment_provider) {
             case SESSION_PRO_BACKEND_PAYMENT_PROVIDER_NIL: [[fallthrough]];
@@ -1555,8 +1542,8 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
-        uint64_t refund_requested_unix_ts_ms,
+        uint64_t ts,
+        uint64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,
@@ -1564,9 +1551,9 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
         size_t payment_tx_order_id_len) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_time<std::chrono::milliseconds> unix_ts{std::chrono::milliseconds(unix_ts_ms)};
-    std::chrono::sys_time<std::chrono::milliseconds> refund_requested_unix_ts{
-            std::chrono::milliseconds(refund_requested_unix_ts_ms)};
+    std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
+    std::chrono::sys_seconds refund_requested_unix_ts =
+            session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
     std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
@@ -1600,8 +1587,8 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
         uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
-        uint64_t unix_ts_ms,
-        uint64_t refund_requested_unix_ts_ms,
+        uint64_t ts,
+        uint64_t refund_requested_ts,
         SESSION_PRO_BACKEND_PAYMENT_PROVIDER payment_tx_provider,
         const uint8_t* payment_tx_payment_id,
         size_t payment_tx_payment_id_len,
@@ -1610,9 +1597,9 @@ session_pro_backend_set_payment_refund_requested_request_build_to_json(
 
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_time<std::chrono::milliseconds> unix_ts{std::chrono::milliseconds(unix_ts_ms)};
-    std::chrono::sys_time<std::chrono::milliseconds> refund_requested_unix_ts{
-            std::chrono::milliseconds(refund_requested_unix_ts_ms)};
+    std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
+    std::chrono::sys_seconds refund_requested_unix_ts =
+            session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
     std::span<const uint8_t> payment_tx_order_id_span(payment_tx_order_id, payment_tx_order_id_len);
@@ -1654,10 +1641,8 @@ session_pro_backend_set_payment_refund_requested_request_to_json(
     std::memcpy(
             cpp.master_pkey.data(), request->master_pkey.data, sizeof(request->master_pkey.data));
     std::memcpy(cpp.master_sig.data(), request->master_sig.data, sizeof(request->master_sig.data));
-    cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>{
-            std::chrono::milliseconds{request->unix_ts_ms}};
-    cpp.refund_requested_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-            std::chrono::milliseconds{request->refund_requested_unix_ts_ms});
+    cpp.unix_ts = session::as_sys_seconds(request->ts);
+    cpp.refund_requested_unix_ts = session::as_sys_seconds(request->refund_requested_ts);
     cpp.payment_tx.provider = request->payment_tx.provider;
     cpp.payment_tx.payment_id =
             std::string(request->payment_tx.payment_id, request->payment_tx.payment_id_count);

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -112,307 +112,327 @@ bool json_require_fixed_bytes_from_hex(
 };  // namespace
 
 namespace session::pro_backend {
-std::string AddProPaymentRequest::to_json() const {
-    nlohmann::json j;
-    j["version"] = version;
-    j["master_pkey"] = oxenc::to_hex(master_pkey);
-    j["rotating_pkey"] = oxenc::to_hex(rotating_pkey);
-    j["payment_tx"]["provider"] = payment_tx.provider_code;
-    j["payment_tx"]["payment_id"] = payment_tx.payment_id;
-    j["master_sig"] = oxenc::to_hex(master_sig);
-    j["rotating_sig"] = oxenc::to_hex(rotating_sig);
-    std::string result = j.dump();
-    return result;
+
+namespace {
+
+    // Endpoint paths (single master storage). Both the C `SESSION_PRO_BACKEND_*_ENDPOINT` symbols
+    // and the C++ `*_request()` return values point at these — the path is defined exactly once.
+    constexpr char add_payment_endpoint[] = "add_pro_payment";
+    constexpr char generate_proof_endpoint[] = "generate_pro_proof";
+    constexpr char get_pro_details_endpoint[] = "get_pro_details";
+    constexpr char get_pro_revocations_endpoint[] = "get_pro_revocations";
+    constexpr char set_refund_endpoint[] = "set_payment_refund_requested";
+
+    // Wire-format version emitted per request type (library-owned; not caller-settable). Kept
+    // independent so a future bump of one request type doesn't drag the others along.
+    constexpr uint8_t add_payment_version = 0;
+    constexpr uint8_t generate_proof_version = 0;
+    constexpr uint8_t get_pro_details_version = 0;
+    constexpr uint8_t get_pro_revocations_version = 0;
+    constexpr uint8_t set_refund_version = 0;
+
+    // Normalise an Ed25519 private key to libsodium's 64-byte form (seed(32) || pubkey(32)): a
+    // 32-byte seed is expanded, a 64-byte key copied, anything else throws. The public key is then
+    // available at bytes [32, 64) so callers never need a second derivation.
+    cleared_uc64 normalize_privkey(std::span<const uint8_t> privkey, const char* name) {
+        cleared_uc64 out;
+        if (privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
+            array_uc32 pubkey;
+            crypto_sign_ed25519_seed_keypair(pubkey.data(), out.data(), privkey.data());
+        } else if (privkey.size() == crypto_sign_ed25519_SECRETKEYBYTES) {
+            std::memcpy(out.data(), privkey.data(), crypto_sign_ed25519_SECRETKEYBYTES);
+        } else {
+            throw std::invalid_argument{fmt::format("Invalid {}: expected 32 or 64 bytes", name)};
+        }
+        return out;
+    }
+
+    // Public-key view (bytes [32, 64)) of a normalised 64-byte private key.
+    std::span<const uint8_t> pubkey_of(const cleared_uc64& priv64) {
+        return {priv64.data() + crypto_sign_ed25519_SEEDBYTES, crypto_sign_ed25519_PUBLICKEYBYTES};
+    }
+
+    std::string_view payment_id_view(std::span<const uint8_t> payment_id) {
+        return {reinterpret_cast<const char*>(payment_id.data()), payment_id.size()};
+    }
+
+    // --- add-payment (endpoint add_pro_payment) ---
+
+    array_uc32 add_payment_hash(
+            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t> rotating_pubkey,
+            std::string_view provider_code,
+            std::span<const uint8_t> payment_id) {
+        // Must match the add-payment signed-request hash in pro-wire-protocol.md §3.2 (+ §3.5).
+        array_uc32 hash = {};
+        crypto_generichash_blake2b_state state = {};
+        make_blake2b32_hasher(
+                &state,
+                {SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION,
+                 sizeof(SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION) - 1});
+        crypto_generichash_blake2b_update(
+                &state, &add_payment_version, sizeof(add_payment_version));
+        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
+        crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
+        crypto_generichash_blake2b_update(
+                &state,
+                reinterpret_cast<const uint8_t*>(provider_code.data()),
+                provider_code.size());
+        crypto_generichash_blake2b_update(&state, payment_id.data(), payment_id.size());
+        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
+        return hash;
+    }
+
+    MasterRotatingSignatures add_payment_sign(
+            const cleared_uc64& master,
+            const cleared_uc64& rotating,
+            std::string_view provider_code,
+            std::span<const uint8_t> payment_id) {
+        auto hash =
+                add_payment_hash(pubkey_of(master), pubkey_of(rotating), provider_code, payment_id);
+        MasterRotatingSignatures result = {};
+        crypto_sign_ed25519_detached(
+                result.master_sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        crypto_sign_ed25519_detached(
+                result.rotating_sig.data(), nullptr, hash.data(), hash.size(), rotating.data());
+        return result;
+    }
+
+    // Serialise an add-payment request body from already-computed fields (shared by the C++
+    // add_payment_request and the C ..._request_to_json wrapper).
+    std::string add_payment_body(
+            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t> rotating_pubkey,
+            std::string_view provider_code,
+            std::string_view payment_id,
+            std::span<const uint8_t> master_sig,
+            std::span<const uint8_t> rotating_sig) {
+        nlohmann::json j;
+        j["version"] = add_payment_version;
+        j["master_pkey"] = oxenc::to_hex(master_pubkey);
+        j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
+        j["payment_tx"]["provider"] = provider_code;
+        j["payment_tx"]["payment_id"] = payment_id;
+        j["master_sig"] = oxenc::to_hex(master_sig);
+        j["rotating_sig"] = oxenc::to_hex(rotating_sig);
+        return j.dump();
+    }
+
+}  // namespace
+
+// C endpoint symbols: each points at the single master endpoint string defined above, so the C API
+// and the C++ `ProRequest::endpoint` values are backed by one definition.
+extern "C" {
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT =
+        add_payment_endpoint;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT =
+        generate_proof_endpoint;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT =
+        get_pro_details_endpoint;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT =
+        get_pro_revocations_endpoint;
+LIBSESSION_EXPORT extern const char* const
+        SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT = set_refund_endpoint;
 }
 
-MasterRotatingSignatures AddProPaymentRequest::build_sigs(
-        std::uint8_t version,
+std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {
+    if (provider_code == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY)
+        return ProviderUrls{
+                "https://support.google.com/googleplay/workflow/9813244?",
+                "https://getsession.org/android-refund",
+                "https://getsession.org/android-refund",
+                "https://play.google.com/store/account/"
+                "subscriptions?package=network.loki.messenger",
+                "https://play.google.com/store/account/"
+                "subscriptions?package=network.loki.messenger"};
+    if (provider_code == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE)
+        return ProviderUrls{
+                "https://support.apple.com/118223",
+                "https://support.apple.com/118223",
+                "https://support.apple.com/118224",
+                "https://apps.apple.com/account/subscriptions",
+                "https://account.apple.com/account/manage/section/subscriptions"};
+    // rangeproof and unknown providers have no applicable URLs
+    return std::nullopt;
+}
+
+LIBSESSION_C_API session_pro_backend_provider_urls
+session_pro_backend_get_provider_urls(const char* provider_code) {
+    // No URLs → all-NULL fields; otherwise each view is a static, null-terminated literal.
+    if (auto u = provider_urls(provider_code))
+        return {u->refund_platform_url.data(),
+                u->refund_support_url.data(),
+                u->refund_status_url.data(),
+                u->update_subscription_url.data(),
+                u->cancel_subscription_url.data()};
+    return {nullptr, nullptr, nullptr, nullptr, nullptr};
+}
+
+MasterRotatingSignatures add_payment_sigs(
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        std::string_view payment_tx_provider_code,
-        std::span<const uint8_t> payment_tx_payment_id) {
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
-    }
-
-    cleared_uc64 rotating_from_seed;
-    if (rotating_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 rotating_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                rotating_pubkey.data(), rotating_from_seed.data(), rotating_privkey.data());
-        rotating_privkey = rotating_from_seed;
-    } else if (rotating_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid rotating_privkey: expected 32 or 64 bytes"};
-    }
-
-    // Hash components to 32 bytes, must match:
-    //   https://github.com/Doy-lee/session-pro-backend/blob/5b66b1a4a64dc8da0225507019cbe21d7642fa78/backend.py#L171
-    array_uc32 hash_to_sign = {};
-    crypto_generichash_blake2b_state state = {};
-    make_blake2b32_hasher(
-            &state,
-            {SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION,
-             sizeof(SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, &version, sizeof(version));
-    crypto_generichash_blake2b_update(
-            &state,
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    crypto_generichash_blake2b_update(
-            &state,
-            rotating_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-
-    crypto_generichash_blake2b_update(
-            &state,
-            reinterpret_cast<const uint8_t*>(payment_tx_provider_code.data()),
-            payment_tx_provider_code.size());
-    crypto_generichash_blake2b_update(
-            &state,
-            reinterpret_cast<const uint8_t*>(payment_tx_payment_id.data()),
-            payment_tx_payment_id.size());
-    crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
-
-    // Sign the hash with both keys
-    MasterRotatingSignatures result = {};
-    crypto_sign_ed25519_detached(
-            result.master_sig.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            master_privkey.data());
-    crypto_sign_ed25519_detached(
-            result.rotating_sig.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            rotating_privkey.data());
-    return result;
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
+    return add_payment_sign(master, rotating, provider_code, payment_id);
 }
 
-std::string AddProPaymentRequest::build_to_json(
-        std::uint8_t version,
+ProRequest add_payment_request(
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
-        std::string_view payment_tx_provider_code,
-        std::span<const uint8_t> payment_tx_payment_id) {
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
+    auto sigs = add_payment_sign(master, rotating, provider_code, payment_id);
+    return {add_payment_endpoint,
+            add_payment_body(
+                    pubkey_of(master),
+                    pubkey_of(rotating),
+                    provider_code,
+                    payment_id_view(payment_id),
+                    sigs.master_sig,
+                    sigs.rotating_sig)};
+}
+
+namespace {
+    // Shared parse for the proof-carrying responses (add-payment and generate-proof both reply with
+    // exactly a proof); fills the common ProProofResponse base of whichever derived response is
+    // passed.
+    void fill_proof_response(std::string_view json, ProProofResponse& result) {
+        // Parse basics
+        nlohmann::json j = json_parse(json, result.errors);
+        result.status = json_require<uint8_t>(j, "status", result.errors);
+        if (result.errors.size()) {
+            result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
+            return;
+        }
+
+        // Parse errors
+        if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
+            parse_json_response_errors(j, result.errors);
+            return;
+        }
+
+        auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
+        if (result.errors.size())
+            return;
+
+        // Parse payload
+        result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
+        auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
+        result.proof.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
+        json_require_fixed_bytes_from_hex(
+                result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
+        json_require_fixed_bytes_from_hex(
+                result_obj, "rotating_pkey", result.errors, result.proof.rotating_pubkey);
+        json_require_fixed_bytes_from_hex(result_obj, "sig", result.errors, result.proof.sig);
     }
+}  // namespace
 
-    cleared_uc64 rotating_from_seed;
-    if (rotating_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 rotating_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                rotating_pubkey.data(), rotating_from_seed.data(), rotating_privkey.data());
-        rotating_privkey = rotating_from_seed;
-    } else if (rotating_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid rotating_privkey: expected 32 or 64 bytes"};
-    }
-
-    MasterRotatingSignatures sigs = AddProPaymentRequest::build_sigs(
-            version,
-            master_privkey,
-            rotating_privkey,
-            payment_tx_provider_code,
-            payment_tx_payment_id);
-
-    AddProPaymentRequest request = {};
-    request.version = version;
-    std::memcpy(
-            request.master_pkey.data(),
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    std::memcpy(
-            request.rotating_pkey.data(),
-            rotating_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.payment_tx.provider_code = std::string(payment_tx_provider_code);
-    request.payment_tx.payment_id = std::string(
-            reinterpret_cast<const char*>(payment_tx_payment_id.data()),
-            payment_tx_payment_id.size());
-    request.master_sig = sigs.master_sig;
-    request.rotating_sig = sigs.rotating_sig;
-
-    std::string result = request.to_json();
+AddProPaymentResponse parse_add_payment(std::string_view json) {
+    AddProPaymentResponse result = {};
+    fill_proof_response(json, result);
     return result;
 }
 
-AddProPaymentOrGenerateProProofResponse AddProPaymentOrGenerateProProofResponse::parse(
-        std::string_view json) {
-    // Parse basics
-    AddProPaymentOrGenerateProProofResponse result = {};
-    nlohmann::json j = json_parse(json, result.errors);
-    result.status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size()) {
-        result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
-        return result;
-    }
-
-    // Parse errors
-    if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
-        parse_json_response_errors(j, result.errors);
-        return result;
-    }
-
-    auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
-    if (result.errors.size())
-        return result;
-
-    // Parse payload
-    result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
-    auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
-    result.proof.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
-    json_require_fixed_bytes_from_hex(
-            result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
-    json_require_fixed_bytes_from_hex(
-            result_obj, "rotating_pkey", result.errors, result.proof.rotating_pubkey);
-    json_require_fixed_bytes_from_hex(result_obj, "sig", result.errors, result.proof.sig);
+GenerateProProofResponse parse_pro_proof(std::string_view json) {
+    GenerateProProofResponse result = {};
+    fill_proof_response(json, result);
     return result;
 }
 
-std::string GenerateProProofRequest::to_json() const {
-    nlohmann::json j;
-    j["version"] = version;
-    j["master_pkey"] = oxenc::to_hex(master_pkey);
-    j["rotating_pkey"] = oxenc::to_hex(rotating_pkey);
-    j["ts"] = epoch_seconds(unix_ts);
-    j["master_sig"] = oxenc::to_hex(master_sig);
-    j["rotating_sig"] = oxenc::to_hex(rotating_sig);
-    std::string result = j.dump();
-    return result;
-}
+namespace {
 
-MasterRotatingSignatures GenerateProProofRequest::build_sigs(
-        std::uint8_t request_version,
+    // --- generate-proof (endpoint generate_pro_proof) ---
+
+    array_uc32 generate_proof_hash(
+            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t> rotating_pubkey,
+            std::chrono::sys_seconds unix_ts) {
+        // Must match the generate-proof signed-request hash in pro-wire-protocol.md §3.1.
+        int64_t ts = epoch_seconds(unix_ts);
+        array_uc32 hash = {};
+        crypto_generichash_blake2b_state state = {};
+        make_blake2b32_hasher(
+                &state,
+                {SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION,
+                 sizeof(SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION) - 1});
+        crypto_generichash_blake2b_update(
+                &state, &generate_proof_version, sizeof(generate_proof_version));
+        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
+        crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
+        oxenc::host_to_little_inplace(ts);
+        crypto_generichash_blake2b_update(&state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
+        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
+        return hash;
+    }
+
+    MasterRotatingSignatures generate_proof_sign(
+            const cleared_uc64& master,
+            const cleared_uc64& rotating,
+            std::chrono::sys_seconds unix_ts) {
+        auto hash = generate_proof_hash(pubkey_of(master), pubkey_of(rotating), unix_ts);
+        MasterRotatingSignatures result = {};
+        crypto_sign_ed25519_detached(
+                result.master_sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        crypto_sign_ed25519_detached(
+                result.rotating_sig.data(), nullptr, hash.data(), hash.size(), rotating.data());
+        return result;
+    }
+
+    std::string generate_proof_body(
+            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t> rotating_pubkey,
+            std::chrono::sys_seconds unix_ts,
+            std::span<const uint8_t> master_sig,
+            std::span<const uint8_t> rotating_sig) {
+        nlohmann::json j;
+        j["version"] = generate_proof_version;
+        j["master_pkey"] = oxenc::to_hex(master_pubkey);
+        j["rotating_pkey"] = oxenc::to_hex(rotating_pubkey);
+        j["ts"] = epoch_seconds(unix_ts);
+        j["master_sig"] = oxenc::to_hex(master_sig);
+        j["rotating_sig"] = oxenc::to_hex(rotating_sig);
+        return j.dump();
+    }
+
+}  // namespace
+
+MasterRotatingSignatures pro_proof_sigs(
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
         std::chrono::sys_seconds unix_ts) {
-
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == 32) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != 64) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
-    }
-
-    cleared_uc64 rotating_from_seed;
-    if (rotating_privkey.size() == 32) {
-        array_uc32 rotating_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                rotating_pubkey.data(), rotating_from_seed.data(), rotating_privkey.data());
-        rotating_privkey = rotating_from_seed;
-    } else if (rotating_privkey.size() != 64) {
-        throw std::invalid_argument{"Invalid rotating_privkey: expected 32 or 64 bytes"};
-    }
-
-    // Hash components to 32 bytes, must match:
-    //   https://github.com/Doy-lee/session-pro-backend/blob/5b66b1a4a64dc8da0225507019cbe21d7642fa78/backend.py#L631
-    uint8_t version = 0;
-    int64_t ts = epoch_seconds(unix_ts);
-    array_uc32 hash_to_sign = {};
-    crypto_generichash_blake2b_state state = {};
-    make_blake2b32_hasher(
-            &state,
-            {SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION,
-             sizeof(SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, &version, sizeof(version));
-    crypto_generichash_blake2b_update(
-            &state, master_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
-    crypto_generichash_blake2b_update(
-            &state, rotating_privkey.data() + 32, crypto_sign_ed25519_PUBLICKEYBYTES);
-    oxenc::host_to_little_inplace(ts);
-    crypto_generichash_blake2b_update(&state, reinterpret_cast<uint8_t*>(&ts), sizeof(ts));
-    crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
-
-    // Sign the hash with both keys
-    MasterRotatingSignatures result = {};
-    crypto_sign_ed25519_detached(
-            result.master_sig.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            master_privkey.data());
-    crypto_sign_ed25519_detached(
-            result.rotating_sig.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            rotating_privkey.data());
-    return result;
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
+    return generate_proof_sign(master, rotating, unix_ts);
 }
 
-std::string GenerateProProofRequest::build_to_json(
-        std::uint8_t request_version,
+ProRequest pro_proof_request(
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,
         std::chrono::sys_seconds unix_ts) {
-    // Rederive keys from 32 byte seed if given
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == 32) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != 64) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
-    }
-
-    cleared_uc64 rotating_from_seed;
-    if (rotating_privkey.size() == 32) {
-        array_uc32 rotating_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                rotating_pubkey.data(), rotating_from_seed.data(), rotating_privkey.data());
-        rotating_privkey = rotating_from_seed;
-    } else if (rotating_privkey.size() != 64) {
-        throw std::invalid_argument{"Invalid rotating_privkey: expected 32 or 64 bytes"};
-    }
-
-    MasterRotatingSignatures sigs = GenerateProProofRequest::build_sigs(
-            request_version, master_privkey, rotating_privkey, unix_ts);
-
-    GenerateProProofRequest request = {};
-    request.version = request_version;
-    std::memcpy(
-            request.master_pkey.data(),
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    std::memcpy(
-            request.rotating_pkey.data(),
-            rotating_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.unix_ts = unix_ts;
-    request.master_sig = sigs.master_sig;
-    request.rotating_sig = sigs.rotating_sig;
-
-    std::string result = request.to_json();
-    return result;
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
+    auto sigs = generate_proof_sign(master, rotating, unix_ts);
+    return {generate_proof_endpoint,
+            generate_proof_body(
+                    pubkey_of(master),
+                    pubkey_of(rotating),
+                    unix_ts,
+                    sigs.master_sig,
+                    sigs.rotating_sig)};
 }
 
-std::string GetProRevocationsRequest::to_json() const {
+ProRequest revocations_request(std::int64_t ticket) {
     nlohmann::json j;
-    j["version"] = version;
+    j["version"] = get_pro_revocations_version;
     j["ticket"] = ticket;
-    std::string result = j.dump();
-    return result;
+    return {get_pro_revocations_endpoint, j.dump()};
 }
 
-GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json) {
+GetProRevocationsResponse parse_revocations(std::string_view json) {
     // Parse basics
     GetProRevocationsResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
@@ -467,93 +487,73 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
     return result;
 }
 
-std::string GetProDetailsRequest::to_json() const {
-    nlohmann::json j;
-    j["version"] = version;
-    j["master_pkey"] = oxenc::to_hex(master_pkey);
-    j["master_sig"] = oxenc::to_hex(master_sig);
-    j["ts"] = epoch_seconds(unix_ts);
-    j["count"] = count;
-    std::string result = j.dump();
-    return result;
-}
+namespace {
 
-array_uc64 GetProDetailsRequest::build_sig(
-        uint8_t version,
-        std::span<const uint8_t> master_privkey,
-        std::chrono::sys_seconds unix_ts,
-        uint32_t count) {
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
+    // --- payment-details / get-pro-details (endpoint get_pro_details) ---
+
+    array_uc32 payment_details_hash(
+            std::span<const uint8_t> master_pubkey,
+            std::chrono::sys_seconds unix_ts,
+            uint32_t count) {
+        // Must match the get-pro-details signed-request hash in pro-wire-protocol.md §3.4.
+        int64_t ts = epoch_seconds(unix_ts);
+        array_uc32 hash = {};
+        crypto_generichash_blake2b_state state = {};
+        make_blake2b32_hasher(
+                &state,
+                {SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION,
+                 sizeof(SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION) - 1});
+        crypto_generichash_blake2b_update(
+                &state, &get_pro_details_version, sizeof(get_pro_details_version));
+        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
+        oxenc::host_to_little_inplace(ts);
+        oxenc::host_to_little_inplace(count);
+        crypto_generichash_blake2b_update(
+                &state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
+        crypto_generichash_blake2b_update(
+                &state, reinterpret_cast<unsigned char*>(&count), sizeof(count));
+        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
+        return hash;
     }
 
-    // Hash components to 32 bytes, must match:
-    //   https://github.com/Doy-lee/session-pro-backend/blob/635b14fc93302658de6c07c017f705673fc7c57f/server.py#L395
-    array_uc32 hash_to_sign = {};
-    crypto_generichash_blake2b_state state = {};
-    int64_t ts = epoch_seconds(unix_ts);
-    make_blake2b32_hasher(
-            &state,
-            {SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION,
-             sizeof(SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, &version, sizeof(version));
-    crypto_generichash_blake2b_update(
-            &state,
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    oxenc::host_to_little_inplace(ts);
-    oxenc::host_to_little_inplace(count);
-    crypto_generichash_blake2b_update(&state, reinterpret_cast<unsigned char*>(&ts), sizeof(ts));
-    crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<unsigned char*>(&count), sizeof(count));
-    crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
-
-    // Sign the hash
-    array_uc64 result = {};
-    crypto_sign_ed25519_detached(
-            result.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            master_privkey.data());
-    return result;
-}
-
-std::string GetProDetailsRequest::build_to_json(
-        uint8_t version,
-        std::span<const uint8_t> master_privkey,
-        std::chrono::sys_seconds unix_ts,
-        uint32_t count) {
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
+    array_uc64 payment_details_sign(
+            const cleared_uc64& master, std::chrono::sys_seconds unix_ts, uint32_t count) {
+        auto hash = payment_details_hash(pubkey_of(master), unix_ts, count);
+        array_uc64 sig = {};
+        crypto_sign_ed25519_detached(sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        return sig;
     }
 
-    GetProDetailsRequest request = {};
-    request.version = version;
-    memcpy(request.master_pkey.data(),
-           master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-           crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.master_sig = GetProDetailsRequest::build_sig(version, master_privkey, unix_ts, count);
-    request.unix_ts = unix_ts;
-    request.count = count;
+    std::string payment_details_body(
+            std::span<const uint8_t> master_pubkey,
+            std::span<const uint8_t> master_sig,
+            std::chrono::sys_seconds unix_ts,
+            uint32_t count) {
+        nlohmann::json j;
+        j["version"] = get_pro_details_version;
+        j["master_pkey"] = oxenc::to_hex(master_pubkey);
+        j["master_sig"] = oxenc::to_hex(master_sig);
+        j["ts"] = epoch_seconds(unix_ts);
+        j["count"] = count;
+        return j.dump();
+    }
 
-    std::string result = request.to_json();
-    return result;
+}  // namespace
+
+array_uc64 payment_details_sig(
+        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts, uint32_t count) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    return payment_details_sign(master, unix_ts, count);
 }
 
-GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
+ProRequest payment_details_request(
+        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts, uint32_t count) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto sig = payment_details_sign(master, unix_ts, count);
+    return {get_pro_details_endpoint, payment_details_body(pubkey_of(master), sig, unix_ts, count)};
+}
+
+GetProDetailsResponse parse_payment_details(std::string_view json) {
     // Parse basics
     GetProDetailsResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
@@ -661,117 +661,107 @@ GetProDetailsResponse GetProDetailsResponse::parse(std::string_view json) {
     return result;
 }
 
-array_uc64 SetPaymentRefundRequestedRequest::build_sig(
-        uint8_t version,
-        std::span<const uint8_t> master_privkey,
-        std::chrono::sys_seconds unix_ts,
-        std::chrono::sys_seconds refund_requested_unix_ts,
-        std::string_view payment_tx_provider_code,
-        std::span<const uint8_t> payment_tx_payment_id) {
-    cleared_uc64 master_from_seed;
-    if (master_privkey.size() == crypto_sign_ed25519_SEEDBYTES) {
-        array_uc32 master_pubkey;
-        crypto_sign_ed25519_seed_keypair(
-                master_pubkey.data(), master_from_seed.data(), master_privkey.data());
-        master_privkey = master_from_seed;
-    } else if (master_privkey.size() != crypto_sign_ed25519_SECRETKEYBYTES) {
-        throw std::invalid_argument{"Invalid master_privkey: expected 32 or 64 bytes"};
+namespace {
+
+    // --- refund / set-payment-refund-requested (endpoint set_payment_refund_requested) ---
+
+    array_uc32 refund_hash(
+            std::span<const uint8_t> master_pubkey,
+            std::chrono::sys_seconds unix_ts,
+            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::string_view provider_code,
+            std::span<const uint8_t> payment_id) {
+        // Must match the set-payment-refund-requested signed-request hash in pro-wire-protocol.md
+        // §3.3 (+ §3.5 for payment_id).
+        int64_t ts = epoch_seconds(unix_ts);
+        int64_t refund_requested_ts = epoch_seconds(refund_requested_unix_ts);
+        array_uc32 hash = {};
+        crypto_generichash_blake2b_state state = {};
+        make_blake2b32_hasher(
+                &state,
+                {SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION,
+                 sizeof(SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION) - 1});
+        crypto_generichash_blake2b_update(&state, &set_refund_version, sizeof(set_refund_version));
+        crypto_generichash_blake2b_update(&state, master_pubkey.data(), master_pubkey.size());
+        oxenc::host_to_little_inplace(ts);
+        oxenc::host_to_little_inplace(refund_requested_ts);
+        crypto_generichash_blake2b_update(
+                &state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
+        crypto_generichash_blake2b_update(
+                &state,
+                reinterpret_cast<const uint8_t*>(&refund_requested_ts),
+                sizeof(refund_requested_ts));
+        crypto_generichash_blake2b_update(
+                &state,
+                reinterpret_cast<const uint8_t*>(provider_code.data()),
+                provider_code.size());
+        crypto_generichash_blake2b_update(&state, payment_id.data(), payment_id.size());
+        crypto_generichash_blake2b_final(&state, hash.data(), hash.size());
+        return hash;
     }
 
-    // Hash components to 32 bytes, must match:
-    //   https://github.com/Doy-lee/session-pro-backend/blob/5962925d7f18f83a3ff5774885495e5dd55ecb0a/server.py#L634
-    array_uc32 hash_to_sign = {};
-    crypto_generichash_blake2b_state state = {};
-    make_blake2b32_hasher(
-            &state,
-            {SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION,
-             sizeof(SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, &version, sizeof(version));
-    crypto_generichash_blake2b_update(
-            &state,
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
+    array_uc64 refund_sign(
+            const cleared_uc64& master,
+            std::chrono::sys_seconds unix_ts,
+            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::string_view provider_code,
+            std::span<const uint8_t> payment_id) {
+        auto hash = refund_hash(
+                pubkey_of(master), unix_ts, refund_requested_unix_ts, provider_code, payment_id);
+        array_uc64 sig = {};
+        crypto_sign_ed25519_detached(sig.data(), nullptr, hash.data(), hash.size(), master.data());
+        return sig;
+    }
 
-    // Timestamps
-    int64_t ts = epoch_seconds(unix_ts);
-    int64_t refund_requested_ts = epoch_seconds(refund_requested_unix_ts);
-    oxenc::host_to_little_inplace(ts);
-    oxenc::host_to_little_inplace(refund_requested_ts);
-    crypto_generichash_blake2b_update(&state, reinterpret_cast<const uint8_t*>(&ts), sizeof(ts));
-    crypto_generichash_blake2b_update(
-            &state,
-            reinterpret_cast<const uint8_t*>(&refund_requested_ts),
-            sizeof(refund_requested_ts));
+    std::string refund_body(
+            std::span<const uint8_t> master_pubkey,
+            std::chrono::sys_seconds unix_ts,
+            std::chrono::sys_seconds refund_requested_unix_ts,
+            std::string_view provider_code,
+            std::string_view payment_id,
+            std::span<const uint8_t> master_sig) {
+        nlohmann::json j;
+        j["version"] = set_refund_version;
+        j["master_pkey"] = oxenc::to_hex(master_pubkey);
+        j["ts"] = epoch_seconds(unix_ts);
+        j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
+        j["payment_tx"]["provider"] = provider_code;
+        j["payment_tx"]["payment_id"] = payment_id;
+        j["master_sig"] = oxenc::to_hex(master_sig);
+        return j.dump();
+    }
 
-    // Payment provider
-    crypto_generichash_blake2b_update(
-            &state,
-            reinterpret_cast<const uint8_t*>(payment_tx_provider_code.data()),
-            payment_tx_provider_code.size());
-    crypto_generichash_blake2b_update(
-            &state,
-            reinterpret_cast<const uint8_t*>(payment_tx_payment_id.data()),
-            payment_tx_payment_id.size());
-    crypto_generichash_blake2b_final(&state, hash_to_sign.data(), hash_to_sign.size());
+}  // namespace
 
-    // Sign the hash
-    array_uc64 result = {};
-    crypto_sign_ed25519_detached(
-            result.data(),
-            nullptr,
-            hash_to_sign.data(),
-            hash_to_sign.size(),
-            master_privkey.data());
-    return result;
-}
-
-std::string SetPaymentRefundRequestedRequest::build_to_json(
-        uint8_t version,
+array_uc64 refund_sig(
         std::span<const uint8_t> master_privkey,
         std::chrono::sys_seconds unix_ts,
         std::chrono::sys_seconds refund_requested_unix_ts,
-        std::string_view payment_tx_provider_code,
-        std::span<const uint8_t> payment_tx_payment_id) {
-    array_uc64 sig = SetPaymentRefundRequestedRequest::build_sig(
-            version,
-            master_privkey,
-            unix_ts,
-            refund_requested_unix_ts,
-            payment_tx_provider_code,
-            payment_tx_payment_id);
-
-    SetPaymentRefundRequestedRequest request = {};
-    request.version = version;
-    std::memcpy(
-            request.master_pkey.data(),
-            master_privkey.data() + crypto_sign_ed25519_SEEDBYTES,
-            crypto_sign_ed25519_PUBLICKEYBYTES);
-    request.payment_tx.provider_code = std::string(payment_tx_provider_code);
-    request.payment_tx.payment_id = std::string(
-            reinterpret_cast<const char*>(payment_tx_payment_id.data()),
-            payment_tx_payment_id.size());
-    request.master_sig = sig;
-    request.unix_ts = unix_ts;
-    request.refund_requested_unix_ts = refund_requested_unix_ts;
-
-    std::string result = request.to_json();
-    return result;
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    return refund_sign(master, unix_ts, refund_requested_unix_ts, provider_code, payment_id);
 }
 
-std::string SetPaymentRefundRequestedRequest::to_json() const {
-    nlohmann::json j;
-    j["version"] = version;
-    j["master_pkey"] = oxenc::to_hex(master_pkey);
-    j["ts"] = epoch_seconds(unix_ts);
-    j["refund_requested_ts"] = epoch_seconds(refund_requested_unix_ts);
-    j["payment_tx"]["provider"] = payment_tx.provider_code;
-    j["payment_tx"]["payment_id"] = payment_tx.payment_id;
-    j["master_sig"] = oxenc::to_hex(master_sig);
-    std::string result = j.dump();
-    return result;
+ProRequest refund_request(
+        std::span<const uint8_t> master_privkey,
+        std::chrono::sys_seconds unix_ts,
+        std::chrono::sys_seconds refund_requested_unix_ts,
+        std::string_view provider_code,
+        std::span<const uint8_t> payment_id) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto sig = refund_sign(master, unix_ts, refund_requested_unix_ts, provider_code, payment_id);
+    return {set_refund_endpoint,
+            refund_body(
+                    pubkey_of(master),
+                    unix_ts,
+                    refund_requested_unix_ts,
+                    provider_code,
+                    payment_id_view(payment_id),
+                    sig)};
 }
 
-SetPaymentRefundRequestedResponse SetPaymentRefundRequestedResponse::parse(std::string_view json) {
+SetPaymentRefundRequestedResponse parse_refund(std::string_view json) {
     // Parse basics
     SetPaymentRefundRequestedResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
@@ -809,7 +799,6 @@ static string8 C_PARSE_ERROR_INVALID_ARGS = STRING8_LIT("One or more C arguments
 
 LIBSESSION_C_API session_pro_backend_master_rotating_signatures
 session_pro_backend_add_pro_payment_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
@@ -826,12 +815,8 @@ session_pro_backend_add_pro_payment_request_build_sigs(
 
     session_pro_backend_master_rotating_signatures result = {};
     try {
-        auto sigs = AddProPaymentRequest::build_sigs(
-                request_version,
-                master_span,
-                rotating_span,
-                payment_tx_provider_code,
-                payment_tx_payment_id_span);
+        auto sigs = add_payment_sigs(
+                master_span, rotating_span, payment_tx_provider_code, payment_tx_payment_id_span);
         std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
         std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
         result.success = true;
@@ -844,52 +829,11 @@ session_pro_backend_add_pro_payment_request_build_sigs(
                 static_cast<int>(error.size()),
                 error.data());
     }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_to_json
-session_pro_backend_add_pro_payment_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        const uint8_t* rotating_privkey,
-        size_t rotating_privkey_len,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) {
-    session_pro_backend_to_json result = {};
-
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
-    std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    std::span<const uint8_t> payment_tx_payment_id_span(
-            payment_tx_payment_id, payment_tx_payment_id_len);
-
-    try {
-        std::string json = AddProPaymentRequest::build_to_json(
-                request_version,
-                master_span,
-                rotating_span,
-                payment_tx_provider_code,
-                payment_tx_payment_id_span);
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-
     return result;
 }
 
 LIBSESSION_C_API session_pro_backend_master_rotating_signatures
 session_pro_backend_generate_pro_proof_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         const uint8_t* rotating_privkey,
@@ -901,39 +845,9 @@ session_pro_backend_generate_pro_proof_request_build_sigs(
     std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
     session_pro_backend_master_rotating_signatures result = {};
     try {
-        auto sigs = GenerateProProofRequest::build_sigs(
-                request_version, master_span, rotating_span, session::as_sys_seconds(ts));
+        auto sigs = pro_proof_sigs(master_span, rotating_span, session::as_sys_seconds(ts));
         std::memcpy(result.master_sig.data, sigs.master_sig.data(), sigs.master_sig.size());
         std::memcpy(result.rotating_sig.data, sigs.rotating_sig.data(), sigs.rotating_sig.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_EXPORT
-session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        const uint8_t* rotating_privkey,
-        size_t rotating_privkey_len,
-        int64_t ts) {
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span(master_privkey, master_privkey_len);
-    std::span<const uint8_t> rotating_span(rotating_privkey, rotating_privkey_len);
-    session_pro_backend_to_json result = {};
-    try {
-        auto json = GenerateProProofRequest::build_to_json(
-                request_version, master_span, rotating_span, session::as_sys_seconds(ts));
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -949,45 +863,13 @@ session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_build
 
 LIBSESSION_C_API session_pro_backend_signature
 session_pro_backend_get_pro_details_request_build_sig(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        uint32_t count) {
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count) {
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
     session_pro_backend_signature result = {};
     try {
-        auto sig = GetProDetailsRequest::build_sig(
-                request_version, master_span, session::as_sys_seconds(ts), count);
+        auto sig = payment_details_sig(master_span, session::as_sys_seconds(ts), count);
         std::memcpy(result.sig.data, sig.data(), sig.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_to_json
-session_pro_backend_get_pro_details_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        uint32_t count) {
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    session_pro_backend_to_json result = {};
-    try {
-        auto json = GetProDetailsRequest::build_to_json(
-                request_version, master_span, session::as_sys_seconds(ts), count);
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -1007,20 +889,14 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_add_pro_payment
     if (!request)
         return result;
 
-    // Construct C++ struct
-    AddProPaymentRequest cpp = {};
-    cpp.version = request->version;
-    std::memcpy(cpp.master_pkey.data(), request->master_pkey.data, cpp.master_pkey.size());
-    std::memcpy(cpp.rotating_pkey.data(), request->rotating_pkey.data, cpp.rotating_pkey.size());
-    cpp.payment_tx.provider_code =
-            std::string(request->payment_tx.provider_code, request->payment_tx.provider_code_count);
-    cpp.payment_tx.payment_id =
-            std::string(request->payment_tx.payment_id, request->payment_tx.payment_id_count);
-    std::memcpy(cpp.master_sig.data(), request->master_sig.data, cpp.master_sig.size());
-    std::memcpy(cpp.rotating_sig.data(), request->rotating_sig.data, cpp.rotating_sig.size());
-
     try {
-        std::string json = cpp.to_json();
+        std::string json = add_payment_body(
+                {request->master_pkey.data, sizeof(request->master_pkey.data)},
+                {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
+                {request->payment_tx.provider_code, request->payment_tx.provider_code_count},
+                {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
+                {request->master_sig.data, sizeof(request->master_sig.data)},
+                {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1042,17 +918,13 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_generate_pro_pr
     if (!request)
         return result;
 
-    // Construct C++ struct
-    GenerateProProofRequest cpp;
-    cpp.version = request->version;
-    std::memcpy(cpp.master_pkey.data(), request->master_pkey.data, cpp.master_pkey.size());
-    std::memcpy(cpp.rotating_pkey.data(), request->rotating_pkey.data, cpp.rotating_pkey.size());
-    cpp.unix_ts = session::as_sys_seconds(request->ts);
-    std::memcpy(cpp.master_sig.data(), request->master_sig.data, cpp.master_sig.size());
-    std::memcpy(cpp.rotating_sig.data(), request->rotating_sig.data, cpp.rotating_sig.size());
-
     try {
-        std::string json = cpp.to_json();
+        std::string json = generate_proof_body(
+                {request->master_pkey.data, sizeof(request->master_pkey.data)},
+                {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
+                session::as_sys_seconds(request->ts),
+                {request->master_sig.data, sizeof(request->master_sig.data)},
+                {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1075,13 +947,8 @@ session_pro_backend_get_pro_revocations_request_to_json(
     if (!request)
         return result;
 
-    // Construct C++ struct
-    GetProRevocationsRequest cpp = {};
-    cpp.version = request->version;
-    cpp.ticket = request->ticket;
-
     try {
-        std::string json = cpp.to_json();
+        std::string json = revocations_request(request->ticket).body;
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1103,17 +970,12 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_get_pro_details
     if (!request)
         return result;
 
-    // Construct C++ struct
-    GetProDetailsRequest cpp = {};
-    cpp.version = request->version;
-    std::memcpy(
-            cpp.master_pkey.data(), request->master_pkey.data, sizeof(request->master_pkey.data));
-    std::memcpy(cpp.master_sig.data(), request->master_sig.data, sizeof(request->master_sig.data));
-    cpp.unix_ts = session::as_sys_seconds(request->ts);
-    cpp.count = request->count;
-
     try {
-        std::string json = cpp.to_json();
+        std::string json = payment_details_body(
+                {request->master_pkey.data, sizeof(request->master_pkey.data)},
+                {request->master_sig.data, sizeof(request->master_sig.data)},
+                session::as_sys_seconds(request->ts),
+                request->count);
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1129,11 +991,10 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_get_pro_details
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_add_pro_payment_or_generate_pro_proof_response
-session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
-        const char* json, size_t json_len) {
+LIBSESSION_C_API session_pro_backend_pro_proof_response
+session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) {
 
-    session_pro_backend_add_pro_payment_or_generate_pro_proof_response result = {};
+    session_pro_backend_pro_proof_response result = {};
     if (!json) {
         result.header.status = 1;
         result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
@@ -1142,7 +1003,9 @@ session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
     }
 
     // Note, parse is written to not throw so we can safely read without try-catch crap
-    auto cpp = AddProPaymentOrGenerateProProofResponse::parse({json, json_len});
+    // add-payment and generate-proof share the proof-response shape; the C response struct is
+    // generic, so either derived parser works here.
+    auto cpp = parse_add_payment({json, json_len});
 
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
@@ -1202,7 +1065,7 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     }
 
     // Note, parse is written to not throw so we can safely read without try-catch crap
-    GetProRevocationsResponse cpp = GetProRevocationsResponse::parse({json, json_len});
+    GetProRevocationsResponse cpp = parse_revocations({json, json_len});
 
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
@@ -1269,7 +1132,7 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     }
 
     // Note, parse is written to not throw so we can safely read without try-catch crap
-    auto cpp = GetProDetailsResponse::parse({json, json_len});
+    auto cpp = parse_payment_details({json, json_len});
 
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
@@ -1343,7 +1206,6 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
 
 LIBSESSION_C_API
 session_pro_backend_signature session_pro_backend_set_payment_refund_requested_request_build_sigs(
-        uint8_t request_version,
         const uint8_t* master_privkey,
         size_t master_privkey_len,
         int64_t ts,
@@ -1361,8 +1223,7 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
 
     session_pro_backend_signature result = {};
     try {
-        auto sig = SetPaymentRefundRequestedRequest::build_sig(
-                request_version,
+        auto sig = refund_sig(
                 master_span,
                 unix_ts,
                 refund_requested_unix_ts,
@@ -1383,69 +1244,20 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
 }
 
 LIBSESSION_C_API session_pro_backend_to_json
-session_pro_backend_set_payment_refund_requested_request_build_to_json(
-        uint8_t request_version,
-        const uint8_t* master_privkey,
-        size_t master_privkey_len,
-        int64_t ts,
-        int64_t refund_requested_ts,
-        const char* payment_tx_provider_code,
-        const uint8_t* payment_tx_payment_id,
-        size_t payment_tx_payment_id_len) {
-
-    // Convert C inputs to C++ types
-    std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
-    std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
-    std::chrono::sys_seconds refund_requested_unix_ts =
-            session::as_sys_seconds(refund_requested_ts);
-    std::span<const uint8_t> payment_tx_payment_id_span(
-            payment_tx_payment_id, payment_tx_payment_id_len);
-
-    session_pro_backend_to_json result = {};
-    try {
-        auto json = SetPaymentRefundRequestedRequest::build_to_json(
-                request_version,
-                master_span,
-                unix_ts,
-                refund_requested_unix_ts,
-                payment_tx_provider_code,
-                payment_tx_payment_id_span);
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
-        result.success = true;
-    } catch (const std::exception& e) {
-        const std::string& error = e.what();
-        result.error_count = snprintf_clamped(
-                result.error,
-                sizeof(result.error_count),
-                "%.*s",
-                static_cast<int>(error.size()),
-                error.data());
-    }
-    return result;
-}
-
-LIBSESSION_C_API session_pro_backend_to_json
 session_pro_backend_set_payment_refund_requested_request_to_json(
         const session_pro_backend_set_payment_refund_requested_request* request) {
     session_pro_backend_to_json result = {};
     if (!request)
         return result;
 
-    // Construct C++ struct
-    SetPaymentRefundRequestedRequest cpp = {};
-    cpp.version = request->version;
-    std::memcpy(
-            cpp.master_pkey.data(), request->master_pkey.data, sizeof(request->master_pkey.data));
-    std::memcpy(cpp.master_sig.data(), request->master_sig.data, sizeof(request->master_sig.data));
-    cpp.unix_ts = session::as_sys_seconds(request->ts);
-    cpp.refund_requested_unix_ts = session::as_sys_seconds(request->refund_requested_ts);
-    cpp.payment_tx.provider_code =
-            std::string(request->payment_tx.provider_code, request->payment_tx.provider_code_count);
-    cpp.payment_tx.payment_id =
-            std::string(request->payment_tx.payment_id, request->payment_tx.payment_id_count);
-
     try {
-        std::string json = cpp.to_json();
+        std::string json = refund_body(
+                {request->master_pkey.data, sizeof(request->master_pkey.data)},
+                session::as_sys_seconds(request->ts),
+                session::as_sys_seconds(request->refund_requested_ts),
+                {request->payment_tx.provider_code, request->payment_tx.provider_code_count},
+                {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
+                {request->master_sig.data, sizeof(request->master_sig.data)});
         result.json = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
@@ -1472,7 +1284,7 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
     }
 
     // Note, parse is written to not throw so we can safely read without try-catch crap
-    auto cpp = SetPaymentRefundRequestedResponse::parse({json, json_len});
+    auto cpp = parse_refund({json, json_len});
 
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
@@ -1518,8 +1330,8 @@ LIBSESSION_C_API void session_pro_backend_to_json_free(session_pro_backend_to_js
     }
 }
 
-LIBSESSION_C_API void session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response* response) {
+LIBSESSION_C_API void session_pro_backend_pro_proof_response_free(
+        session_pro_backend_pro_proof_response* response) {
     if (response) {
         free(response->header.internal_arena_buf_);
         *response = {};

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -357,7 +357,7 @@ AddProPaymentOrGenerateProProofResponse AddProPaymentOrGenerateProProofResponse:
     result.proof.expiry_unix_ts = std::chrono::sys_seconds(
             std::chrono::seconds(expiry_ts));
     json_require_fixed_bytes_from_hex(
-            result_obj, "gen_index_hash", result.errors, result.proof.gen_index_hash);
+            result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
     json_require_fixed_bytes_from_hex(
             result_obj, "rotating_pkey", result.errors, result.proof.rotating_pubkey);
     json_require_fixed_bytes_from_hex(result_obj, "sig", result.errors, result.proof.sig);
@@ -534,7 +534,7 @@ GetProRevocationsResponse GetProRevocationsResponse::parse(std::string_view json
         ProRevocationItem item = {};
         item.expiry_unix_ts = as_sys_seconds(expiry_unix_ts);
         json_require_fixed_bytes_from_hex(
-                obj, "gen_index_hash", result.errors, item.gen_index_hash);
+                obj, "revocation_tag", result.errors, item.revocation_tag);
 
         // Handle parsing result
         if (result.errors.size())
@@ -1339,9 +1339,9 @@ session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
     result.proof.version = cpp.proof.version;
     result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_unix_ts);
     std::memcpy(
-            result.proof.gen_index_hash.data,
-            cpp.proof.gen_index_hash.data(),
-            cpp.proof.gen_index_hash.size());
+            result.proof.revocation_tag.data,
+            cpp.proof.revocation_tag.data(),
+            cpp.proof.revocation_tag.size());
     std::memcpy(
             result.proof.rotating_pubkey.data,
             cpp.proof.rotating_pubkey.data(),
@@ -1418,7 +1418,7 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     for (size_t index = 0; index < result.items_count; ++index) {
         const ProRevocationItem& src = cpp.items[index];
         session_pro_backend_pro_revocation_item& dest = result.items[index];
-        std::memcpy(dest.gen_index_hash.data, src.gen_index_hash.data(), src.gen_index_hash.size());
+        std::memcpy(dest.revocation_tag.data, src.revocation_tag.data(), src.revocation_tag.size());
         dest.expiry_ts = session::epoch_seconds(src.expiry_unix_ts);
     }
     return result;

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -243,37 +243,52 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_
         PAYMENT_PROVIDER_RANGEPROOF.data();
 }
 
-std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {
+using namespace std::literals;
+
+// Fixed per-provider URL sets; provider_urls() just maps a provider code to one of these. The
+// values are `""sv` literals so clang-format keeps each URL on one line (it won't split a string
+// literal).
+constexpr ProviderURLs google_play_urls{
+        .refund_platform_url = "https://support.google.com/googleplay/workflow/9813244?"sv,
+        .refund_support_url = "https://getsession.org/android-refund"sv,
+        .refund_status_url = "https://getsession.org/android-refund"sv,
+        .update_subscription_url =
+                "https://play.google.com/store/account/subscriptions?package=network.loki.messenger"sv,
+        .cancel_subscription_url =
+                "https://play.google.com/store/account/subscriptions?package=network.loki.messenger"sv,
+};
+constexpr ProviderURLs app_store_urls{
+        .refund_platform_url = "https://support.apple.com/118223"sv,
+        .refund_support_url = "https://support.apple.com/118223"sv,
+        .refund_status_url = "https://support.apple.com/118224"sv,
+        .update_subscription_url = "https://apps.apple.com/account/subscriptions"sv,
+        .cancel_subscription_url =
+                "https://account.apple.com/account/manage/section/subscriptions"sv,
+};
+
+const ProviderURLs* provider_urls(std::string_view provider_code) {
     if (provider_code == PAYMENT_PROVIDER_GOOGLE_PLAY)
-        return ProviderUrls{
-                "https://support.google.com/googleplay/workflow/9813244?",
-                "https://getsession.org/android-refund",
-                "https://getsession.org/android-refund",
-                "https://play.google.com/store/account/"
-                "subscriptions?package=network.loki.messenger",
-                "https://play.google.com/store/account/"
-                "subscriptions?package=network.loki.messenger"};
+        return &google_play_urls;
     if (provider_code == PAYMENT_PROVIDER_APP_STORE)
-        return ProviderUrls{
-                "https://support.apple.com/118223",
-                "https://support.apple.com/118223",
-                "https://support.apple.com/118224",
-                "https://apps.apple.com/account/subscriptions",
-                "https://account.apple.com/account/manage/section/subscriptions"};
+        return &app_store_urls;
     // rangeproof and unknown providers have no applicable URLs
-    return std::nullopt;
+    return nullptr;
 }
 
 LIBSESSION_C_API session_pro_backend_provider_urls
 session_pro_backend_get_provider_urls(const char* provider_code) {
-    // No URLs → all-NULL fields; otherwise each view is a static, null-terminated literal.
+    // Each present field is a static, null-terminated literal; an absent one (or no URLs at all) is
+    // NULL.
+    auto c = [](const std::optional<std::string_view>& u) -> const char* {
+        return u ? u->data() : nullptr;
+    };
     if (auto u = provider_urls(provider_code))
-        return {u->refund_platform_url.data(),
-                u->refund_support_url.data(),
-                u->refund_status_url.data(),
-                u->update_subscription_url.data(),
-                u->cancel_subscription_url.data()};
-    return {nullptr, nullptr, nullptr, nullptr, nullptr};
+        return {.refund_platform_url = c(u->refund_platform_url),
+                .refund_support_url = c(u->refund_support_url),
+                .refund_status_url = c(u->refund_status_url),
+                .update_subscription_url = c(u->update_subscription_url),
+                .cancel_subscription_url = c(u->cancel_subscription_url)};
+    return {};
 }
 
 std::span<const std::string_view> visible_platforms() {

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -267,6 +267,27 @@ session_pro_backend_get_provider_urls(const char* provider_code) {
     return {nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
+std::span<const std::string_view> visible_platforms() {
+    static const std::array<std::string_view, 2> platforms = {
+            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE};
+    return platforms;
+}
+
+LIBSESSION_C_API const char* const* session_pro_backend_visible_platforms(size_t* count) {
+    // Derived from the C++ list (single source); each slug's data() is a static, null-terminated
+    // literal, so the pointer array is safe to hand out as static storage.
+    static const std::vector<const char*> codes = [] {
+        std::vector<const char*> v;
+        for (auto slug : visible_platforms())
+            v.push_back(slug.data());
+        return v;
+    }();
+    if (count)
+        *count = codes.size();
+    return codes.data();
+}
+
 MasterRotatingSignatures add_payment_sigs(
         std::span<const uint8_t> master_privkey,
         std::span<const uint8_t> rotating_privkey,

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -131,7 +131,8 @@ namespace {
     // and the C++ `*_request()` return values point at these — the path is defined exactly once.
     constexpr char add_payment_endpoint[] = "add_pro_payment";
     constexpr char generate_proof_endpoint[] = "generate_pro_proof";
-    constexpr char get_pro_details_endpoint[] = "get_pro_details";
+    constexpr char get_pro_status_endpoint[] = "get_pro_status";
+    constexpr char get_payment_details_endpoint[] = "get_payment_details";
     constexpr char get_pro_revocations_endpoint[] = "get_pro_revocations";
     constexpr char set_refund_endpoint[] = "set_payment_refund_requested";
 
@@ -221,8 +222,10 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_E
         add_payment_endpoint;
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT =
         generate_proof_endpoint;
-LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT =
-        get_pro_details_endpoint;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_STATUS_ENDPOINT =
+        get_pro_status_endpoint;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PAYMENT_DETAILS_ENDPOINT =
+        get_payment_details_endpoint;
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT =
         get_pro_revocations_endpoint;
 LIBSESSION_EXPORT extern const char* const
@@ -582,21 +585,58 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
 
 namespace {
 
-    // --- payment-details / get-pro-details (endpoint get_pro_details) ---
+    // --- get-pro-status (endpoint get_pro_status) ---
+
+    std::vector<unsigned char> pro_status_message(
+            std::span<const uint8_t, 32> master_pubkey, std::chrono::sys_seconds unix_ts) {
+        // Must match the get-pro-status signed-request message in pro-wire-protocol.md §3.4, built
+        // per §1.1.
+        return session::pro::signed_message(
+                session::GET_PRO_STATUS_DOMAIN, master_pubkey, epoch_seconds(unix_ts));
+    }
+
+    array_uc64 pro_status_sign(const cleared_uc64& master, std::chrono::sys_seconds unix_ts) {
+        auto msg = pro_status_message(pubkey_of(master), unix_ts);
+        array_uc64 sig = {};
+        crypto_sign_ed25519_detached(sig.data(), nullptr, msg.data(), msg.size(), master.data());
+        return sig;
+    }
+
+    std::string pro_status_body(
+            std::span<const uint8_t, 32> master_pubkey,
+            std::span<const uint8_t, 64> master_sig,
+            std::chrono::sys_seconds unix_ts) {
+        return nlohmann::json{
+                {"master_pkey", oxenc::to_hex(master_pubkey)},
+                {"master_sig", oxenc::to_hex(master_sig)},
+                {"ts", epoch_seconds(unix_ts)}}
+                .dump();
+    }
+
+    // --- get-payment-details (endpoint get_payment_details) ---
 
     std::vector<unsigned char> payment_details_message(
             std::span<const uint8_t, 32> master_pubkey,
             std::chrono::sys_seconds unix_ts,
-            int64_t count) {
-        // Must match the get-pro-details signed-request message in pro-wire-protocol.md §3.4,
-        // built per §1.1. `count` is a signed integer (a decimal-ASCII -1 requests "all").
+            uint32_t limit,
+            std::string_view before) {
+        // Must match the get-payment-details signed-request message in pro-wire-protocol.md §3.4,
+        // built per §1.1. `before` is the opaque pagination cursor (§5.3), empty for the newest
+        // page.
         return session::pro::signed_message(
-                session::GET_PRO_DETAILS_DOMAIN, master_pubkey, epoch_seconds(unix_ts), count);
+                session::GET_PAYMENT_DETAILS_DOMAIN,
+                master_pubkey,
+                epoch_seconds(unix_ts),
+                limit,
+                before);
     }
 
     array_uc64 payment_details_sign(
-            const cleared_uc64& master, std::chrono::sys_seconds unix_ts, uint32_t count) {
-        auto msg = payment_details_message(pubkey_of(master), unix_ts, count);
+            const cleared_uc64& master,
+            std::chrono::sys_seconds unix_ts,
+            uint32_t limit,
+            std::string_view before) {
+        auto msg = payment_details_message(pubkey_of(master), unix_ts, limit, before);
         array_uc64 sig = {};
         crypto_sign_ed25519_detached(sig.data(), nullptr, msg.data(), msg.size(), master.data());
         return sig;
@@ -606,79 +646,22 @@ namespace {
             std::span<const uint8_t, 32> master_pubkey,
             std::span<const uint8_t, 64> master_sig,
             std::chrono::sys_seconds unix_ts,
-            uint32_t count) {
+            uint32_t limit,
+            std::string_view before) {
         return nlohmann::json{
                 {"master_pkey", oxenc::to_hex(master_pubkey)},
                 {"master_sig", oxenc::to_hex(master_sig)},
                 {"ts", epoch_seconds(unix_ts)},
-                {"count", count}}
+                {"limit", limit},
+                {"before", before}}
                 .dump();
     }
 
-}  // namespace
-
-array_uc64 payment_details_sig(
-        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts, uint32_t count) {
-    auto master = normalize_privkey(master_privkey, "master_privkey");
-    return payment_details_sign(master, unix_ts, count);
-}
-
-ProRequest payment_details_request(
-        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts, uint32_t count) {
-    auto master = normalize_privkey(master_privkey, "master_privkey");
-    auto sig = payment_details_sign(master, unix_ts, count);
-    return {get_pro_details_endpoint,
-            application_json,
-            payment_details_body(pubkey_of(master), sig, unix_ts, count)};
-}
-
-GetProDetailsResponse parse_payment_details(std::string_view json) {
-    GetProDetailsResponse result = {};
-    std::vector<std::string> errs;
-    auto result_obj = read_envelope(json, result, errs);
-    if (!result || !errs.empty()) {
-        if (!errs.empty())
-            set_protocol_error(result, errs.front());
-        return result;
-    }
-
-    // Parse payload. The account Pro status is an opaque string code ("never"/"active"/"expired");
-    // an unknown value passes through unchanged (§1: enums are codes) rather than failing the
-    // parse. (Wire key `user_status`, disambiguated from the envelope `status` -- spec §5.2.)
-    result.user_status = json_require<std::string>(result_obj, "user_status", errs);
-
-    uint32_t error_report = json_require<uint32_t>(result_obj, "error_report", errs);
-    if (error_report >= SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT) {
-        errs.push_back(fmt::format("Error report value was out-of-bounds: {}", error_report));
-        set_protocol_error(result, errs.front());
-        return result;
-    }
-    result.error_report =
-            static_cast<SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT>(error_report);
-
-    result.auto_renewing = json_require<bool>(result_obj, "auto_renewing", errs);
-
-    result.payments_total = json_require<uint32_t>(result_obj, "payments_total", errs);
-
-    result.expiry_at = std::chrono::sys_seconds(
-            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", errs)));
-    result.grace_period_duration =
-            std::chrono::seconds(json_require<int64_t>(result_obj, "grace_period_duration", errs));
-    result.refund_requested_at = std::chrono::sys_seconds(
-            std::chrono::seconds(json_require<int64_t>(result_obj, "refund_requested_ts", errs)));
-
-    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", errs);
-    result.items.reserve(array.size());
-    for (size_t index = 0; index < array.size(); index++) {
-        const auto& it = array[index];
-        if (!it.is_object()) {
-            errs.push_back(fmt::format(
-                    "Aborting parse, 'items[{}]' was not an object: {}", index, it.dump(1)));
-            break;
-        }
-
-        // Parse payment item
-        auto obj = it.get<nlohmann::json::object_t>();
+    // Parse one payment item object (shared by get-pro-status's `latest_payment` and
+    // get-payment-details's `items`). Appends to `errs` and returns a best-effort item on any
+    // field error; the caller checks `errs`.
+    ProPaymentItem parse_payment_item(
+            const nlohmann::json::object_t& obj, std::vector<std::string>& errs) {
         auto status = json_require<std::string>(obj, "status", errs);
         auto plan_code = json_require<std::string>(obj, "plan", errs);
         auto plan = parse_plan_period(plan_code);
@@ -706,7 +689,6 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
             item.plan = *plan;
         item.payment_provider = std::move(payment_provider);
         item.payment_id = std::move(payment_id);
-
         item.auto_renewing = auto_renewing;
         item.purchased_at = sys_ms_from_seconds(purchased_ts);
         item.redeemed_at = std::chrono::sys_seconds(std::chrono::seconds(redeemed_ts));
@@ -717,12 +699,139 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         item.revoked_at = sys_ms_from_seconds(revoked_ts);
         item.refund_requested_at =
                 std::chrono::sys_seconds(std::chrono::seconds(refund_requested_ts));
+        return item;
+    }
 
-        // Handle parsing result
-        if (errs.size())
+}  // namespace
+
+array_uc64 pro_status_sig(
+        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    return pro_status_sign(master, unix_ts);
+}
+
+ProRequest pro_status_request(
+        std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto sig = pro_status_sign(master, unix_ts);
+    return {get_pro_status_endpoint,
+            application_json,
+            pro_status_body(pubkey_of(master), sig, unix_ts)};
+}
+
+array_uc64 payment_details_sig(
+        std::span<const uint8_t> master_privkey,
+        std::chrono::sys_seconds unix_ts,
+        uint32_t limit,
+        std::string_view before) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    return payment_details_sign(master, unix_ts, limit, before);
+}
+
+ProRequest payment_details_request(
+        std::span<const uint8_t> master_privkey,
+        std::chrono::sys_seconds unix_ts,
+        uint32_t limit,
+        std::string_view before) {
+    auto master = normalize_privkey(master_privkey, "master_privkey");
+    auto sig = payment_details_sign(master, unix_ts, limit, before);
+    return {get_payment_details_endpoint,
+            application_json,
+            payment_details_body(pubkey_of(master), sig, unix_ts, limit, before)};
+}
+
+ProStatusResponse parse_pro_status(std::string_view json) {
+    ProStatusResponse result = {};
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
+        return result;
+    }
+
+    // Parse payload. The account Pro status is an opaque string code ("never"/"active"/"expired");
+    // an unknown value passes through unchanged (§1: enums are codes) rather than failing the
+    // parse. (Wire key `user_status`, disambiguated from the envelope `status` -- spec §5.2.)
+    result.user_status = json_require<std::string>(result_obj, "user_status", errs);
+
+    uint32_t error_report = json_require<uint32_t>(result_obj, "error_report", errs);
+    if (error_report >= SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_COUNT) {
+        errs.push_back(fmt::format("Error report value was out-of-bounds: {}", error_report));
+        set_protocol_error(result, errs.front());
+        return result;
+    }
+    result.error_report =
+            static_cast<SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT>(error_report);
+
+    result.auto_renewing = json_require<bool>(result_obj, "auto_renewing", errs);
+
+    result.expiry_at = std::chrono::sys_seconds(
+            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", errs)));
+    result.grace_period_duration =
+            std::chrono::seconds(json_require<int64_t>(result_obj, "grace_period_duration", errs));
+    result.refund_requested_at = std::chrono::sys_seconds(
+            std::chrono::seconds(json_require<int64_t>(result_obj, "refund_requested_ts", errs)));
+
+    // `latest_payment` is a single payment item, or null when the account has no payments.
+    if (auto it = result_obj.find("latest_payment"); it == result_obj.end()) {
+        errs.push_back("Key 'latest_payment' is missing");
+    } else if (it->second.is_null()) {
+        // No payments: latest_payment stays std::nullopt.
+    } else if (it->second.is_object()) {
+        auto obj = it->second.get<nlohmann::json::object_t>();
+        auto item = parse_payment_item(obj, errs);
+        if (errs.empty())
+            result.latest_payment = std::move(item);
+    } else {
+        errs.push_back(fmt::format(
+                "Key value (latest_payment, {}) was not an object or null", it->second.dump(1)));
+    }
+
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
+    return result;
+}
+
+PaymentDetailsResponse parse_payment_details(std::string_view json) {
+    PaymentDetailsResponse result = {};
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
+        return result;
+    }
+
+    result.payments_total = json_require<uint32_t>(result_obj, "payments_total", errs);
+
+    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", errs);
+    result.items.reserve(array.size());
+    for (size_t index = 0; index < array.size(); index++) {
+        const auto& it = array[index];
+        if (!it.is_object()) {
+            errs.push_back(fmt::format(
+                    "Aborting parse, 'items[{}]' was not an object: {}", index, it.dump(1)));
             break;
+        }
 
+        auto obj = it.get<nlohmann::json::object_t>();
+        auto item = parse_payment_item(obj, errs);
+        if (!errs.empty())
+            break;
         result.items.emplace_back(std::move(item));
+    }
+
+    // `next_cursor` is the opaque keyset cursor (§5.3), or null at end-of-data.
+    if (auto it = result_obj.find("next_cursor"); it == result_obj.end()) {
+        errs.push_back("Key 'next_cursor' is missing");
+    } else if (it->second.is_null()) {
+        // End of data: next_cursor stays std::nullopt.
+    } else if (it->second.is_string()) {
+        result.next_cursor = it->second.get<std::string>();
+    } else {
+        errs.push_back(fmt::format(
+                "Key value (next_cursor, {}) was not a string or null", it->second.dump(1)));
     }
 
     if (!errs.empty())
@@ -889,7 +998,7 @@ static session_pro_backend_pro_payment_item to_c(ProPaymentItem& src) {
 struct GetProRevocationsCResponse : GetProRevocationsResponse {
     std::vector<session_pro_backend_pro_revocation_item> item_views;
 };
-struct GetProDetailsCResponse : GetProDetailsResponse {
+struct GetPaymentDetailsCResponse : PaymentDetailsResponse {
     std::vector<session_pro_backend_pro_payment_item> item_views;
 };
 
@@ -979,12 +1088,31 @@ session_pro_backend_get_pro_revocations_request_build(int64_t ticket) {
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_details_request_build(
-        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts, uint32_t count) {
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_status_request_build(
+        const uint8_t* master_privkey, size_t master_privkey_len, int64_t ts) {
+    session_pro_backend_request result = {};
+    try {
+        result = c_own_request(pro_status_request(
+                {master_privkey, master_privkey_len}, session::as_sys_seconds(ts)));
+    } catch (const std::exception& e) {
+        c_request_error(result, e);
+    }
+    return result;
+}
+
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_payment_details_request_build(
+        const uint8_t* master_privkey,
+        size_t master_privkey_len,
+        int64_t ts,
+        uint32_t limit,
+        const char* before) {
     session_pro_backend_request result = {};
     try {
         result = c_own_request(payment_details_request(
-                {master_privkey, master_privkey_len}, session::as_sys_seconds(ts), count));
+                {master_privkey, master_privkey_len},
+                session::as_sys_seconds(ts),
+                limit,
+                before ? std::string_view{before} : std::string_view{}));
     } catch (const std::exception& e) {
         c_request_error(result, e);
     }
@@ -1062,9 +1190,9 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_get_pro_details_response
-session_pro_backend_get_pro_details_response_parse(const char* json, size_t json_len) {
-    session_pro_backend_get_pro_details_response result = {};
+LIBSESSION_C_API session_pro_backend_get_pro_status_response
+session_pro_backend_get_pro_status_response_parse(const char* json, size_t json_len) {
+    session_pro_backend_get_pro_status_response result = {};
     if (!json) {
         result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
         result.header.error_code = C_INVALID_RESPONSE_CODE;
@@ -1074,7 +1202,7 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
 
     try {
         using session::epoch_seconds;
-        auto* owned = new GetProDetailsCResponse{parse_payment_details({json, json_len}), {}};
+        auto* owned = new ProStatusResponse(parse_pro_status({json, json_len}));
         result.header.internal_ = owned;
         fill_c_header(result.header, *owned);
 
@@ -1084,7 +1212,36 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         result.expiry_ts = epoch_seconds(owned->expiry_at);
         result.grace_period_duration = owned->grace_period_duration.count();
         result.refund_requested_ts = epoch_seconds(owned->refund_requested_at);
+        result.has_latest_payment = owned->latest_payment.has_value();
+        if (owned->latest_payment)
+            result.latest_payment = to_c(*owned->latest_payment);
+    } catch (const std::exception&) {
+        delete static_cast<ProStatusResponse*>(result.header.internal_);
+        result = {};
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
+    }
+    return result;
+}
+
+LIBSESSION_C_API session_pro_backend_get_payment_details_response
+session_pro_backend_get_payment_details_response_parse(const char* json, size_t json_len) {
+    session_pro_backend_get_payment_details_response result = {};
+    if (!json) {
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_INVALID_ARGS;
+        return result;
+    }
+
+    try {
+        auto* owned = new GetPaymentDetailsCResponse{parse_payment_details({json, json_len}), {}};
+        result.header.internal_ = owned;
+        fill_c_header(result.header, *owned);
+
         result.payments_total = owned->payments_total;
+        result.next_cursor = owned->next_cursor ? owned->next_cursor->c_str() : nullptr;
 
         owned->item_views.reserve(owned->items.size());
         for (auto& src : owned->items)
@@ -1092,7 +1249,7 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         result.items = owned->item_views.data();
         result.items_count = owned->item_views.size();
     } catch (const std::exception&) {
-        delete static_cast<GetProDetailsCResponse*>(result.header.internal_);
+        delete static_cast<GetPaymentDetailsCResponse*>(result.header.internal_);
         result = {};
         result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
         result.header.error_code = C_INVALID_RESPONSE_CODE;
@@ -1167,9 +1324,14 @@ LIBSESSION_C_API void session_pro_backend_get_pro_revocations_response_free(
     c_free_response<GetProRevocationsCResponse>(response);
 }
 
-LIBSESSION_C_API void session_pro_backend_get_pro_details_response_free(
-        session_pro_backend_get_pro_details_response* response) {
-    c_free_response<GetProDetailsCResponse>(response);
+LIBSESSION_C_API void session_pro_backend_get_pro_status_response_free(
+        session_pro_backend_get_pro_status_response* response) {
+    c_free_response<ProStatusResponse>(response);
+}
+
+LIBSESSION_C_API void session_pro_backend_get_payment_details_response_free(
+        session_pro_backend_get_payment_details_response* response) {
+    c_free_response<GetPaymentDetailsCResponse>(response);
 }
 
 LIBSESSION_C_API void session_pro_backend_set_payment_refund_requested_response_free(

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -303,7 +303,7 @@ std::span<const std::string_view> visible_platforms() {
 }
 
 std::optional<ProPlanPeriod> parse_plan_period(std::string_view code) {
-    // pro-wire-protocol.md §1 / Delta #14: closed grammar. "lifetime", or "<N><unit>" with N a
+    // pro-wire-protocol.md §1: closed grammar. "lifetime", or "<N><unit>" with N a
     // positive integer (no leading zeros) and unit one of s/d/w/m/y. Single-unit only.
     if (code == "lifetime")
         return ProPlanPeriod{0, ProPlanUnit::lifetime};

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -151,6 +151,11 @@ namespace {
     constexpr char get_pro_revocations_endpoint[] = "get_pro_revocations";
     constexpr char set_refund_endpoint[] = "set_payment_refund_requested";
 
+    // Content type for the request payload (single master storage, shared with the C API's
+    // session_pro_backend_request.content_type). The wire encoding is libsession's to change; the
+    // content type travels alongside the payload so clients never hardcode a format.
+    constexpr char application_json[] = "application/json";
+
     // Normalise an Ed25519 private key to libsodium's 64-byte form (seed(32) || pubkey(32)): a
     // 32-byte seed is expanded, a 64-byte key copied, anything else throws. The public key is then
     // available at bytes [32, 64) so callers never need a second derivation.
@@ -217,7 +222,7 @@ namespace {
     }
 
     // Serialise an add-payment request body from already-computed fields (shared by the C++
-    // add_payment_request and the C ..._request_to_json wrapper).
+    // add_payment_request and the C ..._request_build wrapper).
     std::string add_payment_body(
             std::span<const uint8_t> master_pubkey,
             std::span<const uint8_t> rotating_pubkey,
@@ -307,6 +312,7 @@ ProRequest add_payment_request(
     auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
     auto sigs = add_payment_sign(master, rotating, provider_code, payment_id);
     return {add_payment_endpoint,
+            application_json,
             add_payment_body(
                     pubkey_of(master),
                     pubkey_of(rotating),
@@ -434,6 +440,7 @@ ProRequest pro_proof_request(
     auto rotating = normalize_privkey(rotating_privkey, "rotating_privkey");
     auto sigs = generate_proof_sign(master, rotating, unix_ts);
     return {generate_proof_endpoint,
+            application_json,
             generate_proof_body(
                     pubkey_of(master),
                     pubkey_of(rotating),
@@ -445,7 +452,7 @@ ProRequest pro_proof_request(
 ProRequest revocations_request(std::int64_t ticket) {
     nlohmann::json j;
     j["ticket"] = ticket;
-    return {get_pro_revocations_endpoint, j.dump()};
+    return {get_pro_revocations_endpoint, application_json, j.dump()};
 }
 
 GetProRevocationsResponse parse_revocations(std::string_view json) {
@@ -563,7 +570,9 @@ ProRequest payment_details_request(
         std::span<const uint8_t> master_privkey, std::chrono::sys_seconds unix_ts, uint32_t count) {
     auto master = normalize_privkey(master_privkey, "master_privkey");
     auto sig = payment_details_sign(master, unix_ts, count);
-    return {get_pro_details_endpoint, payment_details_body(pubkey_of(master), sig, unix_ts, count)};
+    return {get_pro_details_endpoint,
+            application_json,
+            payment_details_body(pubkey_of(master), sig, unix_ts, count)};
 }
 
 GetProDetailsResponse parse_payment_details(std::string_view json) {
@@ -755,6 +764,7 @@ ProRequest refund_request(
     auto master = normalize_privkey(master_privkey, "master_privkey");
     auto sig = refund_sign(master, unix_ts, refund_requested_at, provider_code, payment_id);
     return {set_refund_endpoint,
+            application_json,
             refund_body(
                     pubkey_of(master),
                     unix_ts,
@@ -885,13 +895,14 @@ session_pro_backend_get_pro_details_request_build_sig(
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_add_pro_payment_request_to_json(
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_add_pro_payment_request_build(
         const session_pro_backend_add_pro_payment_request* request) {
-    session_pro_backend_to_json result = {};
+    session_pro_backend_request result = {};
     if (!request)
         return result;
 
     try {
+        result.endpoint = add_payment_endpoint;
         std::string json = add_payment_body(
                 {request->master_pkey.data, sizeof(request->master_pkey.data)},
                 {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
@@ -899,7 +910,8 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_add_pro_payment
                 {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
                 {request->master_sig.data, sizeof(request->master_sig.data)},
                 {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
+        result.content_type = application_json;
+        result.data = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -914,20 +926,22 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_add_pro_payment
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_generate_pro_proof_request_to_json(
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_generate_pro_proof_request_build(
         const session_pro_backend_generate_pro_proof_request* request) {
-    session_pro_backend_to_json result = {};
+    session_pro_backend_request result = {};
     if (!request)
         return result;
 
     try {
+        result.endpoint = generate_proof_endpoint;
         std::string json = generate_proof_body(
                 {request->master_pkey.data, sizeof(request->master_pkey.data)},
                 {request->rotating_pkey.data, sizeof(request->rotating_pkey.data)},
                 session::as_sys_seconds(request->ts),
                 {request->master_sig.data, sizeof(request->master_sig.data)},
                 {request->rotating_sig.data, sizeof(request->rotating_sig.data)});
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
+        result.content_type = application_json;
+        result.data = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -942,16 +956,17 @@ LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_generate_pro_pr
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_to_json
-session_pro_backend_get_pro_revocations_request_to_json(
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_revocations_request_build(
         const session_pro_backend_get_pro_revocations_request* request) {
-    session_pro_backend_to_json result = {};
+    session_pro_backend_request result = {};
     if (!request)
         return result;
 
     try {
-        std::string json = revocations_request(request->ticket).body;
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
+        result.endpoint = get_pro_revocations_endpoint;
+        std::string json = revocations_request(request->ticket).data;
+        result.content_type = application_json;
+        result.data = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -966,19 +981,21 @@ session_pro_backend_get_pro_revocations_request_to_json(
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_to_json session_pro_backend_get_pro_details_request_to_json(
+LIBSESSION_C_API session_pro_backend_request session_pro_backend_get_pro_details_request_build(
         const session_pro_backend_get_pro_details_request* request) {
-    session_pro_backend_to_json result = {};
+    session_pro_backend_request result = {};
     if (!request)
         return result;
 
     try {
+        result.endpoint = get_pro_details_endpoint;
         std::string json = payment_details_body(
                 {request->master_pkey.data, sizeof(request->master_pkey.data)},
                 {request->master_sig.data, sizeof(request->master_sig.data)},
                 session::as_sys_seconds(request->ts),
                 request->count);
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
+        result.content_type = application_json;
+        result.data = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -1220,8 +1237,7 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
     // Convert C inputs to C++ types
     std::span<const uint8_t> master_span{master_privkey, master_privkey_len};
     std::chrono::sys_seconds unix_ts = session::as_sys_seconds(ts);
-    std::chrono::sys_seconds refund_requested_at =
-            session::as_sys_seconds(refund_requested_ts);
+    std::chrono::sys_seconds refund_requested_at = session::as_sys_seconds(refund_requested_ts);
     std::span<const uint8_t> payment_tx_payment_id_span(
             payment_tx_payment_id, payment_tx_payment_id_len);
 
@@ -1247,14 +1263,15 @@ session_pro_backend_signature session_pro_backend_set_payment_refund_requested_r
     return result;
 }
 
-LIBSESSION_C_API session_pro_backend_to_json
-session_pro_backend_set_payment_refund_requested_request_to_json(
+LIBSESSION_C_API session_pro_backend_request
+session_pro_backend_set_payment_refund_requested_request_build(
         const session_pro_backend_set_payment_refund_requested_request* request) {
-    session_pro_backend_to_json result = {};
+    session_pro_backend_request result = {};
     if (!request)
         return result;
 
     try {
+        result.endpoint = set_refund_endpoint;
         std::string json = refund_body(
                 {request->master_pkey.data, sizeof(request->master_pkey.data)},
                 session::as_sys_seconds(request->ts),
@@ -1262,7 +1279,8 @@ session_pro_backend_set_payment_refund_requested_request_to_json(
                 {request->payment_tx.provider_code, request->payment_tx.provider_code_count},
                 {request->payment_tx.payment_id, request->payment_tx.payment_id_count},
                 {request->master_sig.data, sizeof(request->master_sig.data)});
-        result.json = session::string8_copy_or_throw(json.data(), json.size());
+        result.content_type = application_json;
+        result.data = session::string8_copy_or_throw(json.data(), json.size());
         result.success = true;
     } catch (const std::exception& e) {
         const std::string& error = e.what();
@@ -1326,10 +1344,10 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
     return result;
 }
 
-LIBSESSION_C_API void session_pro_backend_to_json_free(session_pro_backend_to_json* to_json) {
-    if (to_json) {
-        free(to_json->json.data);
-        *to_json = {};
+LIBSESSION_C_API void session_pro_backend_request_free(session_pro_backend_request* request) {
+    if (request) {
+        free(request->data.data);
+        *request = {};
     }
 }
 

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -277,13 +277,15 @@ const ProviderURLs* provider_urls(std::string_view provider_code) {
 
 LIBSESSION_C_API session_pro_backend_provider_urls
 session_pro_backend_get_provider_urls(const char* provider_code) {
-    // Each present field is a static, null-terminated literal; an absent one (or no URLs at all) is
-    // NULL.
+    // Each present field is a static, null-terminated literal; an absent one is NULL. `found`
+    // distinguishes an unknown provider ({} -> found == false) from a recognised provider that
+    // simply has some/all URLs absent.
     auto c = [](const std::optional<std::string_view>& u) -> const char* {
         return u ? u->data() : nullptr;
     };
     if (auto u = provider_urls(provider_code))
-        return {.refund_platform_url = c(u->refund_platform_url),
+        return {.found = true,
+                .refund_platform_url = c(u->refund_platform_url),
                 .refund_support_url = c(u->refund_support_url),
                 .refund_status_url = c(u->refund_status_url),
                 .update_subscription_url = c(u->update_subscription_url),

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -233,10 +233,18 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_URL = URL.data();
 LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY = PUBKEY.data();
 LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X25519 =
         PUBKEY_X25519.data();
+
+// Payment-provider code strings: C symbols pointing at the single C++ definitions above.
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY =
+        PAYMENT_PROVIDER_GOOGLE_PLAY.data();
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE =
+        PAYMENT_PROVIDER_APP_STORE.data();
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF =
+        PAYMENT_PROVIDER_RANGEPROOF.data();
 }
 
 std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {
-    if (provider_code == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY)
+    if (provider_code == PAYMENT_PROVIDER_GOOGLE_PLAY)
         return ProviderUrls{
                 "https://support.google.com/googleplay/workflow/9813244?",
                 "https://getsession.org/android-refund",
@@ -245,7 +253,7 @@ std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {
                 "subscriptions?package=network.loki.messenger",
                 "https://play.google.com/store/account/"
                 "subscriptions?package=network.loki.messenger"};
-    if (provider_code == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE)
+    if (provider_code == PAYMENT_PROVIDER_APP_STORE)
         return ProviderUrls{
                 "https://support.apple.com/118223",
                 "https://support.apple.com/118223",
@@ -270,8 +278,7 @@ session_pro_backend_get_provider_urls(const char* provider_code) {
 
 std::span<const std::string_view> visible_platforms() {
     static const std::array<std::string_view, 2> platforms = {
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE};
+            PAYMENT_PROVIDER_GOOGLE_PLAY, PAYMENT_PROVIDER_APP_STORE};
     return platforms;
 }
 

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -92,24 +92,6 @@ double epoch_seconds_double(session::sys_ms t) {
     return std::chrono::duration<double>(t.time_since_epoch()).count();
 }
 
-void parse_json_response_errors(const nlohmann::json& j, std::vector<std::string>& errors) {
-    const auto& array = json_require<nlohmann::json::array_t>(j, "errors", errors);
-    errors.reserve(errors.size() + array.size());
-    for (size_t index = 0; index < array.size(); index++) {
-        const auto& it = array[index];
-        if (it.is_string()) {
-            errors.push_back(it.get<std::string>());
-        } else {
-            errors.push_back(fmt::format(
-                    "Aborting parse, 'result.errors[{}]' was not a string "
-                    "error: '{}'",
-                    index,
-                    it.dump(1)));
-            break;
-        }
-    }
-}
-
 bool json_require_fixed_bytes_from_hex(
         const nlohmann::json& j,
         std::string_view key,
@@ -326,48 +308,87 @@ ProRequest add_payment_request(
 }
 
 namespace {
-    // Shared parse for the proof-carrying responses (add-payment and generate-proof both reply with
-    // exactly a proof); fills the common ProProofResponse base of whichever derived response is
-    // passed. On any failure `result.errors` is populated (the backend sends the human-readable
-    // reason there, including for already-redeemed / unknown-payment).
-    void fill_proof_response(std::string_view json, ProProofResponse& result) {
-        // Parse basics
-        nlohmann::json j = json_parse(json, result.errors);
-        uint32_t status = json_require<uint8_t>(j, "status", result.errors);
-        if (result.errors.size())
-            return;
+    // libsession-side slug when the backend's reply can't be parsed at all (malformed envelope,
+    // missing/unrecognized status). Distinct from any backend error_code slug.
+    constexpr std::string_view invalid_response_code = "invalid_response";
 
-        // Parse errors
-        if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
-            parse_json_response_errors(j, result.errors);
-            return;
+    // Put a ResponseBase into a protocol-error state (a libsession-side parse failure, distinct
+    // from a backend-reported fail/error).
+    void set_protocol_error(ResponseBase& result, std::string message) {
+        result.status = ResponseStatus::Error;
+        result.error_code = std::string(invalid_response_code);
+        result.error = std::move(message);
+    }
+
+    // Read the response envelope (spec §5) into `result`: string `status` -> ResponseStatus (a
+    // CLOSED set -- an unrecognized value is a protocol error, never passed through) and, on
+    // non-ok, `error_code` + `error`. Returns the `result` object to read the payload from when
+    // status is "ok" (an empty object otherwise; the caller returns early). libsession-side parse
+    // problems accumulate in `errs` for the caller to fold into a protocol error.
+    nlohmann::json::object_t read_envelope(
+            std::string_view json, ResponseBase& result, std::vector<std::string>& errs) {
+        nlohmann::json j = json_parse(json, errs);
+        auto status = json_require<std::string>(j, "status", errs);
+        if (!errs.empty())
+            return {};
+        if (status == "ok") {
+            result.status = ResponseStatus::Ok;
+            return json_require<nlohmann::json::object_t>(j, "result", errs);
         }
+        if (status == "fail" || status == "error") {
+            result.status = status == "fail" ? ResponseStatus::Fail : ResponseStatus::Error;
+            result.error_code = json_require<std::string>(j, "error_code", errs);
+            result.error = json_require<std::string>(j, "error", errs);
+            return {};
+        }
+        errs.push_back(fmt::format("Unrecognized response status: '{}'", status));
+        return {};
+    }
 
-        auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
-        if (result.errors.size())
-            return;
-
-        // Parse payload
-        result.proof.version = json_require<uint8_t>(result_obj, "version", result.errors);
-        auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", result.errors);
+    // Fills the common proof payload (add-payment and generate-proof both reply with exactly a
+    // proof) from the already-extracted `result` object.
+    void fill_proof(
+            const nlohmann::json::object_t& result_obj,
+            ProProofResponse& result,
+            std::vector<std::string>& errs) {
+        result.proof.version = json_require<uint8_t>(result_obj, "version", errs);
+        auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts", errs);
         result.proof.expiry_at = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
         json_require_fixed_bytes_from_hex(
-                result_obj, "revocation_tag", result.errors, result.proof.revocation_tag);
+                result_obj, "revocation_tag", errs, result.proof.revocation_tag);
         json_require_fixed_bytes_from_hex(
-                result_obj, "rotating_pkey", result.errors, result.proof.rotating_pubkey);
-        json_require_fixed_bytes_from_hex(result_obj, "sig", result.errors, result.proof.sig);
+                result_obj, "rotating_pkey", errs, result.proof.rotating_pubkey);
+        json_require_fixed_bytes_from_hex(result_obj, "sig", errs, result.proof.sig);
     }
 }  // namespace
 
 AddProPaymentResponse parse_add_payment(std::string_view json) {
     AddProPaymentResponse result = {};
-    fill_proof_response(json, result);
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
+        return result;
+    }
+    fill_proof(result_obj, result, errs);
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
     return result;
 }
 
 GenerateProProofResponse parse_pro_proof(std::string_view json) {
     GenerateProProofResponse result = {};
-    fill_proof_response(json, result);
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
+        return result;
+    }
+    fill_proof(result_obj, result, errs);
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
     return result;
 }
 
@@ -458,55 +479,46 @@ ProRequest revocations_request(std::int64_t ticket) {
 }
 
 GetProRevocationsResponse parse_revocations(std::string_view json) {
-    // Parse basics
     GetProRevocationsResponse result = {};
-    nlohmann::json j = json_parse(json, result.errors);
-    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size())
-        return result;
-
-    // Parse errors
-    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
-        parse_json_response_errors(j, result.errors);
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
         return result;
     }
 
-    auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
-    if (result.errors.size())
-        return result;
-
     // Parse payload
-    result.ticket = json_require<int64_t>(result_obj, "ticket", result.errors);
-    result.retry_in =
-            std::chrono::seconds(json_require<int64_t>(result_obj, "retry_in", result.errors));
-    result.retain_for =
-            std::chrono::seconds(json_require<int64_t>(result_obj, "retain_for", result.errors));
+    result.ticket = json_require<int64_t>(result_obj, "ticket", errs);
+    result.retry_in = std::chrono::seconds(json_require<int64_t>(result_obj, "retry_in", errs));
+    result.retain_for = std::chrono::seconds(json_require<int64_t>(result_obj, "retain_for", errs));
 
-    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
+    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", errs);
     result.items.reserve(array.size());
     for (size_t index = 0; index < array.size(); index++) {
         const auto& it = array[index];
         if (!it.is_object()) {
-            result.errors.push_back(fmt::format(
+            errs.push_back(fmt::format(
                     "Aborting parse, 'items[{}]' was not an object: {}", index, it.dump(1)));
             break;
         }
 
         // Parse revocation item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto effective_ts = json_require<int64_t>(obj, "effective_ts", result.errors);
+        auto effective_ts = json_require<int64_t>(obj, "effective_ts", errs);
 
         ProRevocationItem item = {};
         item.effective_at = as_sys_seconds(effective_ts);
-        json_require_fixed_bytes_from_hex(
-                obj, "revocation_tag", result.errors, item.revocation_tag);
+        json_require_fixed_bytes_from_hex(obj, "revocation_tag", errs, item.revocation_tag);
 
         // Handle parsing result
-        if (result.errors.size())
+        if (errs.size())
             break;
         result.items.emplace_back(std::move(item));
     }
 
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
     return result;
 }
 
@@ -576,77 +588,68 @@ ProRequest payment_details_request(
 }
 
 GetProDetailsResponse parse_payment_details(std::string_view json) {
-    // Parse basics
     GetProDetailsResponse result = {};
-    nlohmann::json j = json_parse(json, result.errors);
-    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size())
-        return result;
-
-    // Parse errors
-    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
-        parse_json_response_errors(j, result.errors);
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
         return result;
     }
 
-    auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
-    if (result.errors.size())
-        return result;
-
     // Parse payload. The account Pro status is an opaque string code ("never"/"active"/"expired");
     // an unknown value passes through unchanged (§1: enums are codes) rather than failing the
-    // parse.
-    result.user_status = json_require<std::string>(result_obj, "status", result.errors);
+    // parse. (Wire key `user_status`, disambiguated from the envelope `status` -- spec §5.2.)
+    result.user_status = json_require<std::string>(result_obj, "user_status", errs);
 
-    uint32_t error_report = json_require<uint32_t>(result_obj, "error_report", result.errors);
+    uint32_t error_report = json_require<uint32_t>(result_obj, "error_report", errs);
     if (error_report >= SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_COUNT) {
-        result.errors.push_back(
-                fmt::format("Error report value was out-of-bounds: {}", error_report));
+        errs.push_back(fmt::format("Error report value was out-of-bounds: {}", error_report));
+        set_protocol_error(result, errs.front());
         return result;
     }
     result.error_report =
             static_cast<SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT>(error_report);
 
-    result.auto_renewing = json_require<bool>(result_obj, "auto_renewing", result.errors);
+    result.auto_renewing = json_require<bool>(result_obj, "auto_renewing", errs);
 
-    result.payments_total = json_require<uint32_t>(result_obj, "payments_total", result.errors);
+    result.payments_total = json_require<uint32_t>(result_obj, "payments_total", errs);
 
     result.expiry_at = std::chrono::sys_seconds(
-            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", result.errors)));
-    result.grace_period_duration = std::chrono::seconds(
-            json_require<int64_t>(result_obj, "grace_period_duration", result.errors));
-    result.refund_requested_at = std::chrono::sys_seconds(std::chrono::seconds(
-            json_require<int64_t>(result_obj, "refund_requested_ts", result.errors)));
+            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts", errs)));
+    result.grace_period_duration =
+            std::chrono::seconds(json_require<int64_t>(result_obj, "grace_period_duration", errs));
+    result.refund_requested_at = std::chrono::sys_seconds(
+            std::chrono::seconds(json_require<int64_t>(result_obj, "refund_requested_ts", errs)));
 
-    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", result.errors);
+    auto array = json_require<nlohmann::json::array_t>(result_obj, "items", errs);
     result.items.reserve(array.size());
     for (size_t index = 0; index < array.size(); index++) {
         const auto& it = array[index];
         if (!it.is_object()) {
-            result.errors.push_back(fmt::format(
+            errs.push_back(fmt::format(
                     "Aborting parse, 'items[{}]' was not an object: {}", index, it.dump(1)));
             break;
         }
 
         // Parse payment item
         auto obj = it.get<nlohmann::json::object_t>();
-        auto status = json_require<std::string>(obj, "status", result.errors);
-        auto plan = json_require<std::string>(obj, "plan", result.errors);
-        auto payment_provider = json_require<std::string>(obj, "payment_provider", result.errors);
-        auto payment_id = json_require<std::string>(obj, "payment_id", result.errors);
-        auto auto_renewing = json_require<bool>(obj, "auto_renewing", result.errors);
+        auto status = json_require<std::string>(obj, "status", errs);
+        auto plan = json_require<std::string>(obj, "plan", errs);
+        auto payment_provider = json_require<std::string>(obj, "payment_provider", errs);
+        auto payment_id = json_require<std::string>(obj, "payment_id", errs);
+        auto auto_renewing = json_require<bool>(obj, "auto_renewing", errs);
         // purchased_ts and revoked_ts are upstream-provider event instants: floats on the wire
         // carrying sub-second precision (kept as millisecond-precision sys_ms). All other
         // timestamps are whole-second integers.
-        auto purchased_ts = json_require_number(obj, "purchased_ts", result.errors);
-        auto redeemed_ts = json_require<int64_t>(obj, "redeemed_ts", result.errors);
-        auto expiry_ts = json_require<int64_t>(obj, "expiry_ts", result.errors);
-        auto grace_period_duration =
-                json_require<int64_t>(obj, "grace_period_duration", result.errors);
+        auto purchased_ts = json_require_number(obj, "purchased_ts", errs);
+        auto redeemed_ts = json_require<int64_t>(obj, "redeemed_ts", errs);
+        auto expiry_ts = json_require<int64_t>(obj, "expiry_ts", errs);
+        auto grace_period_duration = json_require<int64_t>(obj, "grace_period_duration", errs);
         auto platform_refund_expiry_ts =
-                json_require<int64_t>(obj, "platform_refund_expiry_ts", result.errors);
-        auto revoked_ts = json_require_number(obj, "revoked_ts", result.errors);
-        auto refund_requested_ts = json_require<int64_t>(obj, "refund_requested_ts", result.errors);
+                json_require<int64_t>(obj, "platform_refund_expiry_ts", errs);
+        auto revoked_ts = json_require_number(obj, "revoked_ts", errs);
+        auto refund_requested_ts = json_require<int64_t>(obj, "refund_requested_ts", errs);
 
         ProPaymentItem item = {};
         item.status = std::move(status);
@@ -666,11 +669,14 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
                 std::chrono::sys_seconds(std::chrono::seconds(refund_requested_ts));
 
         // Handle parsing result
-        if (result.errors.size())
+        if (errs.size())
             break;
 
         result.items.emplace_back(std::move(item));
     }
+
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
     return result;
 }
 
@@ -773,25 +779,18 @@ ProRequest refund_request(
 }
 
 SetPaymentRefundRequestedResponse parse_refund(std::string_view json) {
-    // Parse basics
     SetPaymentRefundRequestedResponse result = {};
-    nlohmann::json j = json_parse(json, result.errors);
-    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size())
-        return result;
-
-    // Parse errors
-    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
-        parse_json_response_errors(j, result.errors);
+    std::vector<std::string> errs;
+    auto result_obj = read_envelope(json, result, errs);
+    if (!result || !errs.empty()) {
+        if (!errs.empty())
+            set_protocol_error(result, errs.front());
         return result;
     }
 
-    auto result_obj = json_require<nlohmann::json::object_t>(j, "result", result.errors);
-    if (result.errors.size())
-        return result;
-
-    // Parse payload
-    result.updated = json_require<bool>(result_obj, "updated", result.errors);
+    result.updated = json_require<bool>(result_obj, "updated", errs);
+    if (!errs.empty())
+        set_protocol_error(result, errs.front());
     return result;
 }
 }  // namespace session::pro_backend
@@ -804,6 +803,41 @@ using namespace session::pro_backend;
 
 static string8 C_PARSE_ERROR_OUT_OF_MEMORY = STRING8_LIT("Ran out-of-memory creating C response");
 static string8 C_PARSE_ERROR_INVALID_ARGS = STRING8_LIT("One or more C arguments were NULL");
+// error_code slug libsession reports when it can't parse/build the C response at all.
+static string8 C_INVALID_RESPONSE_CODE = STRING8_LIT("invalid_response");
+
+// Map the C++ ResponseStatus to the C enum.
+static SESSION_PRO_BACKEND_RESPONSE_STATUS c_response_status(ResponseStatus status) {
+    switch (status) {
+        case ResponseStatus::Ok: return SESSION_PRO_BACKEND_RESPONSE_STATUS_OK;
+        case ResponseStatus::Fail: return SESSION_PRO_BACKEND_RESPONSE_STATUS_FAIL;
+        case ResponseStatus::Error: break;
+    }
+    return SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+}
+
+// Arena bytes needed for a header's error_code + error strings.
+static size_t c_header_arena_bytes(const ResponseBase& cpp) {
+    size_t n = 0;
+    if (cpp.error_code)
+        n += cpp.error_code->size() + 1;
+    if (cpp.error)
+        n += cpp.error->size() + 1;
+    return n;
+}
+
+// Fill a C response header's status + error_code/error from a C++ ResponseBase, copying the two
+// optional strings into the arena (which must already have room; see c_header_arena_bytes).
+static void fill_c_header(
+        session_pro_backend_response_header& header, const ResponseBase& cpp, arena_t& arena) {
+    header.status = c_response_status(cpp.status);
+    header.error_code =
+            cpp.error_code
+                    ? arena_alloc_to_string8(&arena, cpp.error_code->data(), cpp.error_code->size())
+                    : string8{};
+    header.error = cpp.error ? arena_alloc_to_string8(&arena, cpp.error->data(), cpp.error->size())
+                             : string8{};
+}
 
 // Wrap a freshly-built C++ ProRequest as an owning C session_pro_backend_request: heap-own the
 // ProRequest and point endpoint/content_type/data into it (zero copy). Released by
@@ -897,8 +931,9 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
 
     session_pro_backend_pro_proof_response result = {};
     if (!json) {
-        result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
-        result.header.errors_count = 1;
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_INVALID_ARGS;
         return result;
     }
 
@@ -910,15 +945,15 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
     {
-        for (const auto& it : cpp.errors)
-            arena.max += sizeof(*result.header.errors) + (it.size() + 1 /*null-terminator*/);
+        arena.max += c_header_arena_bytes(cpp);
 
         if (arena.max)
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
-            result.header.errors_count = 1;
+            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+            result.header.error_code = C_INVALID_RESPONSE_CODE;
+            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
             return result;
         }
 
@@ -941,14 +976,8 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
             cpp.proof.rotating_pubkey.size());
     std::memcpy(result.proof.sig.data, cpp.proof.sig.data(), cpp.proof.sig.size());
 
-    // Copy errors
-    result.header.errors_count = cpp.errors.size();
-    result.header.errors = static_cast<string8*>(
-            arena_alloc(&arena, result.header.errors_count * sizeof(*result.header.errors)));
-    for (size_t index = 0; index < cpp.errors.size(); index++) {
-        const std::string& it = cpp.errors[index];
-        result.header.errors[index] = arena_alloc_to_string8(&arena, it.data(), it.size());
-    }
+    // Copy status + error code/message
+    fill_c_header(result.header, cpp, arena);
     return result;
 }
 
@@ -956,8 +985,9 @@ LIBSESSION_C_API session_pro_backend_get_pro_revocations_response
 session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t json_len) {
     session_pro_backend_get_pro_revocations_response result = {};
     if (!json) {
-        result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
-        result.header.errors_count = 1;
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_INVALID_ARGS;
         return result;
     }
 
@@ -972,15 +1002,15 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
                 sizeof(cpp.items[0]) >= sizeof(*result.items),
                 "Ensure we allocate enough memory. We might slightly over-allocate but that's not "
                 "a big deal");
-        for (auto it : cpp.errors)
-            arena.max += sizeof(*result.header.errors) + (it.size() + 1 /*null-terminator*/);
+        arena.max += c_header_arena_bytes(cpp);
 
         if (arena.max)
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
-            result.header.errors_count = 1;
+            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+            result.header.error_code = C_INVALID_RESPONSE_CODE;
+            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
             return result;
         }
 
@@ -993,14 +1023,8 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     result.retry_in = cpp.retry_in.count();
     result.retain_for = cpp.retain_for.count();
 
-    // Copy errors
-    result.header.errors_count = cpp.errors.size();
-    result.header.errors = (string8*)arena_alloc(
-            &arena, result.header.errors_count * sizeof(*result.header.errors));
-    for (size_t index = 0; index < cpp.errors.size(); index++) {
-        const std::string& it = cpp.errors[index];
-        result.header.errors[index] = arena_alloc_to_string8(&arena, it.data(), it.size());
-    }
+    // Copy status + error code/message
+    fill_c_header(result.header, cpp, arena);
 
     // Copy items
     result.items_count = cpp.items.size();
@@ -1020,8 +1044,9 @@ LIBSESSION_C_API session_pro_backend_get_pro_details_response
 session_pro_backend_get_pro_details_response_parse(const char* json, size_t json_len) {
     session_pro_backend_get_pro_details_response result = {};
     if (!json) {
-        result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
-        result.header.errors_count = 1;
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_INVALID_ARGS;
         return result;
     }
 
@@ -1032,15 +1057,15 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     arena_t arena = {};
     {
         arena.max += cpp.items.size() * sizeof(*result.items);
-        for (auto it : cpp.errors)
-            arena.max += sizeof(*result.header.errors) + (it.size() + 1 /*null-terminator*/);
+        arena.max += c_header_arena_bytes(cpp);
 
         if (arena.max)
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
-            result.header.errors_count = 1;
+            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+            result.header.error_code = C_INVALID_RESPONSE_CODE;
+            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
             return result;
         }
 
@@ -1086,14 +1111,8 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
                 dest.payment_id, sizeof(dest.payment_id), "%s", src.payment_id.c_str());
     }
 
-    // Copy errors
-    result.header.errors_count = cpp.errors.size();
-    result.header.errors = (string8*)arena_alloc(
-            &arena, result.header.errors_count * sizeof(*result.header.errors));
-    for (size_t index = 0; index < cpp.errors.size(); index++) {
-        const std::string& it = cpp.errors[index];
-        result.header.errors[index] = arena_alloc_to_string8(&arena, it.data(), it.size());
-    }
+    // Copy status + error code/message
+    fill_c_header(result.header, cpp, arena);
 
     return result;
 }
@@ -1125,8 +1144,9 @@ LIBSESSION_C_API session_pro_backend_set_payment_refund_requested_response
 session_pro_backend_set_payment_refund_requested_response_parse(const char* json, size_t json_len) {
     session_pro_backend_set_payment_refund_requested_response result = {};
     if (!json) {
-        result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
-        result.header.errors_count = 1;
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_INVALID_ARGS;
         return result;
     }
 
@@ -1136,15 +1156,15 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
     // Calculate how much memory we need and create an arena
     arena_t arena = {};
     {
-        for (auto it : cpp.errors)
-            arena.max += sizeof(*result.header.errors) + (it.size() + 1 /*null-terminator*/);
+        arena.max += c_header_arena_bytes(cpp);
 
         if (arena.max)
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
-            result.header.errors_count = 1;
+            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+            result.header.error_code = C_INVALID_RESPONSE_CODE;
+            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
             return result;
         }
 
@@ -1155,14 +1175,8 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
     // Copy to C struct
     result.updated = cpp.updated;
 
-    // Copy errors
-    result.header.errors_count = cpp.errors.size();
-    result.header.errors = (string8*)arena_alloc(
-            &arena, result.header.errors_count * sizeof(*result.header.errors));
-    for (size_t index = 0; index < cpp.errors.size(); index++) {
-        const std::string& it = cpp.errors[index];
-        result.header.errors[index] = arena_alloc_to_string8(&arena, it.data(), it.size());
-    }
+    // Copy status + error code/message
+    fill_c_header(result.header, cpp, arena);
 
     return result;
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -813,14 +813,10 @@ SetPaymentRefundRequestedResponse parse_refund(std::string_view json) {
 
 using namespace session::pro_backend;
 
-/// Define a string8 from a c-string literal. The string should not be modified as it'll live in the
-/// data-section of the binary (or be interned, e.t.c)
-#define STRING8_LIT(val) {(char*)val, sizeof(val) - 1}
-
-static string8 C_PARSE_ERROR_OUT_OF_MEMORY = STRING8_LIT("Ran out-of-memory creating C response");
-static string8 C_PARSE_ERROR_INVALID_ARGS = STRING8_LIT("One or more C arguments were NULL");
-// error_code slug libsession reports when it can't parse/build the C response at all.
-static string8 C_INVALID_RESPONSE_CODE = STRING8_LIT("invalid_response");
+// error / error_code strings libsession synthesizes when it cannot parse or build the C response.
+static constexpr const char* C_PARSE_ERROR_OUT_OF_MEMORY = "Ran out-of-memory creating C response";
+static constexpr const char* C_PARSE_ERROR_INVALID_ARGS = "One or more C arguments were NULL";
+static constexpr const char* C_INVALID_RESPONSE_CODE = "invalid_response";
 
 // Map the C++ ResponseStatus to the C enum.
 static SESSION_PRO_BACKEND_RESPONSE_STATUS c_response_status(ResponseStatus status) {
@@ -832,27 +828,63 @@ static SESSION_PRO_BACKEND_RESPONSE_STATUS c_response_status(ResponseStatus stat
     return SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
 }
 
-// Arena bytes needed for a header's error_code + error strings.
-static size_t c_header_arena_bytes(const ResponseBase& cpp) {
-    size_t n = 0;
-    if (cpp.error_code)
-        n += cpp.error_code->size() + 1;
-    if (cpp.error)
-        n += cpp.error->size() + 1;
-    return n;
+// Fill a C response header from a C++ ResponseBase. error_code/error point into `cpp`
+// (NUL-terminated via c_str(), NULL when absent); `cpp` is owned by the response's
+// header.internal_.
+static void fill_c_header(session_pro_backend_response_header& header, const ResponseBase& cpp) {
+    header.status = c_response_status(cpp.status);
+    header.error_code = cpp.error_code ? cpp.error_code->c_str() : nullptr;
+    header.error = cpp.error ? cpp.error->c_str() : nullptr;
 }
 
-// Fill a C response header's status + error_code/error from a C++ ResponseBase, copying the two
-// optional strings into the arena (which must already have room; see c_header_arena_bytes).
-static void fill_c_header(
-        session_pro_backend_response_header& header, const ResponseBase& cpp, arena_t& arena) {
-    header.status = c_response_status(cpp.status);
-    header.error_code =
-            cpp.error_code
-                    ? arena_alloc_to_string8(&arena, cpp.error_code->data(), cpp.error_code->size())
-                    : string8{};
-    header.error = cpp.error ? arena_alloc_to_string8(&arena, cpp.error->data(), cpp.error->size())
-                             : string8{};
+// Project a parsed C++ item to its C view. The string members are pointers into `src` (valid while
+// the owning response lives) -- kept file-local rather than a public conversion operator, and
+// taking a non-const lvalue ref so a temporary (whose aliased strings would immediately dangle)
+// can't bind.
+static session_pro_backend_pro_revocation_item to_c(ProRevocationItem& src) {
+    return {
+            .revocation_tag = src.revocation_tag.data(),
+            .effective_ts = session::epoch_seconds(src.effective_at),
+    };
+}
+
+static session_pro_backend_pro_payment_item to_c(ProPaymentItem& src) {
+    return {
+            .status = src.status.c_str(),
+            .plan_count = src.plan.count,
+            .plan_unit = static_cast<SESSION_PRO_BACKEND_PLAN_UNIT>(src.plan.unit),
+            .payment_provider = src.payment_provider.c_str(),
+            .auto_renewing = src.auto_renewing,
+            .purchased_ts = epoch_seconds_double(src.purchased_at),
+            .redeemed_ts = session::epoch_seconds(src.redeemed_at),
+            .expiry_ts = session::epoch_seconds(src.expiry_at),
+            .grace_period_duration = src.grace_period_duration.count(),
+            .platform_refund_expiry_ts = session::epoch_seconds(src.platform_refund_expiry_at),
+            .revoked_ts = epoch_seconds_double(src.revoked_at),
+            .refund_requested_ts = session::epoch_seconds(src.refund_requested_at),
+            .payment_id = src.payment_id.c_str(),
+    };
+}
+
+// Owns the parsed C++ response object that a C response's fields point into, plus the C item-view
+// array. `header.internal_` points here; the response's *_free deletes it. (Item-less responses own
+// the bare C++ object directly.)
+struct GetProRevocationsCResponse : GetProRevocationsResponse {
+    std::vector<session_pro_backend_pro_revocation_item> item_views;
+};
+struct GetProDetailsCResponse : GetProDetailsResponse {
+    std::vector<session_pro_backend_pro_payment_item> item_views;
+};
+
+// Free any C response: delete the owned object (of concrete type `Owned`, as stored by the matching
+// *_parse) behind header.internal_, then zero the struct. `Owned` is a proof/refund response or a
+// *CResponse holder -- all deriving from ResponseBase.
+template <std::derived_from<ResponseBase> Owned, typename Response>
+static void c_free_response(Response* response) {
+    if (response) {
+        delete static_cast<Owned*>(response->header.internal_);
+        *response = {};
+    }
 }
 
 // Wrap a freshly-built C++ ProRequest as an owning C session_pro_backend_request: heap-own the
@@ -953,47 +985,30 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
         return result;
     }
 
-    // Note, parse is written to not throw so we can safely read without try-catch crap
-    // add-payment and generate-proof share the proof-response shape; the C response struct is
-    // generic, so either derived parser works here.
-    auto cpp = parse_add_payment({json, json_len});
+    try {
+        // add-payment and generate-proof share the proof-response shape; either parser works.
+        auto* owned = new AddProPaymentResponse(parse_add_payment({json, json_len}));
+        result.header.internal_ = owned;
+        fill_c_header(result.header, *owned);
 
-    // Calculate how much memory we need and create an arena
-    arena_t arena = {};
-    {
-        arena.max += c_header_arena_bytes(cpp);
-
-        if (arena.max)
-            arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
-
-        if (arena.max && !arena.data) {
-            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
-            result.header.error_code = C_INVALID_RESPONSE_CODE;
-            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
-            return result;
-        }
-
-        // Store the pointer to the backing memory. Upon freeing, we release this one pointer
-        result.header.internal_arena_buf_ = arena.data;
+        // Success and error responses fold into one path -- different fields populated.
+        const auto& p = owned->proof;
+        result.proof.version = p.version;
+        result.proof.expiry_ts = session::epoch_seconds(p.expiry_at);
+        std::memcpy(
+                result.proof.revocation_tag.data, p.revocation_tag.data(), p.revocation_tag.size());
+        std::memcpy(
+                result.proof.rotating_pubkey.data,
+                p.rotating_pubkey.data(),
+                p.rotating_pubkey.size());
+        std::memcpy(result.proof.sig.data, p.sig.data(), p.sig.size());
+    } catch (const std::exception&) {
+        delete static_cast<AddProPaymentResponse*>(result.header.internal_);
+        result = {};
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
     }
-
-    // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
-    // Note that a response error and success case folds into the same code path. A success and
-    // error response returns the same struct just with different fields populated.
-    result.proof.version = cpp.proof.version;
-    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_at);
-    std::memcpy(
-            result.proof.revocation_tag.data,
-            cpp.proof.revocation_tag.data(),
-            cpp.proof.revocation_tag.size());
-    std::memcpy(
-            result.proof.rotating_pubkey.data,
-            cpp.proof.rotating_pubkey.data(),
-            cpp.proof.rotating_pubkey.size());
-    std::memcpy(result.proof.sig.data, cpp.proof.sig.data(), cpp.proof.sig.size());
-
-    // Copy status + error code/message
-    fill_c_header(result.header, cpp, arena);
     return result;
 }
 
@@ -1007,51 +1022,25 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
         return result;
     }
 
-    // Note, parse is written to not throw so we can safely read without try-catch crap
-    GetProRevocationsResponse cpp = parse_revocations({json, json_len});
+    try {
+        auto* owned = new GetProRevocationsCResponse{parse_revocations({json, json_len}), {}};
+        result.header.internal_ = owned;
+        fill_c_header(result.header, *owned);
+        result.ticket = owned->ticket;
+        result.retry_in = owned->retry_in.count();
+        result.retain_for = owned->retain_for.count();
 
-    // Calculate how much memory we need and create an arena
-    arena_t arena = {};
-    {
-        arena.max += cpp.items.size() * sizeof(*result.items);
-        static_assert(
-                sizeof(cpp.items[0]) >= sizeof(*result.items),
-                "Ensure we allocate enough memory. We might slightly over-allocate but that's not "
-                "a big deal");
-        arena.max += c_header_arena_bytes(cpp);
-
-        if (arena.max)
-            arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
-
-        if (arena.max && !arena.data) {
-            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
-            result.header.error_code = C_INVALID_RESPONSE_CODE;
-            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
-            return result;
-        }
-
-        // Store the pointer to the backing memory. Upon freeing, we release this one pointer
-        result.header.internal_arena_buf_ = arena.data;
-    }
-
-    // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
-    result.ticket = cpp.ticket;
-    result.retry_in = cpp.retry_in.count();
-    result.retain_for = cpp.retain_for.count();
-
-    // Copy status + error code/message
-    fill_c_header(result.header, cpp, arena);
-
-    // Copy items
-    result.items_count = cpp.items.size();
-    result.items = static_cast<session_pro_backend_pro_revocation_item*>(
-            arena_alloc(&arena, result.items_count * sizeof(*result.items)));
-
-    for (size_t index = 0; index < result.items_count; ++index) {
-        const ProRevocationItem& src = cpp.items[index];
-        session_pro_backend_pro_revocation_item& dest = result.items[index];
-        std::memcpy(dest.revocation_tag.data, src.revocation_tag.data(), src.revocation_tag.size());
-        dest.effective_ts = session::epoch_seconds(src.effective_at);
+        owned->item_views.reserve(owned->items.size());
+        for (auto& src : owned->items)
+            owned->item_views.push_back(to_c(src));
+        result.items = owned->item_views.data();
+        result.items_count = owned->item_views.size();
+    } catch (const std::exception&) {
+        delete static_cast<GetProRevocationsCResponse*>(result.header.internal_);
+        result = {};
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
     }
     return result;
 }
@@ -1066,71 +1055,32 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
         return result;
     }
 
-    // Note, parse is written to not throw so we can safely read without try-catch crap
-    auto cpp = parse_payment_details({json, json_len});
+    try {
+        using session::epoch_seconds;
+        auto* owned = new GetProDetailsCResponse{parse_payment_details({json, json_len}), {}};
+        result.header.internal_ = owned;
+        fill_c_header(result.header, *owned);
 
-    // Calculate how much memory we need and create an arena
-    arena_t arena = {};
-    {
-        arena.max += cpp.items.size() * sizeof(*result.items);
-        arena.max += c_header_arena_bytes(cpp);
+        result.status = owned->user_status.c_str();
+        result.error_report = owned->error_report;
+        result.auto_renewing = owned->auto_renewing;
+        result.expiry_ts = epoch_seconds(owned->expiry_at);
+        result.grace_period_duration = owned->grace_period_duration.count();
+        result.refund_requested_ts = epoch_seconds(owned->refund_requested_at);
+        result.payments_total = owned->payments_total;
 
-        if (arena.max)
-            arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
-
-        if (arena.max && !arena.data) {
-            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
-            result.header.error_code = C_INVALID_RESPONSE_CODE;
-            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
-            return result;
-        }
-
-        // Store the pointer to the backing memory. Upon freeing, we release this one pointer
-        result.header.internal_arena_buf_ = arena.data;
+        owned->item_views.reserve(owned->items.size());
+        for (auto& src : owned->items)
+            owned->item_views.push_back(to_c(src));
+        result.items = owned->item_views.data();
+        result.items_count = owned->item_views.size();
+    } catch (const std::exception&) {
+        delete static_cast<GetProDetailsCResponse*>(result.header.internal_);
+        result = {};
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
     }
-
-    using session::epoch_seconds;
-
-    // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
-    result.status_count =
-            snprintf_clamped(result.status, sizeof(result.status), "%s", cpp.user_status.c_str());
-    result.error_report = cpp.error_report;
-    result.items_count = cpp.items.size();
-    result.items = (session_pro_backend_pro_payment_item*)arena_alloc(
-            &arena, result.items_count * sizeof(*result.items));
-    result.auto_renewing = cpp.auto_renewing;
-    result.expiry_ts = epoch_seconds(cpp.expiry_at);
-    result.grace_period_duration = cpp.grace_period_duration.count();
-    result.refund_requested_ts = epoch_seconds(cpp.refund_requested_at);
-    result.payments_total = cpp.payments_total;
-
-    for (size_t index = 0; index < result.items_count; ++index) {
-        const ProPaymentItem& src = cpp.items[index];
-        session_pro_backend_pro_payment_item& dest = result.items[index];
-        dest.status_count =
-                snprintf_clamped(dest.status, sizeof(dest.status), "%s", src.status.c_str());
-        dest.plan_count = src.plan.count;
-        dest.plan_unit = static_cast<SESSION_PRO_BACKEND_PLAN_UNIT>(src.plan.unit);
-        dest.payment_provider_count = snprintf_clamped(
-                dest.payment_provider,
-                sizeof(dest.payment_provider),
-                "%s",
-                src.payment_provider.c_str());
-        dest.purchased_ts = epoch_seconds_double(src.purchased_at);
-        dest.redeemed_ts = epoch_seconds(src.redeemed_at);
-        dest.expiry_ts = epoch_seconds(src.expiry_at);
-        dest.grace_period_duration = src.grace_period_duration.count();
-        dest.platform_refund_expiry_ts = epoch_seconds(src.platform_refund_expiry_at);
-        dest.revoked_ts = epoch_seconds_double(src.revoked_at);
-        dest.refund_requested_ts = epoch_seconds(src.refund_requested_at);
-
-        dest.payment_id_count = snprintf_clamped(
-                dest.payment_id, sizeof(dest.payment_id), "%s", src.payment_id.c_str());
-    }
-
-    // Copy status + error code/message
-    fill_c_header(result.header, cpp, arena);
-
     return result;
 }
 
@@ -1167,34 +1117,18 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
         return result;
     }
 
-    // Note, parse is written to not throw so we can safely read without try-catch crap
-    auto cpp = parse_refund({json, json_len});
-
-    // Calculate how much memory we need and create an arena
-    arena_t arena = {};
-    {
-        arena.max += c_header_arena_bytes(cpp);
-
-        if (arena.max)
-            arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
-
-        if (arena.max && !arena.data) {
-            result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
-            result.header.error_code = C_INVALID_RESPONSE_CODE;
-            result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
-            return result;
-        }
-
-        // Store the pointer to the backing memory. Upon freeing, we release this one pointer
-        result.header.internal_arena_buf_ = arena.data;
+    try {
+        auto* owned = new SetPaymentRefundRequestedResponse(parse_refund({json, json_len}));
+        result.header.internal_ = owned;
+        fill_c_header(result.header, *owned);
+        result.updated = owned->updated;
+    } catch (const std::exception&) {
+        delete static_cast<SetPaymentRefundRequestedResponse*>(result.header.internal_);
+        result = {};
+        result.header.status = SESSION_PRO_BACKEND_RESPONSE_STATUS_ERROR;
+        result.header.error_code = C_INVALID_RESPONSE_CODE;
+        result.header.error = C_PARSE_ERROR_OUT_OF_MEMORY;
     }
-
-    // Copy to C struct
-    result.updated = cpp.updated;
-
-    // Copy status + error code/message
-    fill_c_header(result.header, cpp, arena);
-
     return result;
 }
 
@@ -1208,32 +1142,20 @@ LIBSESSION_C_API void session_pro_backend_request_free(session_pro_backend_reque
 
 LIBSESSION_C_API void session_pro_backend_pro_proof_response_free(
         session_pro_backend_pro_proof_response* response) {
-    if (response) {
-        free(response->header.internal_arena_buf_);
-        *response = {};
-    }
+    c_free_response<AddProPaymentResponse>(response);
 }
 
 LIBSESSION_C_API void session_pro_backend_get_pro_revocations_response_free(
         session_pro_backend_get_pro_revocations_response* response) {
-    if (response) {
-        free(response->header.internal_arena_buf_);
-        *response = {};
-    }
+    c_free_response<GetProRevocationsCResponse>(response);
 }
 
 LIBSESSION_C_API void session_pro_backend_get_pro_details_response_free(
         session_pro_backend_get_pro_details_response* response) {
-    if (response) {
-        free(response->header.internal_arena_buf_);
-        *response = {};
-    }
+    c_free_response<GetProDetailsCResponse>(response);
 }
 
 LIBSESSION_C_API void session_pro_backend_set_payment_refund_requested_response_free(
         session_pro_backend_set_payment_refund_requested_response* response) {
-    if (response) {
-        free(response->header.internal_arena_buf_);
-        *response = {};
-    }
+    c_free_response<SetPaymentRefundRequestedResponse>(response);
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -259,6 +259,8 @@ LIBSESSION_EXPORT extern const char* const
 // Backend base URL + Ed25519 pubkey: C symbols pointing at the single C++ definitions above.
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_URL = URL.data();
 LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY = PUBKEY.data();
+LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X25519 =
+        PUBKEY_X25519.data();
 }
 
 std::optional<ProviderUrls> provider_urls(std::string_view provider_code) {

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -64,6 +64,34 @@ const T json_require(
     return result;
 }
 
+// Reads a JSON number that may be an integer *or* a float, as a double. Used for the two
+// upstream-provider event instants (`purchased_ts`, `revoked_ts`) which the backend emits as floats
+// carrying the provider's sub-second precision (pro-wire-protocol.md §1).
+double json_require_number(
+        const nlohmann::json& j, std::string_view key, std::vector<std::string>& errors) {
+    auto it = j.find(key);
+    if (it == j.end())
+        errors.push_back(fmt::format("Key '{}' is missing", key));
+    else if (it->is_number())
+        return it->get<double>();
+    else
+        errors.push_back(fmt::format("Key value ({}, {}) was not a number", key, it->dump(1)));
+    return 0;
+}
+
+// Fractional UNIX seconds (double) -> millisecond-precision system time, preserving the provider's
+// sub-second precision (rounded to the nearest millisecond).
+session::sys_ms sys_ms_from_seconds(double seconds) {
+    return session::sys_ms(
+            std::chrono::round<std::chrono::milliseconds>(std::chrono::duration<double>(seconds)));
+}
+
+// Millisecond-precision system time -> fractional UNIX seconds (double); the C API carries these
+// two instants as double seconds (millisecond-precise, having passed through sys_ms).
+double epoch_seconds_double(session::sys_ms t) {
+    return std::chrono::duration<double>(t.time_since_epoch()).count();
+}
+
 void parse_json_response_errors(const nlohmann::json& j, std::vector<std::string>& errors) {
     const auto& array = json_require<nlohmann::json::array_t>(j, "errors", errors);
     errors.reserve(errors.size() + array.size());
@@ -619,14 +647,17 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         auto payment_provider = json_require<std::string>(obj, "payment_provider", result.errors);
         auto payment_id = json_require<std::string>(obj, "payment_id", result.errors);
         auto auto_renewing = json_require<bool>(obj, "auto_renewing", result.errors);
-        auto unredeemed_ts = json_require<int64_t>(obj, "unredeemed_ts", result.errors);
+        // purchased_ts and revoked_ts are upstream-provider event instants: floats on the wire
+        // carrying sub-second precision (kept as millisecond-precision sys_ms). All other
+        // timestamps are whole-second integers.
+        auto purchased_ts = json_require_number(obj, "purchased_ts", result.errors);
         auto redeemed_ts = json_require<int64_t>(obj, "redeemed_ts", result.errors);
         auto expiry_ts = json_require<int64_t>(obj, "expiry_ts", result.errors);
         auto grace_period_duration =
                 json_require<int64_t>(obj, "grace_period_duration", result.errors);
         auto platform_refund_expiry_ts =
                 json_require<int64_t>(obj, "platform_refund_expiry_ts", result.errors);
-        auto revoked_ts = json_require<int64_t>(obj, "revoked_ts", result.errors);
+        auto revoked_ts = json_require_number(obj, "revoked_ts", result.errors);
         auto refund_requested_ts = json_require<int64_t>(obj, "refund_requested_ts", result.errors);
 
         ProPaymentItem item = {};
@@ -642,13 +673,13 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
         item.payment_id = std::move(payment_id);
 
         item.auto_renewing = auto_renewing;
-        item.unredeemed_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(unredeemed_ts));
+        item.purchased_unix_ts = sys_ms_from_seconds(purchased_ts);
         item.redeemed_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(redeemed_ts));
         item.expiry_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
         item.grace_period_duration = std::chrono::seconds(grace_period_duration);
         item.platform_refund_expiry_unix_ts =
                 std::chrono::sys_seconds(std::chrono::seconds(platform_refund_expiry_ts));
-        item.revoked_unix_ts = std::chrono::sys_seconds(std::chrono::seconds(revoked_ts));
+        item.revoked_unix_ts = sys_ms_from_seconds(revoked_ts);
         item.refund_requested_unix_ts =
                 std::chrono::sys_seconds(std::chrono::seconds(refund_requested_ts));
 
@@ -1180,12 +1211,12 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
                 sizeof(dest.payment_provider),
                 "%s",
                 src.payment_provider.c_str());
-        dest.unredeemed_ts = epoch_seconds(src.unredeemed_unix_ts);
+        dest.purchased_ts = epoch_seconds_double(src.purchased_unix_ts);
         dest.redeemed_ts = epoch_seconds(src.redeemed_unix_ts);
         dest.expiry_ts = epoch_seconds(src.expiry_unix_ts);
         dest.grace_period_duration = src.grace_period_duration.count();
         dest.platform_refund_expiry_ts = epoch_seconds(src.platform_refund_expiry_unix_ts);
-        dest.revoked_ts = epoch_seconds(src.revoked_unix_ts);
+        dest.revoked_ts = epoch_seconds_double(src.revoked_unix_ts);
         dest.refund_requested_ts = epoch_seconds(src.refund_requested_unix_ts);
 
         dest.payment_id_count = snprintf_clamped(

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -328,18 +328,17 @@ ProRequest add_payment_request(
 namespace {
     // Shared parse for the proof-carrying responses (add-payment and generate-proof both reply with
     // exactly a proof); fills the common ProProofResponse base of whichever derived response is
-    // passed.
+    // passed. On any failure `result.errors` is populated (the backend sends the human-readable
+    // reason there, including for already-redeemed / unknown-payment).
     void fill_proof_response(std::string_view json, ProProofResponse& result) {
         // Parse basics
         nlohmann::json j = json_parse(json, result.errors);
-        result.status = json_require<uint8_t>(j, "status", result.errors);
-        if (result.errors.size()) {
-            result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
+        uint32_t status = json_require<uint8_t>(j, "status", result.errors);
+        if (result.errors.size())
             return;
-        }
 
         // Parse errors
-        if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
+        if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
             parse_json_response_errors(j, result.errors);
             return;
         }
@@ -462,14 +461,12 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
     // Parse basics
     GetProRevocationsResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
-    result.status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size()) {
-        result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
+    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
+    if (result.errors.size())
         return result;
-    }
 
     // Parse errors
-    if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
+    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
         parse_json_response_errors(j, result.errors);
         return result;
     }
@@ -582,14 +579,12 @@ GetProDetailsResponse parse_payment_details(std::string_view json) {
     // Parse basics
     GetProDetailsResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
-    result.status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size()) {
-        result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
+    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
+    if (result.errors.size())
         return result;
-    }
 
     // Parse errors
-    if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
+    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
         parse_json_response_errors(j, result.errors);
         return result;
     }
@@ -781,14 +776,12 @@ SetPaymentRefundRequestedResponse parse_refund(std::string_view json) {
     // Parse basics
     SetPaymentRefundRequestedResponse result = {};
     nlohmann::json j = json_parse(json, result.errors);
-    result.status = json_require<uint8_t>(j, "status", result.errors);
-    if (result.errors.size()) {
-        result.status = SESSION_PRO_BACKEND_STATUS_GENERIC_ERROR;
+    uint32_t status = json_require<uint8_t>(j, "status", result.errors);
+    if (result.errors.size())
         return result;
-    }
 
     // Parse errors
-    if (result.status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
+    if (status != SESSION_PRO_BACKEND_STATUS_SUCCESS) {
         parse_json_response_errors(j, result.errors);
         return result;
     }
@@ -904,7 +897,6 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
 
     session_pro_backend_pro_proof_response result = {};
     if (!json) {
-        result.header.status = 1;
         result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
         result.header.errors_count = 1;
         return result;
@@ -925,7 +917,6 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.status = 1;
             result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
             result.header.errors_count = 1;
             return result;
@@ -938,7 +929,6 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
     // Note that a response error and success case folds into the same code path. A success and
     // error response returns the same struct just with different fields populated.
-    result.header.status = cpp.status;
     result.proof.version = cpp.proof.version;
     result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_at);
     std::memcpy(
@@ -966,7 +956,6 @@ LIBSESSION_C_API session_pro_backend_get_pro_revocations_response
 session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t json_len) {
     session_pro_backend_get_pro_revocations_response result = {};
     if (!json) {
-        result.header.status = 1;
         result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
         result.header.errors_count = 1;
         return result;
@@ -990,7 +979,6 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.status = 1;
             result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
             result.header.errors_count = 1;
             return result;
@@ -1001,7 +989,6 @@ session_pro_backend_get_pro_revocations_response_parse(const char* json, size_t 
     }
 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
-    result.header.status = cpp.status;
     result.ticket = cpp.ticket;
     result.retry_in = cpp.retry_in.count();
     result.retain_for = cpp.retain_for.count();
@@ -1033,7 +1020,6 @@ LIBSESSION_C_API session_pro_backend_get_pro_details_response
 session_pro_backend_get_pro_details_response_parse(const char* json, size_t json_len) {
     session_pro_backend_get_pro_details_response result = {};
     if (!json) {
-        result.header.status = 1;
         result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
         result.header.errors_count = 1;
         return result;
@@ -1053,7 +1039,6 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.status = 1;
             result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
             result.header.errors_count = 1;
             return result;
@@ -1066,7 +1051,6 @@ session_pro_backend_get_pro_details_response_parse(const char* json, size_t json
     using session::epoch_seconds;
 
     // Copy to C struct, this is guaranteed not to fail because we pre-allocated memory upfront.
-    result.header.status = cpp.status;
     result.status_count =
             snprintf_clamped(result.status, sizeof(result.status), "%s", cpp.user_status.c_str());
     result.error_report = cpp.error_report;
@@ -1141,7 +1125,6 @@ LIBSESSION_C_API session_pro_backend_set_payment_refund_requested_response
 session_pro_backend_set_payment_refund_requested_response_parse(const char* json, size_t json_len) {
     session_pro_backend_set_payment_refund_requested_response result = {};
     if (!json) {
-        result.header.status = 1;
         result.header.errors = &C_PARSE_ERROR_INVALID_ARGS;
         result.header.errors_count = 1;
         return result;
@@ -1160,7 +1143,6 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
             arena.data = static_cast<uint8_t*>(calloc(1, arena.max));
 
         if (arena.max && !arena.data) {
-            result.header.status = 1;
             result.header.errors = &C_PARSE_ERROR_OUT_OF_MEMORY;
             result.header.errors_count = 1;
             return result;
@@ -1171,7 +1153,6 @@ session_pro_backend_set_payment_refund_requested_response_parse(const char* json
     }
 
     // Copy to C struct
-    result.header.status = cpp.status;
     result.updated = cpp.updated;
 
     // Copy errors

--- a/src/pro_message.hpp
+++ b/src/pro_message.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <charconv>
+#include <concepts>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace session::pro {
+
+/// Builds the byte string that is Ed25519-signed for a Pro proof (§2) or a signed request (§3),
+/// following the signed-message construction in pro-wire-protocol.md §1.1. Pass the 16-byte domain
+/// prefix first, then the fields in order; each field is encoded by its type:
+///
+/// - **byte-spannable** (public key, revocation tag — fixed-width raw values): appended verbatim
+///   and self-delimiting;
+/// - **integer**: canonical decimal ASCII (`std::to_chars`, base 10, locale-independent — never a
+///   locale-aware formatter);
+/// - **string_view** (`provider_code`, and the opaque variable-length `payment_id` via
+///   `to_string_view`): its bytes verbatim.
+///
+/// A single NUL byte is inserted between two *adjacent* variable-length fields (integer/string);
+/// raw fields need no separator, and the domain prefix (also raw) never precedes one. The message
+/// is signed directly — there is no pre-hash (Ed25519 hashes internally).
+template <typename... Fields>
+std::vector<unsigned char> signed_message(std::string_view domain, const Fields&... fields) {
+    std::vector<unsigned char> buf(domain.begin(), domain.end());
+    bool prev_var = false;  // the previously-appended field was variable-length (int/string)
+
+    auto append = [&](const auto& field) {
+        using T = std::remove_cvref_t<decltype(field)>;
+        if constexpr (std::is_integral_v<T>) {
+            if (prev_var)
+                buf.push_back('\0');
+            char tmp[24];  // enough for -9223372036854775808 (20 chars)
+            auto [ptr, ec] = std::to_chars(tmp, tmp + sizeof(tmp), field);
+            buf.insert(buf.end(), tmp, ptr);
+            prev_var = true;
+        } else if constexpr (std::convertible_to<const T&, std::string_view>) {
+            if (prev_var)
+                buf.push_back('\0');
+            std::string_view s = field;
+            buf.insert(buf.end(), s.begin(), s.end());
+            prev_var = true;
+        } else {
+            static_assert(
+                    std::convertible_to<const T&, std::span<const unsigned char>>,
+                    "signed_message() fields must be an integer, a string_view, or a "
+                    "byte-spannable raw value (e.g. a public key or tag)");
+            std::span<const unsigned char> b = field;
+            buf.insert(buf.end(), b.begin(), b.end());
+            prev_var = false;
+        }
+    };
+    (append(fields), ...);
+    return buf;
+}
+
+}  // namespace session::pro

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -75,7 +75,6 @@ session::array_uc32 proof_hash_internal(
         std::span<const std::uint8_t> rotating_pubkey,
         std::uint64_t expiry_unix_ts_ms) {
 
-    constexpr std::string_view PRO_BACKEND_BLAKE2B_PERSONALISATION = "SeshProBackend__";
     // This must match the hashing routine at
     // https://github.com/Doy-lee/session-pro-backend/blob/9417e00adbff3bf608b7ae831f87045bdab06232/backend.py#L545-L558
     session::array_uc32 result = {};

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -75,8 +75,7 @@ session::array_uc32 proof_hash_internal(
         std::span<const std::uint8_t> rotating_pubkey,
         std::int64_t expiry_ts) {
 
-    // This must match the hashing routine at
-    // https://github.com/Doy-lee/session-pro-backend/blob/9417e00adbff3bf608b7ae831f87045bdab06232/backend.py#L545-L558
+    // This must match the Pro proof signed digest in pro-wire-protocol.md §2.
     session::array_uc32 result = {};
     crypto_generichash_blake2b_state state = {};
     session::make_blake2b32_hasher(

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -1227,7 +1227,7 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_message(
 }
 
 LIBSESSION_C_API bool session_protocol_pro_proof_is_active(
-        session_protocol_pro_proof const* proof, uint64_t ts) {
+        session_protocol_pro_proof const* proof, int64_t ts) {
     return ts <= proof->expiry_ts;
 }
 
@@ -1235,7 +1235,7 @@ LIBSESSION_C_API SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
         session_protocol_pro_proof const* proof,
         const uint8_t* verify_pubkey,
         size_t verify_pubkey_len,
-        uint64_t ts,
+        int64_t ts,
         const session_protocol_pro_signed_message* signed_msg) {
     SESSION_PROTOCOL_PRO_STATUS result = SESSION_PROTOCOL_PRO_STATUS_VALID;
     if (!session_protocol_pro_proof_verify_signature(proof, verify_pubkey, verify_pubkey_len))
@@ -1571,7 +1571,7 @@ LIBSESSION_C_API
 session_protocol_decoded_community_message session_protocol_decode_for_community(
         const void* content_or_envelope_payload,
         size_t content_or_envelope_payload_len,
-        uint64_t ts,
+        int64_t ts,
         OPTIONAL const void* pro_backend_pubkey,
         size_t pro_backend_pubkey_len,
         OPTIONAL char* error,

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -73,7 +73,7 @@ session::array_uc32 proof_hash_internal(
         std::uint8_t version,
         std::span<const std::uint8_t> gen_index_hash,
         std::span<const std::uint8_t> rotating_pubkey,
-        std::uint64_t expiry_unix_ts_ms) {
+        std::int64_t expiry_ts) {
 
     // This must match the hashing routine at
     // https://github.com/Doy-lee/session-pro-backend/blob/9417e00adbff3bf608b7ae831f87045bdab06232/backend.py#L545-L558
@@ -86,9 +86,9 @@ session::array_uc32 proof_hash_internal(
     crypto_generichash_blake2b_update(&state, &version, sizeof(version));
     crypto_generichash_blake2b_update(&state, gen_index_hash.data(), gen_index_hash.size());
     crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
-    oxenc::host_to_little_inplace(expiry_unix_ts_ms);
+    oxenc::host_to_little_inplace(expiry_ts);
     crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<uint8_t*>(&expiry_unix_ts_ms), sizeof(expiry_unix_ts_ms));
+            &state, reinterpret_cast<uint8_t*>(&expiry_ts), sizeof(expiry_ts));
     crypto_generichash_blake2b_final(&state, result.data(), result.size());
     return result;
 }
@@ -166,7 +166,7 @@ static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedP
             result.proof.rotating_pubkey.data,
             cpp.proof.rotating_pubkey.data(),
             cpp.proof.rotating_pubkey.max_size());
-    result.proof.expiry_unix_ts_ms = session::epoch_ms(cpp.proof.expiry_unix_ts);
+    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_unix_ts);
     std::memcpy(result.proof.sig.data, cpp.proof.sig.data(), cpp.proof.sig.max_size());
     result.msg_bitset.data = cpp.msg_bitset.data;
     result.profile_bitset.data = cpp.profile_bitset.data;
@@ -199,13 +199,13 @@ bool ProProof::verify_message(std::span<const uint8_t> sig, std::span<const uint
     return result;
 }
 
-bool ProProof::is_active(std::chrono::sys_time<std::chrono::milliseconds> unix_ts) const {
+bool ProProof::is_active(sys_seconds unix_ts) const {
     return unix_ts <= expiry_unix_ts;
 }
 
 ProStatus ProProof::status(
         std::span<const uint8_t> verify_pubkey,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
+        sys_seconds unix_ts,
         const std::optional<ProSignedMessage>& signed_msg) {
     ProStatus result = ProStatus::Valid;
     // Verify the at the proof is verified by the Session Pro Backend key (e.g.: It was
@@ -227,7 +227,7 @@ ProStatus ProProof::status(
 
 array_uc32 ProProof::hash() const {
     array_uc32 result = proof_hash_internal(
-            version, gen_index_hash, rotating_pubkey, expiry_unix_ts.time_since_epoch().count());
+            version, gen_index_hash, rotating_pubkey, epoch_seconds(expiry_unix_ts));
     return result;
 }
 
@@ -916,8 +916,7 @@ DecodedEnvelope decode_envelope(
                     proof.rotating_pubkey.data(),
                     proto_proof.rotatingpublickey().data(),
                     proto_proof.rotatingpublickey().size());
-            proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(proto_proof.expiryunixts()));
+            proof.expiry_unix_ts = as_sys_seconds(proto_proof.expiryunixts());
             std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
             // Evaluate the pro status given the extracted components (was it signed, is it expired,
@@ -927,8 +926,9 @@ DecodedEnvelope decode_envelope(
 
             // Note that we sign the envelope content wholesale. For 1o1 which are padded to 160
             // bytes, this means that we expected the user to have signed the padding as well.
-            auto unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(content.sigtimestamp()));
+            auto unix_ts = std::chrono::floor<std::chrono::seconds>(
+                    std::chrono::sys_time<std::chrono::milliseconds>(
+                            std::chrono::milliseconds(content.sigtimestamp())));
             signed_msg.msg = to_span(envelope.content());
             pro.status = proof.status(pro_backend_pubkey, unix_ts, signed_msg);
         }
@@ -938,7 +938,7 @@ DecodedEnvelope decode_envelope(
 
 DecodedCommunityMessage decode_for_community(
         std::span<const uint8_t> content_or_envelope_payload,
-        std::chrono::sys_time<std::chrono::milliseconds> unix_ts,
+        sys_seconds unix_ts,
         const array_uc32& pro_backend_pubkey) {
     // TODO: Community message parsing requires a custom code path for now as we are planning to
     // migrate from sending plain `Content` to `Content` with a pro signature embedded in `Content`
@@ -1076,8 +1076,7 @@ DecodedCommunityMessage decode_for_community(
                 proof.rotating_pubkey.data(),
                 proto_proof.rotatingpublickey().data(),
                 proto_proof.rotatingpublickey().size());
-        proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                std::chrono::milliseconds(proto_proof.expiryunixts()));
+        proof.expiry_unix_ts = as_sys_seconds(proto_proof.expiryunixts());
         std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
         // Evaluate the pro status given the extracted components (was it signed, is it expired,
@@ -1194,7 +1193,7 @@ LIBSESSION_C_API bytes32 session_protocol_pro_proof_hash(session_protocol_pro_pr
             proof->version,
             proof->gen_index_hash.data,
             proof->rotating_pubkey.data,
-            proof->expiry_unix_ts_ms);
+            proof->expiry_ts);
     std::memcpy(result.data, hash.data(), hash.size());
     return result;
 }
@@ -1210,7 +1209,7 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_signature(
             proof->version,
             proof->gen_index_hash.data,
             proof->rotating_pubkey.data,
-            proof->expiry_unix_ts_ms);
+            proof->expiry_ts);
     bool result = proof_verify_signature_internal(hash, proof->sig.data, verify_pubkey_span);
     return result;
 }
@@ -1228,15 +1227,15 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_message(
 }
 
 LIBSESSION_C_API bool session_protocol_pro_proof_is_active(
-        session_protocol_pro_proof const* proof, uint64_t unix_ts_ms) {
-    return unix_ts_ms <= proof->expiry_unix_ts_ms;
+        session_protocol_pro_proof const* proof, uint64_t ts) {
+    return ts <= proof->expiry_ts;
 }
 
 LIBSESSION_C_API SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
         session_protocol_pro_proof const* proof,
         const uint8_t* verify_pubkey,
         size_t verify_pubkey_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         const session_protocol_pro_signed_message* signed_msg) {
     SESSION_PROTOCOL_PRO_STATUS result = SESSION_PROTOCOL_PRO_STATUS_VALID;
     if (!session_protocol_pro_proof_verify_signature(proof, verify_pubkey, verify_pubkey_len))
@@ -1255,7 +1254,7 @@ LIBSESSION_C_API SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
 
     // Check if the proof has expired
     if (result == SESSION_PROTOCOL_PRO_STATUS_VALID &&
-        !session_protocol_pro_proof_is_active(proof, unix_ts_ms))
+        !session_protocol_pro_proof_is_active(proof, ts))
         result = SESSION_PROTOCOL_PRO_STATUS_EXPIRED;
     return result;
 }
@@ -1572,7 +1571,7 @@ LIBSESSION_C_API
 session_protocol_decoded_community_message session_protocol_decode_for_community(
         const void* content_or_envelope_payload,
         size_t content_or_envelope_payload_len,
-        uint64_t unix_ts_ms,
+        uint64_t ts,
         OPTIONAL const void* pro_backend_pubkey,
         size_t pro_backend_pubkey_len,
         OPTIONAL char* error,
@@ -1581,8 +1580,7 @@ session_protocol_decoded_community_message session_protocol_decode_for_community
     auto content_or_envelope_payload_span = std::span<const uint8_t>(
             reinterpret_cast<const uint8_t*>(content_or_envelope_payload),
             content_or_envelope_payload_len);
-    auto unix_ts =
-            std::chrono::sys_time<std::chrono::milliseconds>(std::chrono::milliseconds(unix_ts_ms));
+    auto unix_ts = as_sys_seconds(ts);
     array_uc32_from_ptr_result pro_backend_pubkey_cpp =
             array_uc32_from_ptr(pro_backend_pubkey, pro_backend_pubkey_len);
     if (!pro_backend_pubkey_cpp.success) {

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -71,7 +71,7 @@ const session_protocol_strings SESSION_PROTOCOL_STRINGS = {
 namespace {
 session::array_uc32 proof_hash_internal(
         std::uint8_t version,
-        std::span<const std::uint8_t> gen_index_hash,
+        std::span<const std::uint8_t> revocation_tag,
         std::span<const std::uint8_t> rotating_pubkey,
         std::int64_t expiry_ts) {
 
@@ -84,7 +84,7 @@ session::array_uc32 proof_hash_internal(
             {SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION,
              sizeof(SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION) - 1});
     crypto_generichash_blake2b_update(&state, &version, sizeof(version));
-    crypto_generichash_blake2b_update(&state, gen_index_hash.data(), gen_index_hash.size());
+    crypto_generichash_blake2b_update(&state, revocation_tag.data(), revocation_tag.size());
     crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
     oxenc::host_to_little_inplace(expiry_ts);
     crypto_generichash_blake2b_update(
@@ -159,9 +159,9 @@ static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedP
     result.status = static_cast<SESSION_PROTOCOL_PRO_STATUS>(cpp.status);
     result.proof.version = cpp.proof.version;
     std::memcpy(
-            result.proof.gen_index_hash.data,
-            cpp.proof.gen_index_hash.data(),
-            cpp.proof.gen_index_hash.max_size());
+            result.proof.revocation_tag.data,
+            cpp.proof.revocation_tag.data(),
+            cpp.proof.revocation_tag.max_size());
     std::memcpy(
             result.proof.rotating_pubkey.data,
             cpp.proof.rotating_pubkey.data(),
@@ -176,7 +176,7 @@ static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedP
 
 namespace session {
 
-static_assert(sizeof(((ProProof*)0)->gen_index_hash) == 32);
+static_assert(sizeof(((ProProof*)0)->revocation_tag) == 32);
 static_assert(sizeof(((ProProof*)0)->rotating_pubkey) == crypto_sign_ed25519_PUBLICKEYBYTES);
 static_assert(sizeof(((ProProof*)0)->sig) == crypto_sign_ed25519_BYTES);
 
@@ -227,7 +227,7 @@ ProStatus ProProof::status(
 
 array_uc32 ProProof::hash() const {
     array_uc32 result = proof_hash_internal(
-            version, gen_index_hash, rotating_pubkey, epoch_seconds(expiry_unix_ts));
+            version, revocation_tag, rotating_pubkey, epoch_seconds(expiry_unix_ts));
     return result;
 }
 
@@ -894,7 +894,7 @@ DecodedEnvelope decode_envelope(
             // clang-format off
             size_t proof_errors = 0;
             proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
-            proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.gen_index_hash.max_size();
+            proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.revocation_tag.max_size();
             proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
             proof_errors += !proto_proof.has_expiryunixts();
             proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
@@ -909,7 +909,7 @@ DecodedEnvelope decode_envelope(
             std::memcpy(result.envelope.pro_sig.data(), pro_sig.data(), pro_sig.size());
 
             std::memcpy(
-                    proof.gen_index_hash.data(),
+                    proof.revocation_tag.data(),
                     proto_proof.genindexhash().data(),
                     proto_proof.genindexhash().size());
             std::memcpy(
@@ -1056,7 +1056,7 @@ DecodedCommunityMessage decode_for_community(
         // clang-format off
         size_t proof_errors = 0;
         proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
-        proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.gen_index_hash.max_size();
+        proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.revocation_tag.max_size();
         proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
         proof_errors += !proto_proof.has_expiryunixts();
         proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
@@ -1069,7 +1069,7 @@ DecodedCommunityMessage decode_for_community(
         pro.msg_bitset.data = pro_msg.msgbitset();
         pro.profile_bitset.data = pro_msg.profilebitset();
         std::memcpy(
-                proof.gen_index_hash.data(),
+                proof.revocation_tag.data(),
                 proto_proof.genindexhash().data(),
                 proto_proof.genindexhash().size());
         std::memcpy(
@@ -1139,7 +1139,7 @@ void make_blake2b32_hasher(
 
 using namespace session;
 
-static_assert((sizeof((session_protocol_pro_proof*)0)->gen_index_hash) == 32);
+static_assert((sizeof((session_protocol_pro_proof*)0)->revocation_tag) == 32);
 static_assert(
         (sizeof((session_protocol_pro_proof*)0)->rotating_pubkey) ==
         crypto_sign_ed25519_PUBLICKEYBYTES);
@@ -1191,7 +1191,7 @@ LIBSESSION_C_API bytes32 session_protocol_pro_proof_hash(session_protocol_pro_pr
     bytes32 result = {};
     session::array_uc32 hash = proof_hash_internal(
             proof->version,
-            proof->gen_index_hash.data,
+            proof->revocation_tag.data,
             proof->rotating_pubkey.data,
             proof->expiry_ts);
     std::memcpy(result.data, hash.data(), hash.size());
@@ -1207,7 +1207,7 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_signature(
     auto verify_pubkey_span = std::span<const std::uint8_t>(verify_pubkey, verify_pubkey_len);
     session::array_uc32 hash = proof_hash_internal(
             proof->version,
-            proof->gen_index_hash.data,
+            proof->revocation_tag.data,
             proof->rotating_pubkey.data,
             proof->expiry_ts);
     bool result = proof_verify_signature_internal(hash, proof->sig.data, verify_pubkey_span);

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -70,19 +70,19 @@ const session_protocol_strings SESSION_PROTOCOL_STRINGS = {
 
 namespace {
 session::array_uc32 proof_hash_internal(
-        std::uint8_t version,
         std::span<const std::uint8_t> revocation_tag,
         std::span<const std::uint8_t> rotating_pubkey,
         std::int64_t expiry_ts) {
 
-    // This must match the Pro proof signed digest in pro-wire-protocol.md §2.
+    // This must match the Pro proof signed digest in pro-wire-protocol.md §2. The proof version is
+    // NOT hashed as a byte; it selects the personalisation (v0 -> "ProProof_v0_____"), and that
+    // choice of personalisation is what binds the version into the signature.
     session::array_uc32 result = {};
     crypto_generichash_blake2b_state state = {};
     session::make_blake2b32_hasher(
             &state,
             {SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION,
              sizeof(SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, &version, sizeof(version));
     crypto_generichash_blake2b_update(&state, revocation_tag.data(), revocation_tag.size());
     crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
     oxenc::host_to_little_inplace(expiry_ts);
@@ -225,8 +225,8 @@ ProStatus ProProof::status(
 }
 
 array_uc32 ProProof::hash() const {
-    array_uc32 result = proof_hash_internal(
-            version, revocation_tag, rotating_pubkey, epoch_seconds(expiry_unix_ts));
+    array_uc32 result =
+            proof_hash_internal(revocation_tag, rotating_pubkey, epoch_seconds(expiry_unix_ts));
     return result;
 }
 
@@ -1189,10 +1189,7 @@ LIBSESSION_C_API void session_protocol_pro_message_bitset_unset(
 LIBSESSION_C_API bytes32 session_protocol_pro_proof_hash(session_protocol_pro_proof const* proof) {
     bytes32 result = {};
     session::array_uc32 hash = proof_hash_internal(
-            proof->version,
-            proof->revocation_tag.data,
-            proof->rotating_pubkey.data,
-            proof->expiry_ts);
+            proof->revocation_tag.data, proof->rotating_pubkey.data, proof->expiry_ts);
     std::memcpy(result.data, hash.data(), hash.size());
     return result;
 }
@@ -1205,10 +1202,7 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_signature(
         return false;
     auto verify_pubkey_span = std::span<const std::uint8_t>(verify_pubkey, verify_pubkey_len);
     session::array_uc32 hash = proof_hash_internal(
-            proof->version,
-            proof->revocation_tag.data,
-            proof->rotating_pubkey.data,
-            proof->expiry_ts);
+            proof->revocation_tag.data, proof->rotating_pubkey.data, proof->expiry_ts);
     bool result = proof_verify_signature_internal(hash, proof->sig.data, verify_pubkey_span);
     return result;
 }

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -894,7 +894,7 @@ DecodedEnvelope decode_envelope(
             // clang-format off
             size_t proof_errors = 0;
             proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
-            proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.revocation_tag.max_size();
+            proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
             proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
             proof_errors += !proto_proof.has_expiryunixts();
             proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
@@ -910,8 +910,8 @@ DecodedEnvelope decode_envelope(
 
             std::memcpy(
                     proof.revocation_tag.data(),
-                    proto_proof.genindexhash().data(),
-                    proto_proof.genindexhash().size());
+                    proto_proof.revocationtag().data(),
+                    proto_proof.revocationtag().size());
             std::memcpy(
                     proof.rotating_pubkey.data(),
                     proto_proof.rotatingpublickey().data(),
@@ -1056,7 +1056,7 @@ DecodedCommunityMessage decode_for_community(
         // clang-format off
         size_t proof_errors = 0;
         proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
-        proof_errors += !proto_proof.has_genindexhash()      || proto_proof.genindexhash().size()      != proof.revocation_tag.max_size();
+        proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
         proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
         proof_errors += !proto_proof.has_expiryunixts();
         proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
@@ -1070,8 +1070,8 @@ DecodedCommunityMessage decode_for_community(
         pro.profile_bitset.data = pro_msg.profilebitset();
         std::memcpy(
                 proof.revocation_tag.data(),
-                proto_proof.genindexhash().data(),
-                proto_proof.genindexhash().size());
+                proto_proof.revocationtag().data(),
+                proto_proof.revocationtag().size());
         std::memcpy(
                 proof.rotating_pubkey.data(),
                 proto_proof.rotatingpublickey().data(),

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -3,7 +3,6 @@
 #include <oxenc/hex.h>
 #include <session/config/groups/keys.h>
 #include <simdutf.h>
-#include <sodium/crypto_generichash_blake2b.h>
 #include <sodium/crypto_sign_ed25519.h>
 #include <sodium/randombytes.h>
 
@@ -16,27 +15,8 @@
 
 #include "SessionProtos.pb.h"
 #include "WebSocketResources.pb.h"
+#include "pro_message.hpp"
 #include "session/export.h"
-
-static_assert(
-        sizeof(SESSION_PROTOCOL_GENERATE_PROOF_HASH_PERSONALISATION) - 1 ==
-        crypto_generichash_blake2b_PERSONALBYTES);
-
-static_assert(
-        sizeof(SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION) - 1 ==
-        crypto_generichash_blake2b_PERSONALBYTES);
-
-static_assert(
-        sizeof(SESSION_PROTOCOL_ADD_PRO_PAYMENT_HASH_PERSONALISATION) - 1 ==
-        crypto_generichash_blake2b_PERSONALBYTES);
-
-static_assert(
-        sizeof(SESSION_PROTOCOL_SET_PAYMENT_REFUND_REQUESTED_HASH_PERSONALISATION) - 1 ==
-        crypto_generichash_blake2b_PERSONALBYTES);
-
-static_assert(
-        sizeof(SESSION_PROTOCOL_GET_PRO_DETAILS_HASH_PERSONALISATION) - 1 ==
-        crypto_generichash_blake2b_PERSONALBYTES);
 
 // clang-format off
 const session_protocol_strings SESSION_PROTOCOL_STRINGS = {
@@ -69,43 +49,16 @@ const session_protocol_strings SESSION_PROTOCOL_STRINGS = {
 // clang-format on
 
 namespace {
-session::array_uc32 proof_hash_internal(
+std::vector<unsigned char> proof_signed_message(
         std::span<const std::uint8_t> revocation_tag,
         std::span<const std::uint8_t> rotating_pubkey,
         std::int64_t expiry_ts) {
 
-    // This must match the Pro proof signed digest in pro-wire-protocol.md §2. The proof version is
-    // NOT hashed as a byte; it selects the personalisation (v0 -> "ProProof_v0_____"), and that
-    // choice of personalisation is what binds the version into the signature.
-    session::array_uc32 result = {};
-    crypto_generichash_blake2b_state state = {};
-    session::make_blake2b32_hasher(
-            &state,
-            {SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION,
-             sizeof(SESSION_PROTOCOL_BUILD_PROOF_HASH_PERSONALISATION) - 1});
-    crypto_generichash_blake2b_update(&state, revocation_tag.data(), revocation_tag.size());
-    crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
-    oxenc::host_to_little_inplace(expiry_ts);
-    crypto_generichash_blake2b_update(
-            &state, reinterpret_cast<uint8_t*>(&expiry_ts), sizeof(expiry_ts));
-    crypto_generichash_blake2b_final(&state, result.data(), result.size());
-    return result;
-}
-
-bool proof_verify_signature_internal(
-        std::span<const std::uint8_t> hash,
-        std::span<const std::uint8_t> sig,
-        std::span<const std::uint8_t> verify_pubkey) {
-    // The C/C++ interface verifies that the payloads are the correct size using the type system so
-    // only need asserts here.
-    assert(hash.size() == 32);
-    assert(sig.size() == crypto_sign_ed25519_BYTES);
-    assert(verify_pubkey.size() == crypto_sign_ed25519_PUBLICKEYBYTES);
-
-    int verify_result = crypto_sign_ed25519_verify_detached(
-            sig.data(), hash.data(), hash.size(), verify_pubkey.data());
-    bool result = verify_result == 0;
-    return result;
+    // This must match the Pro proof signed message in pro-wire-protocol.md §2 (built per §1.1). The
+    // proof version is NOT part of the message; it selects the 16-byte domain prefix (v0 ->
+    // "ProProof_v0_____"), and that choice of prefix is what binds the version into the signature.
+    return session::pro::signed_message(
+            session::BUILD_PROOF_DOMAIN, revocation_tag, rotating_pubkey, expiry_ts);
 }
 
 bool proof_verify_message_internal(
@@ -185,8 +138,8 @@ bool ProProof::verify_signature(const std::span<const uint8_t>& verify_pubkey) c
                 "Invalid verify_pubkey: Must be 32 byte Ed25519 public key (was: {})",
                 verify_pubkey.size())};
 
-    array_uc32 hash_to_sign = hash();
-    bool result = proof_verify_signature_internal(hash_to_sign, sig, verify_pubkey);
+    auto msg = proof_signed_message(revocation_tag, rotating_pubkey, epoch_seconds(expiry_at));
+    bool result = proof_verify_message_internal(verify_pubkey, sig, msg);
     return result;
 }
 
@@ -224,10 +177,8 @@ ProStatus ProProof::status(
     return result;
 }
 
-array_uc32 ProProof::hash() const {
-    array_uc32 result =
-            proof_hash_internal(revocation_tag, rotating_pubkey, epoch_seconds(expiry_at));
-    return result;
+std::vector<unsigned char> ProProof::signed_message() const {
+    return proof_signed_message(revocation_tag, rotating_pubkey, epoch_seconds(expiry_at));
 }
 
 void ProProfileBitset::set(SESSION_PROTOCOL_PRO_PROFILE_FEATURES features) {
@@ -1120,20 +1071,6 @@ DecodedCommunityMessage decode_for_community(
 
     return result;
 }
-
-void make_blake2b32_hasher(
-        crypto_generichash_blake2b_state* hasher, std::string_view personalization) {
-    assert(personalization.data() == nullptr ||
-           (personalization.data() &&
-            personalization.size() == crypto_generichash_blake2b_PERSONALBYTES));
-    crypto_generichash_blake2b_init_salt_personal(
-            hasher,
-            /*key*/ nullptr,
-            0,
-            32,
-            /*salt*/ nullptr,
-            reinterpret_cast<const unsigned char*>(personalization.data()));
-}
 }  // namespace session
 
 using namespace session;
@@ -1186,14 +1123,6 @@ LIBSESSION_C_API void session_protocol_pro_message_bitset_unset(
     value->data &= ~(1ULL << features);
 }
 
-LIBSESSION_C_API bytes32 session_protocol_pro_proof_hash(session_protocol_pro_proof const* proof) {
-    bytes32 result = {};
-    session::array_uc32 hash = proof_hash_internal(
-            proof->revocation_tag.data, proof->rotating_pubkey.data, proof->expiry_ts);
-    std::memcpy(result.data, hash.data(), hash.size());
-    return result;
-}
-
 LIBSESSION_C_API bool session_protocol_pro_proof_verify_signature(
         session_protocol_pro_proof const* proof,
         uint8_t const* verify_pubkey,
@@ -1201,9 +1130,9 @@ LIBSESSION_C_API bool session_protocol_pro_proof_verify_signature(
     if (verify_pubkey_len != crypto_sign_ed25519_PUBLICKEYBYTES)
         return false;
     auto verify_pubkey_span = std::span<const std::uint8_t>(verify_pubkey, verify_pubkey_len);
-    session::array_uc32 hash = proof_hash_internal(
+    auto msg = proof_signed_message(
             proof->revocation_tag.data, proof->rotating_pubkey.data, proof->expiry_ts);
-    bool result = proof_verify_signature_internal(hash, proof->sig.data, verify_pubkey_span);
+    bool result = proof_verify_message_internal(verify_pubkey_span, proof->sig.data, msg);
     return result;
 }
 

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -1,4 +1,5 @@
 #include <fmt/core.h>
+#include <oxenc/endian.h>
 #include <oxenc/hex.h>
 #include <session/config/groups/keys.h>
 #include <simdutf.h>
@@ -86,6 +87,7 @@ session::array_uc32 proof_hash_internal(
     crypto_generichash_blake2b_update(&state, &version, sizeof(version));
     crypto_generichash_blake2b_update(&state, gen_index_hash.data(), gen_index_hash.size());
     crypto_generichash_blake2b_update(&state, rotating_pubkey.data(), rotating_pubkey.size());
+    oxenc::host_to_little_inplace(expiry_unix_ts_ms);
     crypto_generichash_blake2b_update(
             &state, reinterpret_cast<uint8_t*>(&expiry_unix_ts_ms), sizeof(expiry_unix_ts_ms));
     crypto_generichash_blake2b_final(&state, result.data(), result.size());

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -79,20 +79,17 @@ bool proof_verify_message_internal(
     return result;
 }
 
-struct array_uc32_from_ptr_result {
-    bool success;
-    session::array_uc32 data;
-};
-
-static array_uc32_from_ptr_result array_uc32_from_ptr(const void* ptr, size_t len) {
-    array_uc32_from_ptr_result result = {};
+// Copies an optional 32-byte value out of a possibly-null C pointer. A null pointer yields a
+// zero-filled value (the "not provided" case); a non-null pointer with the wrong length yields
+// nullopt to signal an error.
+static std::optional<session::array_uc32> maybe_uc32_from_ptr(const void* ptr, size_t len) {
+    session::array_uc32 out = {};
     if (ptr) {
-        if (len != result.data.max_size())
-            return result;
-        std::memcpy(result.data.data(), ptr, len);
+        if (len != out.max_size())
+            return std::nullopt;
+        std::memcpy(out.data(), ptr, len);
     }
-    result.success = true;
-    return result;
+    return out;
 }
 
 static session_protocol_envelope envelope_from_cpp(const session::Envelope& cpp) {
@@ -128,9 +125,9 @@ static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedP
 
 namespace session {
 
-static_assert(sizeof(((ProProof*)0)->revocation_tag) == 32);
-static_assert(sizeof(((ProProof*)0)->rotating_pubkey) == crypto_sign_ed25519_PUBLICKEYBYTES);
-static_assert(sizeof(((ProProof*)0)->sig) == crypto_sign_ed25519_BYTES);
+static_assert(sizeof(ProProof::revocation_tag) == 32);
+static_assert(sizeof(ProProof::rotating_pubkey) == crypto_sign_ed25519_PUBLICKEYBYTES);
+static_assert(sizeof(ProProof::sig) == crypto_sign_ed25519_BYTES);
 
 bool ProProof::verify_signature(const std::span<const uint8_t>& verify_pubkey) const {
     if (verify_pubkey.size() != crypto_sign_ed25519_PUBLICKEYBYTES)
@@ -208,20 +205,21 @@ bool ProMessageBitset::is_set(SESSION_PROTOCOL_PRO_MESSAGE_FEATURES features) co
 }
 
 session::ProFeaturesForMsg pro_features_for_utf8_or_16(
-        const void* utf, size_t utf_size, bool is_utf8) {
+        const void* text, size_t text_size, bool is_utf8) {
     session::ProFeaturesForMsg result = {};
-    simdutf::result validate = is_utf8 ? simdutf::validate_utf8_with_errors(
-                                                 reinterpret_cast<const char*>(utf), utf_size)
-                                       : simdutf::validate_utf16_with_errors(
-                                                 reinterpret_cast<const char16_t*>(utf), utf_size);
+    simdutf::result validate = is_utf8
+                                     ? simdutf::validate_utf8_with_errors(
+                                               reinterpret_cast<const char*>(text), text_size)
+                                     : simdutf::validate_utf16_with_errors(
+                                               reinterpret_cast<const char16_t*>(text), text_size);
     if (validate.is_ok()) {
         result.status = session::ProFeaturesForMsgStatus::Success;
         result.codepoint_count =
-                is_utf8 ? simdutf::count_utf8(reinterpret_cast<const char*>(utf), utf_size)
-                        : simdutf::count_utf16(reinterpret_cast<const char16_t*>(utf), utf_size);
+                is_utf8 ? simdutf::count_utf8(reinterpret_cast<const char*>(text), text_size)
+                        : simdutf::count_utf16(reinterpret_cast<const char16_t*>(text), text_size);
 
-        if (result.codepoint_count > SESSION_PROTOCOL_PRO_STANDARD_CHARACTER_LIMIT) {
-            if (result.codepoint_count <= SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT) {
+        if (result.codepoint_count > STANDARD_CHARACTER_LIMIT) {
+            if (result.codepoint_count <= PRO_HIGHER_CHARACTER_LIMIT) {
                 result.bitset.set(SESSION_PROTOCOL_PRO_MESSAGE_FEATURES_10K_CHARACTER_LIMIT);
             } else {
                 result.error = "Message exceeds the maximum character limit allowed";
@@ -238,13 +236,13 @@ session::ProFeaturesForMsg pro_features_for_utf8_or_16(
 
 namespace session {
 
-ProFeaturesForMsg pro_features_for_utf8(const char* utf, size_t utf_size) {
-    ProFeaturesForMsg result = pro_features_for_utf8_or_16(utf, utf_size, /*is_utf8*/ true);
+ProFeaturesForMsg pro_features_for_utf8(const char* text, size_t text_size) {
+    ProFeaturesForMsg result = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ true);
     return result;
 }
 
-ProFeaturesForMsg pro_features_for_utf16(const char16_t* utf, size_t utf_size) {
-    ProFeaturesForMsg result = pro_features_for_utf8_or_16(utf, utf_size, /*is_utf8*/ false);
+ProFeaturesForMsg pro_features_for_utf16(const char16_t* text, size_t text_size) {
+    ProFeaturesForMsg result = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ false);
     return result;
 }
 
@@ -326,10 +324,9 @@ std::vector<uint8_t> pad_message(std::span<const uint8_t> payload) {
     // Calculate amount of padding required
     size_t padded_content_size = payload.size() + 1 /*padding byte*/;
     uint8_t const bytes_for_padding =
-            SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING -
-            (padded_content_size % SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING);
+            COMMUNITY_OR_1O1_MSG_PADDING - (padded_content_size % COMMUNITY_OR_1O1_MSG_PADDING);
     padded_content_size += bytes_for_padding;
-    assert(padded_content_size % SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING == 0);
+    assert(padded_content_size % COMMUNITY_OR_1O1_MSG_PADDING == 0);
 
     // Do the padding
     std::vector<uint8_t> result;
@@ -1075,15 +1072,26 @@ DecodedCommunityMessage decode_for_community(
 
 using namespace session;
 
-static_assert((sizeof((session_protocol_pro_proof*)0)->revocation_tag) == 32);
+// Protocol limit/padding constants: C symbols pointing at the single C++ definitions above.
+extern "C" {
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT =
+        STANDARD_CHARACTER_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT =
+        PRO_HIGHER_CHARACTER_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT =
+        STANDARD_PINNED_CONVERSATION_LIMIT;
+LIBSESSION_EXPORT extern const int SESSION_PROTOCOL_COMMUNITY_OR_1O1_MSG_PADDING =
+        COMMUNITY_OR_1O1_MSG_PADDING;
+}
+
+static_assert(sizeof(session_protocol_pro_proof::revocation_tag) == 32);
 static_assert(
-        (sizeof((session_protocol_pro_proof*)0)->rotating_pubkey) ==
-        crypto_sign_ed25519_PUBLICKEYBYTES);
-static_assert((sizeof((session_protocol_pro_proof*)0)->sig) == crypto_sign_ed25519_BYTES);
+        sizeof(session_protocol_pro_proof::rotating_pubkey) == crypto_sign_ed25519_PUBLICKEYBYTES);
+static_assert(sizeof(session_protocol_pro_proof::sig) == crypto_sign_ed25519_BYTES);
 
 static_assert(
         SESSION_PROTOCOL_PRO_PROFILE_FEATURES_COUNT <=
-                sizeof(((session_protocol_pro_profile_bitset*)0)->data) * 8 /*bits per byte*/,
+                sizeof(session_protocol_pro_profile_bitset::data) * 8 /*bits per byte*/,
         "There are more feature flags than is available in the bitset, the bitset needs to be "
         "upgraded into an array of bytes");
 
@@ -1183,8 +1191,8 @@ LIBSESSION_C_API SESSION_PROTOCOL_PRO_STATUS session_protocol_pro_proof_status(
 
 LIBSESSION_C_API
 session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf8(
-        const char* utf, size_t utf_size) {
-    ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(utf, utf_size, /*is_utf8*/ true);
+        const char* text, size_t text_size) {
+    ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ true);
     session_protocol_pro_features_for_msg result = {
             .status = static_cast<SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS>(result_cpp.status),
             .error = {const_cast<char*>(result_cpp.error.data()), result_cpp.error.size()},
@@ -1196,8 +1204,8 @@ session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf8(
 
 LIBSESSION_C_API
 session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf16(
-        const uint16_t* utf, size_t utf_size) {
-    ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(utf, utf_size, /*is_utf8*/ false);
+        const uint16_t* text, size_t text_size) {
+    ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ false);
     session_protocol_pro_features_for_msg result = {
             .status = static_cast<SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS>(result_cpp.status),
             .error = {const_cast<char*>(result_cpp.error.data()), result_cpp.error.size()},
@@ -1393,9 +1401,8 @@ session_protocol_decoded_envelope session_protocol_decode_envelope(
     session_protocol_decoded_envelope result = {};
 
     // Setup the pro backend pubkey
-    array_uc32_from_ptr_result pro_backend_pubkey_cpp =
-            array_uc32_from_ptr(pro_backend_pubkey, pro_backend_pubkey_len);
-    if (!pro_backend_pubkey_cpp.success) {
+    auto pro_backend_pubkey_cpp = maybe_uc32_from_ptr(pro_backend_pubkey, pro_backend_pubkey_len);
+    if (!pro_backend_pubkey_cpp) {
         result.error_len_incl_null_terminator = snprintf_clamped(
                                                         error,
                                                         error_len,
@@ -1422,7 +1429,7 @@ session_protocol_decoded_envelope session_protocol_decode_envelope(
             result_cpp = decode_envelope(
                     keys_cpp,
                     {static_cast<const uint8_t*>(envelope_plaintext), envelope_plaintext_len},
-                    pro_backend_pubkey_cpp.data);
+                    *pro_backend_pubkey_cpp);
             result.success = true;
             break;
         } catch (const std::exception& e) {
@@ -1503,9 +1510,8 @@ session_protocol_decoded_community_message session_protocol_decode_for_community
             reinterpret_cast<const uint8_t*>(content_or_envelope_payload),
             content_or_envelope_payload_len);
     auto unix_ts = as_sys_seconds(ts);
-    array_uc32_from_ptr_result pro_backend_pubkey_cpp =
-            array_uc32_from_ptr(pro_backend_pubkey, pro_backend_pubkey_len);
-    if (!pro_backend_pubkey_cpp.success) {
+    auto pro_backend_pubkey_cpp = maybe_uc32_from_ptr(pro_backend_pubkey, pro_backend_pubkey_len);
+    if (!pro_backend_pubkey_cpp) {
         result.error_len_incl_null_terminator = snprintf_clamped(
                                                         error,
                                                         error_len,
@@ -1518,7 +1524,7 @@ session_protocol_decoded_community_message session_protocol_decode_for_community
 
     try {
         DecodedCommunityMessage decoded = decode_for_community(
-                content_or_envelope_payload_span, unix_ts, pro_backend_pubkey_cpp.data);
+                content_or_envelope_payload_span, unix_ts, *pro_backend_pubkey_cpp);
         result.has_envelope = decoded.envelope.has_value();
         if (result.has_envelope)
             result.envelope = envelope_from_cpp(*decoded.envelope);

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -165,7 +165,7 @@ static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedP
             result.proof.rotating_pubkey.data,
             cpp.proof.rotating_pubkey.data(),
             cpp.proof.rotating_pubkey.max_size());
-    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_unix_ts);
+    result.proof.expiry_ts = session::epoch_seconds(cpp.proof.expiry_at);
     std::memcpy(result.proof.sig.data, cpp.proof.sig.data(), cpp.proof.sig.max_size());
     result.msg_bitset.data = cpp.msg_bitset.data;
     result.profile_bitset.data = cpp.profile_bitset.data;
@@ -199,7 +199,7 @@ bool ProProof::verify_message(std::span<const uint8_t> sig, std::span<const uint
 }
 
 bool ProProof::is_active(sys_seconds unix_ts) const {
-    return unix_ts <= expiry_unix_ts;
+    return unix_ts <= expiry_at;
 }
 
 ProStatus ProProof::status(
@@ -226,7 +226,7 @@ ProStatus ProProof::status(
 
 array_uc32 ProProof::hash() const {
     array_uc32 result =
-            proof_hash_internal(revocation_tag, rotating_pubkey, epoch_seconds(expiry_unix_ts));
+            proof_hash_internal(revocation_tag, rotating_pubkey, epoch_seconds(expiry_at));
     return result;
 }
 
@@ -915,7 +915,7 @@ DecodedEnvelope decode_envelope(
                     proof.rotating_pubkey.data(),
                     proto_proof.rotatingpublickey().data(),
                     proto_proof.rotatingpublickey().size());
-            proof.expiry_unix_ts = as_sys_seconds(proto_proof.expiryunixts());
+            proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
             std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
             // Evaluate the pro status given the extracted components (was it signed, is it expired,
@@ -1075,7 +1075,7 @@ DecodedCommunityMessage decode_for_community(
                 proof.rotating_pubkey.data(),
                 proto_proof.rotatingpublickey().data(),
                 proto_proof.rotatingpublickey().size());
-        proof.expiry_unix_ts = as_sys_seconds(proto_proof.expiryunixts());
+        proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
         std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
         // Evaluate the pro status given the extracted components (was it signed, is it expired,

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -20,31 +20,31 @@
 
 // clang-format off
 const session_protocol_strings SESSION_PROTOCOL_STRINGS = {
-    .build_variant_apk        = string8_literal("APK"),
-    .build_variant_fdroid     = string8_literal("F-Droid Store"),
-    .build_variant_huawei     = string8_literal("Huawei App Gallery"),
-    .build_variant_ipa        = string8_literal("IPA"),
-    .url_donations            = string8_literal("https://getsession.org/donate"),
-    .url_donations_app        = string8_literal("https://getsession.org/donate#app"),
-    .url_download             = string8_literal("https://getsession.org/download"),
-    .url_faq                  = string8_literal("https://getsession.org/faq"),
-    .url_feedback             = string8_literal("https://getsession.org/feedback"),
-    .url_network              = string8_literal("https://docs.getsession.org/session-network"),
-    .url_privacy_policy       = string8_literal("https://getsession.org/privacy-policy"),
-    .url_pro_access_not_found = string8_literal("https://sessionapp.zendesk.com/hc/sections/4416517450649-Support"),
-    .url_pro_faq              = string8_literal("https://getsession.org/pro#faq"),
-    .url_pro_page             = string8_literal("https://getsession.org/pro"),
-    .url_pro_privacy_policy   = string8_literal("https://getsession.org/pro-privacy"),
-    .url_pro_roadmap          = string8_literal("https://getsession.org/pro#roadmap"),
-    .url_pro_support          = string8_literal("https://getsession.org/pro-support"),
-    .url_pro_terms_of_service = string8_literal("https://getsession.org/pro-terms"),
-    .url_pro_upgrade          = string8_literal("https://getsession.org/pro#upgrade"),
-    .url_staking              = string8_literal("https://docs.getsession.org/session-network/staking"),
-    .url_support              = string8_literal("https://getsession.org/support"),
-    .url_survey               = string8_literal("https://getsession.org/survey"),
-    .url_terms_of_service     = string8_literal("https://getsession.org/terms-of-service"),
-    .url_token                = string8_literal("https://token.getsession.org"),
-    .url_translate            = string8_literal("https://getsession.org/translate"),
+    .build_variant_apk        = "APK",
+    .build_variant_fdroid     = "F-Droid Store",
+    .build_variant_huawei     = "Huawei App Gallery",
+    .build_variant_ipa        = "IPA",
+    .url_donations            = "https://getsession.org/donate",
+    .url_donations_app        = "https://getsession.org/donate#app",
+    .url_download             = "https://getsession.org/download",
+    .url_faq                  = "https://getsession.org/faq",
+    .url_feedback             = "https://getsession.org/feedback",
+    .url_network              = "https://docs.getsession.org/session-network",
+    .url_privacy_policy       = "https://getsession.org/privacy-policy",
+    .url_pro_access_not_found = "https://sessionapp.zendesk.com/hc/sections/4416517450649-Support",
+    .url_pro_faq              = "https://getsession.org/pro#faq",
+    .url_pro_page             = "https://getsession.org/pro",
+    .url_pro_privacy_policy   = "https://getsession.org/pro-privacy",
+    .url_pro_roadmap          = "https://getsession.org/pro#roadmap",
+    .url_pro_support          = "https://getsession.org/pro-support",
+    .url_pro_terms_of_service = "https://getsession.org/pro-terms",
+    .url_pro_upgrade          = "https://getsession.org/pro#upgrade",
+    .url_staking              = "https://docs.getsession.org/session-network/staking",
+    .url_support              = "https://getsession.org/support",
+    .url_survey               = "https://getsession.org/survey",
+    .url_terms_of_service     = "https://getsession.org/terms-of-service",
+    .url_token                = "https://token.getsession.org",
+    .url_translate            = "https://getsession.org/translate",
 };
 // clang-format on
 
@@ -1195,7 +1195,7 @@ session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf8(
     ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ true);
     session_protocol_pro_features_for_msg result = {
             .status = static_cast<SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS>(result_cpp.status),
-            .error = {const_cast<char*>(result_cpp.error.data()), result_cpp.error.size()},
+            .error = result_cpp.error.data(),
             .bitset = {result_cpp.bitset.data},
             .codepoint_count = result_cpp.codepoint_count,
     };
@@ -1208,7 +1208,7 @@ session_protocol_pro_features_for_msg session_protocol_pro_features_for_utf16(
     ProFeaturesForMsg result_cpp = pro_features_for_utf8_or_16(text, text_size, /*is_utf8*/ false);
     session_protocol_pro_features_for_msg result = {
             .status = static_cast<SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS>(result_cpp.status),
-            .error = {const_cast<char*>(result_cpp.error.data()), result_cpp.error.size()},
+            .error = result_cpp.error.data(),
             .bitset = {result_cpp.bitset.data},
             .codepoint_count = result_cpp.codepoint_count,
     };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -21,23 +21,6 @@ span_u8 span_u8_copy_or_throw(const void* data, size_t size) {
     return result;
 }
 
-string8 string8_alloc_or_throw(size_t size) {
-    string8 result = {};
-    result.size = size;
-    result.data = static_cast<char*>(malloc(size + 1 /*null-terminator*/));
-    if (!result.data)
-        throw std::runtime_error(
-                fmt::format("Failed to allocate {} bytes for string8, out of memory", size + 1));
-    result.data[result.size] = 0;
-    return result;
-}
-
-string8 string8_copy_or_throw(const void* data, size_t size) {
-    string8 result = string8_alloc_or_throw(size);
-    std::memcpy(result.data, data, result.size);
-    result.data[result.size] = 0;
-    return result;
-}
 };  // namespace session
 
 int snprintf_clamped(char* buffer, size_t size, char const* fmt, ...) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -51,24 +51,3 @@ int snprintf_clamped(char* buffer, size_t size, char const* fmt, ...) {
         result = size - 1;
     return result;
 }
-
-void* arena_alloc(arena_t* arena, size_t bytes) {
-    void* result = nullptr;
-    size_t new_size = arena->size + bytes;
-    if (bytes && new_size <= arena->max) {
-        result = arena->data + arena->size;
-        arena->size = new_size;
-    }
-    return result;
-}
-
-string8 arena_alloc_to_string8(arena_t* arena, void const* data, size_t size) {
-    string8 result = {};
-    result.data = static_cast<char*>(arena_alloc(arena, size + 1));
-    if (result.data) {
-        result.size = size;
-        std::memcpy(result.data, data, size);
-        result.data[result.size] = 0;
-    }
-    return result;
-}

--- a/tests/test_config_convo_info_volatile.cpp
+++ b/tests/test_config_convo_info_volatile.cpp
@@ -623,7 +623,7 @@ TEST_CASE("Conversation pruning", "[config][conversations][pruning]") {
                 c.unread = true;
 
             if (i % 7 == 0) {
-                c.pro_expiry_unix_ts =
+                c.pro_expiry_at =
                         std::chrono::sys_seconds{std::chrono::duration_cast<std::chrono::seconds>(
                                 std::chrono::milliseconds{unix_timestamp(i)})};
 

--- a/tests/test_config_convo_info_volatile.cpp
+++ b/tests/test_config_convo_info_volatile.cpp
@@ -623,8 +623,9 @@ TEST_CASE("Conversation pruning", "[config][conversations][pruning]") {
                 c.unread = true;
 
             if (i % 7 == 0) {
-                c.pro_expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>{
-                        std::chrono::milliseconds{unix_timestamp(i)}};
+                c.pro_expiry_unix_ts =
+                        std::chrono::sys_seconds{std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::milliseconds{unix_timestamp(i)})};
 
                 session::array_uc32 hash{};
                 std::fill(hash.begin(), hash.end(), static_cast<uint8_t>(i % 256));
@@ -834,7 +835,7 @@ TEST_CASE("Conversation pro data", "[config][conversations][pro]") {
     c.last_read = std::chrono::duration_cast<std::chrono::milliseconds>(
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
-    c.pro_expiry_unix_ts_ms = 10000;
+    c.pro_expiry_ts = 10000;
 
     session::array_uc32 hash{};
     std::fill(hash.begin(), hash.end(), static_cast<uint8_t>(3));
@@ -869,7 +870,7 @@ TEST_CASE("Conversation pro data", "[config][conversations][pro]") {
     CHECK(convo_info_volatile_get_or_construct_1to1(
             conf2, &c2, "051111111111111111111111111111111111111111111111111111111111111111"));
 
-    CHECK(c2.pro_expiry_unix_ts_ms == c.pro_expiry_unix_ts_ms);
+    CHECK(c2.pro_expiry_ts == c.pro_expiry_ts);
     CHECK(c.has_pro_gen_index_hash);
     CHECK(c2.has_pro_gen_index_hash);
     CHECK(oxenc::to_hex(c2.pro_gen_index_hash.data) == oxenc::to_hex(c.pro_gen_index_hash.data));

--- a/tests/test_config_convo_info_volatile.cpp
+++ b/tests/test_config_convo_info_volatile.cpp
@@ -629,7 +629,7 @@ TEST_CASE("Conversation pruning", "[config][conversations][pruning]") {
 
                 session::array_uc32 hash{};
                 std::fill(hash.begin(), hash.end(), static_cast<uint8_t>(i % 256));
-                c.pro_gen_index_hash = hash;
+                c.pro_revocation_tag = hash;
             }
 
             convos.set(c);
@@ -839,8 +839,8 @@ TEST_CASE("Conversation pro data", "[config][conversations][pro]") {
 
     session::array_uc32 hash{};
     std::fill(hash.begin(), hash.end(), static_cast<uint8_t>(3));
-    std::memcpy(c.pro_gen_index_hash.data, hash.data(), hash.size());
-    c.has_pro_gen_index_hash = true;
+    std::memcpy(c.pro_revocation_tag.data, hash.data(), hash.size());
+    c.has_pro_revocation_tag = true;
     convo_info_volatile_set_1to1(conf, &c);
 
     // Fake push:
@@ -871,7 +871,7 @@ TEST_CASE("Conversation pro data", "[config][conversations][pro]") {
             conf2, &c2, "051111111111111111111111111111111111111111111111111111111111111111"));
 
     CHECK(c2.pro_expiry_ts == c.pro_expiry_ts);
-    CHECK(c.has_pro_gen_index_hash);
-    CHECK(c2.has_pro_gen_index_hash);
-    CHECK(oxenc::to_hex(c2.pro_gen_index_hash.data) == oxenc::to_hex(c.pro_gen_index_hash.data));
+    CHECK(c.has_pro_revocation_tag);
+    CHECK(c2.has_pro_revocation_tag);
+    CHECK(oxenc::to_hex(c2.pro_revocation_tag.data) == oxenc::to_hex(c.pro_revocation_tag.data));
 }

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -40,31 +40,27 @@ TEST_CASE("Pro", "[config][pro]") {
         std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
     }
 
-    // Generate and write the hashes that are signed by the faux pro backend into the proof
+    // Sign the proof with the faux pro backend key (Ed25519 over the message directly). The C and
+    // C++ proof representations above mirror each other, so a single message signs both.
     {
-        // Generate the hashes
         static_assert(crypto_sign_ed25519_BYTES == pro_cpp.proof.sig.max_size());
-        std::array<uint8_t, 32> hash_to_sign_cpp = pro_cpp.proof.hash();
-        bytes32 hash_to_sign = session_protocol_pro_proof_hash(&pro.proof);
+        auto msg_to_sign = pro_cpp.proof.signed_message();
 
-        static_assert(hash_to_sign_cpp.size() == sizeof(hash_to_sign));
-        CHECK(std::memcmp(hash_to_sign_cpp.data(), hash_to_sign.data, hash_to_sign_cpp.size()) ==
-              0);
-
-        // Write the signature into the proof
+        // Write the signature into the C++ proof
         int sig_result = crypto_sign_ed25519_detached(
                 pro_cpp.proof.sig.data(),
                 nullptr,
-                hash_to_sign_cpp.data(),
-                hash_to_sign_cpp.size(),
+                msg_to_sign.data(),
+                msg_to_sign.size(),
                 signing_sk.data());
         CHECK(sig_result == 0);
 
+        // ... and into the C proof
         sig_result = crypto_sign_ed25519_detached(
                 pro.proof.sig.data,
                 nullptr,
-                hash_to_sign.data,
-                sizeof(hash_to_sign.data),
+                msg_to_sign.data(),
+                msg_to_sign.size(),
                 signing_sk.data());
         CHECK(sig_result == 0);
     }

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Pro", "[config][pro]") {
         pro_cpp.rotating_privkey = rotating_sk;
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
-        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(1s);
+        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
         constexpr auto gen_index_hash =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
         static_assert(pro_cpp.proof.gen_index_hash.max_size() == gen_index_hash.size());
@@ -36,7 +36,7 @@ TEST_CASE("Pro", "[config][pro]") {
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
-        pro.proof.expiry_unix_ts_ms = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
+        pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
         std::memcpy(pro.proof.gen_index_hash.data, gen_index_hash.data(), gen_index_hash.size());
     }
 
@@ -72,11 +72,10 @@ TEST_CASE("Pro", "[config][pro]") {
     // Verify expiry
     {
         CHECK(pro_cpp.proof.is_active(pro_cpp.proof.expiry_unix_ts));
-        CHECK_FALSE(pro_cpp.proof.is_active(pro_cpp.proof.expiry_unix_ts + 1ms));
+        CHECK_FALSE(pro_cpp.proof.is_active(pro_cpp.proof.expiry_unix_ts + 1s));
 
-        CHECK(session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_unix_ts_ms));
-        CHECK_FALSE(
-                session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_unix_ts_ms + 1));
+        CHECK(session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_ts));
+        CHECK_FALSE(session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_ts + 1));
     }
 
     // Verify it can verify messages signed with the rotating public key

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -26,18 +26,18 @@ TEST_CASE("Pro", "[config][pro]") {
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
         pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
-        constexpr auto gen_index_hash =
+        constexpr auto revocation_tag =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
-        static_assert(pro_cpp.proof.gen_index_hash.max_size() == gen_index_hash.size());
+        static_assert(pro_cpp.proof.revocation_tag.max_size() == revocation_tag.size());
         std::memcpy(
-                pro_cpp.proof.gen_index_hash.data(), gen_index_hash.data(), gen_index_hash.size());
+                pro_cpp.proof.revocation_tag.data(), revocation_tag.data(), revocation_tag.size());
 
         // C
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
         pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
-        std::memcpy(pro.proof.gen_index_hash.data, gen_index_hash.data(), gen_index_hash.size());
+        std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
     }
 
     // Generate and write the hashes that are signed by the faux pro backend into the proof
@@ -106,7 +106,7 @@ TEST_CASE("Pro", "[config][pro]") {
             {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), crypto_sign_ed25519_SEEDBYTES)},
             {"p", session::config::dict{
                 /*version*/         {"@", proof.version},
-                /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},
+                /*revocation_tag*/  {"g", std::string(reinterpret_cast<const char *>(proof.revocation_tag.data()), proof.revocation_tag.size())},
                 /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
                 /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
                 /*signature*/       {"s", std::string{reinterpret_cast<const char *>(proof.sig.data()), proof.sig.size()}},
@@ -118,7 +118,7 @@ TEST_CASE("Pro", "[config][pro]") {
         CHECK(loaded_pro.load(good_dict));
         CHECK(loaded_pro.rotating_privkey == pro_cpp.rotating_privkey);
         CHECK(loaded_pro.proof.version == pro_cpp.proof.version);
-        CHECK(loaded_pro.proof.gen_index_hash == pro_cpp.proof.gen_index_hash);
+        CHECK(loaded_pro.proof.revocation_tag == pro_cpp.proof.revocation_tag);
         CHECK(loaded_pro.proof.rotating_pubkey == pro_cpp.proof.rotating_pubkey);
         CHECK(loaded_pro.proof.expiry_unix_ts == pro_cpp.proof.expiry_unix_ts);
         CHECK(loaded_pro.proof.sig == pro_cpp.proof.sig);
@@ -136,7 +136,7 @@ TEST_CASE("Pro", "[config][pro]") {
             {"r", std::string(reinterpret_cast<const char *>(rotating_sk.data()), crypto_sign_ed25519_SEEDBYTES)},
             {"p", session::config::dict{
                 /*version*/         {"@", proof.version},
-                /*gen_index_hash*/  {"g", std::string(reinterpret_cast<const char *>(proof.gen_index_hash.data()), proof.gen_index_hash.size())},
+                /*revocation_tag*/  {"g", std::string(reinterpret_cast<const char *>(proof.revocation_tag.data()), proof.revocation_tag.size())},
                 /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
                 /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
                 /*signature*/       {"s", std::string{reinterpret_cast<const char *>(broken_sig.data()), broken_sig.size()}},

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Pro", "[config][pro]") {
         pro_cpp.rotating_privkey = rotating_sk;
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
-        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
+        pro_cpp.proof.expiry_at = std::chrono::sys_seconds(1s);
         constexpr auto revocation_tag =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
         static_assert(pro_cpp.proof.revocation_tag.max_size() == revocation_tag.size());
@@ -36,7 +36,7 @@ TEST_CASE("Pro", "[config][pro]") {
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
-        pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
+        pro.proof.expiry_ts = pro_cpp.proof.expiry_at.time_since_epoch().count();
         std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
     }
 
@@ -71,8 +71,8 @@ TEST_CASE("Pro", "[config][pro]") {
 
     // Verify expiry
     {
-        CHECK(pro_cpp.proof.is_active(pro_cpp.proof.expiry_unix_ts));
-        CHECK_FALSE(pro_cpp.proof.is_active(pro_cpp.proof.expiry_unix_ts + 1s));
+        CHECK(pro_cpp.proof.is_active(pro_cpp.proof.expiry_at));
+        CHECK_FALSE(pro_cpp.proof.is_active(pro_cpp.proof.expiry_at + 1s));
 
         CHECK(session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_ts));
         CHECK_FALSE(session_protocol_pro_proof_is_active(&pro.proof, pro.proof.expiry_ts + 1));
@@ -108,7 +108,7 @@ TEST_CASE("Pro", "[config][pro]") {
                 /*version*/         {"@", proof.version},
                 /*revocation_tag*/  {"g", std::string(reinterpret_cast<const char *>(proof.revocation_tag.data()), proof.revocation_tag.size())},
                 /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
-                /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
+                /*expiry unix ts*/  {"e", proof.expiry_at.time_since_epoch().count()},
                 /*signature*/       {"s", std::string{reinterpret_cast<const char *>(proof.sig.data()), proof.sig.size()}},
             }}
         };
@@ -120,7 +120,7 @@ TEST_CASE("Pro", "[config][pro]") {
         CHECK(loaded_pro.proof.version == pro_cpp.proof.version);
         CHECK(loaded_pro.proof.revocation_tag == pro_cpp.proof.revocation_tag);
         CHECK(loaded_pro.proof.rotating_pubkey == pro_cpp.proof.rotating_pubkey);
-        CHECK(loaded_pro.proof.expiry_unix_ts == pro_cpp.proof.expiry_unix_ts);
+        CHECK(loaded_pro.proof.expiry_at == pro_cpp.proof.expiry_at);
         CHECK(loaded_pro.proof.sig == pro_cpp.proof.sig);
         CHECK(loaded_pro.proof.verify_signature(signing_pk));
     }
@@ -138,7 +138,7 @@ TEST_CASE("Pro", "[config][pro]") {
                 /*version*/         {"@", proof.version},
                 /*revocation_tag*/  {"g", std::string(reinterpret_cast<const char *>(proof.revocation_tag.data()), proof.revocation_tag.size())},
                 /*rotating pubkey*/ {"r", std::string(reinterpret_cast<const char *>(proof.rotating_pubkey.data()), proof.rotating_pubkey.size())},
-                /*expiry unix ts*/  {"e", proof.expiry_unix_ts.time_since_epoch().count()},
+                /*expiry unix ts*/  {"e", proof.expiry_at.time_since_epoch().count()},
                 /*signature*/       {"s", std::string{reinterpret_cast<const char *>(broken_sig.data()), broken_sig.size()}},
             }}
         };

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -618,7 +618,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         pro_cpp.rotating_privkey = rotating_sk;
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
-        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(1s);
+        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
         constexpr auto gen_index_hash =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
         static_assert(pro_cpp.proof.gen_index_hash.max_size() == gen_index_hash.size());
@@ -629,7 +629,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
-        pro.proof.expiry_unix_ts_ms = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
+        pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
         std::memcpy(pro.proof.gen_index_hash.data, gen_index_hash.data(), gen_index_hash.size());
     }
 
@@ -648,8 +648,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     profile.remove_pro_config();
     CHECK_FALSE(profile.get_pro_config().has_value());
 
-    auto access_expiry_ms =
-            std::chrono::sys_time<std::chrono::milliseconds>{std::chrono::milliseconds{500}};
-    profile.set_pro_access_expiry(access_expiry_ms);
-    CHECK(profile.get_pro_access_expiry() == access_expiry_ms);
+    auto access_expiry = std::chrono::sys_seconds{std::chrono::seconds{500}};
+    profile.set_pro_access_expiry(access_expiry);
+    CHECK(profile.get_pro_access_expiry() == access_expiry);
 }

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -618,7 +618,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         pro_cpp.rotating_privkey = rotating_sk;
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
-        pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
+        pro_cpp.proof.expiry_at = std::chrono::sys_seconds(1s);
         constexpr auto revocation_tag =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
         static_assert(pro_cpp.proof.revocation_tag.max_size() == revocation_tag.size());
@@ -629,7 +629,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
-        pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
+        pro.proof.expiry_ts = pro_cpp.proof.expiry_at.time_since_epoch().count();
         std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
     }
 

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -619,18 +619,18 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         pro_cpp.proof.version = 2;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
         pro_cpp.proof.expiry_unix_ts = std::chrono::sys_seconds(1s);
-        constexpr auto gen_index_hash =
+        constexpr auto revocation_tag =
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_u;
-        static_assert(pro_cpp.proof.gen_index_hash.max_size() == gen_index_hash.size());
+        static_assert(pro_cpp.proof.revocation_tag.max_size() == revocation_tag.size());
         std::memcpy(
-                pro_cpp.proof.gen_index_hash.data(), gen_index_hash.data(), gen_index_hash.size());
+                pro_cpp.proof.revocation_tag.data(), revocation_tag.data(), revocation_tag.size());
 
         // C
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
         pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
         pro.proof.expiry_ts = pro_cpp.proof.expiry_unix_ts.time_since_epoch().count();
-        std::memcpy(pro.proof.gen_index_hash.data, gen_index_hash.data(), gen_index_hash.size());
+        std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
     }
 
     UserProfileTester::set_profile_updated(profile, std::chrono::sys_seconds{123s});

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -27,7 +27,7 @@ static bool string8_equals(string8 s8, std::string_view str) {
             "proof.rotating_pubkey: %s\n",
             oxenc::to_hex(proof.rotating_pubkey.data, std::end(proof.rotating_pubkey.data))
                     .c_str());
-    fprintf(stderr, "proof.expiry_unix_ts_ms: %" PRIu64 "\n", proof.expiry_unix_ts_ms);
+    fprintf(stderr, "proof.expiry_ts: %" PRId64 "\n", proof.expiry_ts);
     fprintf(stderr,
             "proof.sig: %s\n",
             oxenc::to_hex(proof.sig.data, std::end(proof.sig.data)).c_str());
@@ -39,16 +39,14 @@ static bool string8_equals(string8 s8, std::string_view str) {
     fprintf(stderr, "item.plan: %d\n", item.plan);
     fprintf(stderr, "item.payment_provider: %d\n", item.payment_provider);
     fprintf(stderr, "item.auto_renewing: %d\n", item.auto_renewing);
-    fprintf(stderr, "item.unredeemed_unix_ts_ms: %" PRIu64 "zu\n", item.unredeemed_unix_ts_ms);
-    fprintf(stderr, "item.redeemed_unix_ts_ms: %" PRIu64 "zu\n", item.redeemed_unix_ts_ms);
-    fprintf(stderr, "item.expiry_unix_ts_ms: %" PRIu64 "\n", item.expiry_unix_ts_ms);
+    fprintf(stderr, "item.unredeemed_ts: %" PRId64 "zu\n", item.unredeemed_ts);
+    fprintf(stderr, "item.redeemed_ts: %" PRId64 "zu\n", item.redeemed_ts);
+    fprintf(stderr, "item.expiry_ts: %" PRId64 "\n", item.expiry_ts);
+    fprintf(stderr, "item.grace_period_duration: %" PRId64 "zu\n", item.grace_period_duration);
     fprintf(stderr,
-            "item.grace_period_duration_ms: %" PRIu64 "zu\n",
-            item.grace_period_duration_ms);
-    fprintf(stderr,
-            "item.platform_refund_expiry_unix_ts_ms: %" PRIu64 "zu\n",
-            item.platform_refund_expiry_unix_ts_ms);
-    fprintf(stderr, "item.revoked_unix_ts_ms: %" PRIu64 "zu\n", item.revoked_unix_ts_ms);
+            "item.platform_refund_expiry_ts: %" PRId64 "zu\n",
+            item.platform_refund_expiry_ts);
+    fprintf(stderr, "item.revoked_ts: %" PRId64 "zu\n", item.revoked_ts);
     fprintf(stderr,
             "item.google_payment_token: %.*s\n",
             (int)item.google_payment_token_count,
@@ -70,7 +68,7 @@ static bool string8_equals(string8 s8, std::string_view str) {
 
 [[maybe_unused]] static void dump_pro_revocation(
         const session_pro_backend_pro_revocation_item& item) {
-    fprintf(stderr, "item.expiry_unix_ts: %" PRIu64 "zu\n", item.expiry_unix_ts_ms);
+    fprintf(stderr, "item.expiry_unix_ts: %" PRId64 "zu\n", item.expiry_ts);
     fprintf(stderr,
             "item.gen_index_hash: %s\n",
             oxenc::to_hex(item.gen_index_hash.data, std::end(item.gen_index_hash.data)).c_str());
@@ -107,7 +105,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
         std::memcpy(
                 payment_tx.order_id, fake_google_order_id_hex.data(), payment_tx.order_id_count);
 
-        uint64_t unix_ts_ms = 1698765432ULL * 1000;  // Arbitrary timestamp
+        int64_t unix_ts = 1698765432;  // Arbitrary timestamp (unix epoch seconds)
 
         SECTION("session_pro_backend_add_pro_payment_request_build_sigs") {
             // Valid inputs
@@ -175,7 +173,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
                     sizeof(rotating_privkey.data),
-                    unix_ts_ms);
+                    unix_ts);
             REQUIRE(result.success);
             REQUIRE(result.error_count == 0);
 
@@ -184,8 +182,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     0,
                     master_privkey.data,
                     rotating_privkey.data,
-                    std::chrono::sys_time<std::chrono::milliseconds>(
-                            std::chrono::milliseconds{unix_ts_ms}));
+                    session::as_sys_seconds(unix_ts));
             REQUIRE(std::memcmp(
                             result.master_sig.data,
                             cpp_sigs.master_sig.data(),
@@ -202,7 +199,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
                     sizeof(rotating_privkey.data) - 1,
-                    unix_ts_ms);
+                    unix_ts);
             REQUIRE(!result.success);
             REQUIRE(result.error_count > 0);
         }
@@ -297,7 +294,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             request.version = 0;
             request.master_pkey = master_pubkey;
             request.rotating_pkey = rotating_pubkey;
-            request.unix_ts_ms = unix_ts_ms;
+            request.ts = unix_ts;
 
             session_pro_backend_master_rotating_signatures sigs =
                     session_pro_backend_generate_pro_proof_request_build_sigs(
@@ -306,7 +303,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
                             sizeof(rotating_privkey.data),
-                            request.unix_ts_ms);
+                            request.ts);
 
             request.master_sig = sigs.master_sig;
             request.rotating_sig = sigs.rotating_sig;
@@ -327,8 +324,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         cpp.rotating_pkey.data(),
                         rotating_pubkey.data,
                         sizeof(rotating_pubkey.data));
-                cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                        std::chrono::milliseconds{unix_ts_ms});
+                cpp.unix_ts = session::as_sys_seconds(unix_ts);
                 std::memcpy(
                         cpp.master_sig.data(), sigs.master_sig.data, sizeof(sigs.master_sig.data));
                 std::memcpy(
@@ -345,7 +341,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        request.unix_ts_ms);
+                        request.ts);
                 REQUIRE(one_shot.success);
                 REQUIRE(one_shot.json.size == result.json.size);
                 INFO("One shot: " << one_shot.json.data << "\n\nJSON: " << result.json.data);
@@ -399,7 +395,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             session_pro_backend_get_pro_details_request request = {};
             request.version = 0;
             request.master_pkey = master_pubkey;
-            request.unix_ts_ms = unix_ts_ms;
+            request.ts = unix_ts;
             request.count = 10'000;
 
             session_pro_backend_signature sig =
@@ -407,7 +403,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                             request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
-                            request.unix_ts_ms,
+                            request.ts,
                             request.count);
 
             request.master_sig = sig.sig;
@@ -425,8 +421,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 cpp.version = 0;
                 std::memcpy(cpp.master_pkey.data(), master_pubkey.data, sizeof(master_pubkey.data));
                 std::memcpy(cpp.master_sig.data(), sig.sig.data, sizeof(sig.sig.data));
-                cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>{
-                        std::chrono::milliseconds{unix_ts_ms}};
+                cpp.unix_ts = session::as_sys_seconds(unix_ts);
                 cpp.count = request.count;
                 std::string cpp_json = cpp.to_json();
                 REQUIRE(string8_equals(result.json, cpp_json));
@@ -436,7 +431,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         request.version,
                         master_privkey.data,
                         sizeof(master_privkey.data),
-                        request.unix_ts_ms,
+                        request.ts,
                         request.count);
                 REQUIRE(one_shot.success);
                 REQUIRE(one_shot.json.size == result.json.size);
@@ -463,7 +458,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
             j["result"] = {
                     {"version", 0},
-                    {"expiry_unix_ts_ms", unix_ts_ms},
+                    {"expiry_ts", unix_ts},
                     {"gen_index_hash", oxenc::to_hex(fake_gen_index_hash)},
                     {"rotating_pkey",
                      oxenc::to_hex(rotating_pubkey.data, std::end(rotating_pubkey.data))},
@@ -485,7 +480,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
-                REQUIRE(result.proof.expiry_unix_ts_ms == unix_ts_ms);
+                REQUIRE(result.proof.expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
                                 result.proof.gen_index_hash.data,
                                 fake_gen_index_hash.data(),
@@ -514,7 +509,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                 result.proof.rotating_pubkey.data,
                                 result_cpp.proof.rotating_pubkey.data(),
                                 result_cpp.proof.rotating_pubkey.size()) == 0);
-                REQUIRE(result.proof.expiry_unix_ts_ms ==
+                REQUIRE(result.proof.expiry_ts ==
                         result_cpp.proof.expiry_unix_ts.time_since_epoch().count());
                 REQUIRE(std::memcmp(
                                 result.proof.sig.data,
@@ -565,7 +560,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             randombytes_buf(fake_gen_index_hash.data(), fake_gen_index_hash.size());
 
             auto obj = nlohmann::json::object();
-            obj["expiry_unix_ts_ms"] = unix_ts_ms;
+            obj["expiry_ts"] = unix_ts;
             obj["gen_index_hash"] = oxenc::to_hex(fake_gen_index_hash);
             j["result"]["items"].push_back(obj);
 
@@ -585,7 +580,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.ticket == 123);
                 REQUIRE(result.items_count == 1);
                 REQUIRE(result.items != nullptr);
-                REQUIRE(result.items[0].expiry_unix_ts_ms == unix_ts_ms);
+                REQUIRE(result.items[0].expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
                                 result.items[0].gen_index_hash.data,
                                 fake_gen_index_hash.data(),
@@ -628,9 +623,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     {"error_report",
                      SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR},
                     {"auto_renewing", true},
-                    {"expiry_unix_ts_ms", unix_ts_ms + 2},
-                    {"grace_period_duration_ms", 1000},
-                    {"refund_requested_unix_ts_ms", unix_ts_ms + 3602},
+                    {"expiry_ts", unix_ts + 2},
+                    {"grace_period_duration", 1000},
+                    {"refund_requested_ts", unix_ts + 3602},
                     {"payments_total", 3},
                     {"items",
                      nlohmann::json::array(
@@ -639,13 +634,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                {"payment_provider",
                                 SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE},
                                {"auto_renewing", false},
-                               {"unredeemed_unix_ts_ms", unix_ts_ms - 3600},
-                               {"redeemed_unix_ts_ms", unix_ts_ms - 3600},
-                               {"expiry_unix_ts_ms", unix_ts_ms},
-                               {"grace_period_duration_ms", 1001},
-                               {"platform_refund_expiry_unix_ts_ms", unix_ts_ms + 1},
-                               {"revoked_unix_ts_ms", unix_ts_ms + 3600},
-                               {"refund_requested_unix_ts_ms", unix_ts_ms + 3601},
+                               {"unredeemed_ts", unix_ts - 3600},
+                               {"redeemed_ts", unix_ts - 3600},
+                               {"expiry_ts", unix_ts},
+                               {"grace_period_duration", 1001},
+                               {"platform_refund_expiry_ts", unix_ts + 1},
+                               {"revoked_ts", unix_ts + 3600},
+                               {"refund_requested_ts", unix_ts + 3601},
                                {"google_payment_token",
                                 std::string(payment_tx.payment_id, payment_tx.payment_id_count)},
                                {"google_order_id",
@@ -669,22 +664,22 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR);
                 REQUIRE(result.items_count == 1);
                 REQUIRE(result.auto_renewing == true);
-                REQUIRE(result.grace_period_duration_ms == 1000);
-                REQUIRE(result.expiry_unix_ts_ms == unix_ts_ms + 2);
-                REQUIRE(result.refund_requested_unix_ts_ms == unix_ts_ms + 3602);
+                REQUIRE(result.grace_period_duration == 1000);
+                REQUIRE(result.expiry_ts == unix_ts + 2);
+                REQUIRE(result.refund_requested_ts == unix_ts + 3602);
                 REQUIRE(result.payments_total == 3);
                 REQUIRE(result.items != nullptr);
                 REQUIRE(result.items[0].status == SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED);
                 REQUIRE(result.items[0].plan == SESSION_PRO_BACKEND_PLAN_ONE_MONTH);
                 REQUIRE(result.items[0].payment_provider ==
                         SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE);
-                REQUIRE(result.items[0].unredeemed_unix_ts_ms == unix_ts_ms - 3600);
-                REQUIRE(result.items[0].redeemed_unix_ts_ms == unix_ts_ms - 3600);
-                REQUIRE(result.items[0].expiry_unix_ts_ms == unix_ts_ms);
-                REQUIRE(result.items[0].grace_period_duration_ms == 1001);
-                REQUIRE(result.items[0].platform_refund_expiry_unix_ts_ms == unix_ts_ms + 1);
-                REQUIRE(result.items[0].revoked_unix_ts_ms == unix_ts_ms + 3600);
-                REQUIRE(result.items[0].refund_requested_unix_ts_ms == unix_ts_ms + 3601);
+                REQUIRE(result.items[0].unredeemed_ts == unix_ts - 3600);
+                REQUIRE(result.items[0].redeemed_ts == unix_ts - 3600);
+                REQUIRE(result.items[0].expiry_ts == unix_ts);
+                REQUIRE(result.items[0].grace_period_duration == 1001);
+                REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
+                REQUIRE(result.items[0].revoked_ts == unix_ts + 3600);
+                REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
                 REQUIRE(result.items[0].google_payment_token_count == payment_tx.payment_id_count);
                 REQUIRE(std::memcmp(
                                 result.items[0].google_payment_token,
@@ -777,16 +772,16 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             session_pro_backend_set_payment_refund_requested_request request = {};
             request.version = 0;
             request.master_pkey = master_pubkey;
-            request.unix_ts_ms = unix_ts_ms;
-            request.refund_requested_unix_ts_ms = unix_ts_ms + 1;
+            request.ts = unix_ts;
+            request.refund_requested_ts = unix_ts + 1;
 
             session_pro_backend_signature sig =
                     session_pro_backend_set_payment_refund_requested_request_build_sigs(
                             request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
-                            request.unix_ts_ms,
-                            request.refund_requested_unix_ts_ms,
+                            request.ts,
+                            request.refund_requested_ts,
                             payment_tx.provider,
                             reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
                             payment_tx.payment_id_count,
@@ -811,10 +806,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         cpp.master_pkey.data(),
                         request.master_pkey.data,
                         sizeof(request.master_pkey.data));
-                cpp.unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                        std::chrono::milliseconds{unix_ts_ms});
-                cpp.refund_requested_unix_ts = std::chrono::sys_time<std::chrono::milliseconds>(
-                        std::chrono::milliseconds{request.refund_requested_unix_ts_ms});
+                cpp.unix_ts = session::as_sys_seconds(unix_ts);
+                cpp.refund_requested_unix_ts = session::as_sys_seconds(request.refund_requested_ts);
                 std::memcpy(
                         cpp.master_sig.data(),
                         request.master_sig.data,
@@ -1031,7 +1024,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
     // Authorise new key
     {
-        uint64_t now_unix_ts_ms = time(nullptr) * 1000;
+        int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
         // Build request
         session_pro_backend_master_rotating_signatures pro_sigs =
                 session_pro_backend_generate_pro_proof_request_build_sigs(
@@ -1040,13 +1033,13 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        now_unix_ts_ms);
+                        now_unix_ts);
 
         session_pro_backend_generate_pro_proof_request request = {};
         request.version = 0;
         request.master_pkey = master_pubkey;
         request.rotating_pkey = rotating_pubkey;
-        request.unix_ts_ms = now_unix_ts_ms;
+        request.ts = now_unix_ts;
         request.master_sig = pro_sigs.master_sig;
         request.rotating_sig = pro_sigs.rotating_sig;
 
@@ -1097,14 +1090,14 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         session_pro_backend_get_pro_details_request request = {};
         request.version = 0;
         request.master_pkey = master_pubkey;
-        request.unix_ts_ms = time(nullptr) * 1000;
+        request.ts = session::epoch_seconds(session::sysclock_now_s());
         request.count = 10'000;
 
         session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
                 request.version,
                 master_privkey.data,
                 sizeof(master_privkey.data),
-                request.unix_ts_ms,
+                request.ts,
                 request.count);
         REQUIRE(sig.success);
         request.master_sig = sig.sig;
@@ -1146,13 +1139,13 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         session_pro_backend_get_pro_details_request request = {};
         request.version = 0;
         request.master_pkey = master_pubkey;
-        request.unix_ts_ms = time(nullptr) * 1000;
+        request.ts = session::epoch_seconds(session::sysclock_now_s());
 
         session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
                 request.version,
                 master_privkey.data,
                 sizeof(master_privkey.data),
-                request.unix_ts_ms,
+                request.ts,
                 request.count);
         REQUIRE(sig.success);
         request.master_sig = sig.sig;
@@ -1305,14 +1298,14 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     // Set payment refund requested
     {
         // Build request
-        uint64_t now_unix_ts_ms = time(nullptr) * 1000;
+        int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
         session_pro_backend_to_json request_json =
                 session_pro_backend_set_payment_refund_requested_request_build_to_json(
                         /*version*/ 0,
                         master_privkey.data,
                         sizeof(master_privkey.data),
-                        /*unix_ts_ms*/ now_unix_ts_ms,
-                        /*refund_requested_unix_ts_ms*/ now_unix_ts_ms,
+                        /*ts*/ now_unix_ts,
+                        /*refund_requested_ts*/ now_unix_ts,
                         another_payment_tx.provider,
                         reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
                         another_payment_tx.payment_id_count,

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -131,7 +131,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.error_count > 0);
         }
 
-        SECTION("session_pro_backend_add_pro_payment_request_to_json") {
+        SECTION("session_pro_backend_add_pro_payment_request_build") {
             session_pro_backend_add_pro_payment_request request = {};
             request.master_pkey = master_pubkey;
             request.rotating_pkey = rotating_pubkey;
@@ -151,12 +151,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             request.rotating_sig = sigs.rotating_sig;
 
             // Valid request
-            auto result = session_pro_backend_add_pro_payment_request_to_json(&request);
+            auto result = session_pro_backend_add_pro_payment_request_build(&request);
             {
-                scope_exit result_free{[&]() { session_pro_backend_to_json_free(&result); }};
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.json.data != nullptr);
-                REQUIRE(result.json.size > 0);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
                 // Verify JSON + route match the C++ free-function implementation
                 auto cpp = add_payment_request(
@@ -167,21 +167,25 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                 reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
                                 payment_tx.payment_id_count));
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
-                REQUIRE(string8_equals(result.json, cpp.body));
+                REQUIRE(cpp.content_type == "application/json");
+                REQUIRE(string8_equals(result.data, cpp.data));
+                // The C request mirror carries the same endpoint + content_type as the C++ side.
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
+                REQUIRE(std::string_view(result.content_type) == cpp.content_type);
             }
 
             // After freeing
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
 
             // Null request
-            result = session_pro_backend_add_pro_payment_request_to_json(nullptr);
+            result = session_pro_backend_add_pro_payment_request_build(nullptr);
             REQUIRE(!result.success);
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
         }
 
-        SECTION("session_pro_backend_generate_pro_proof_request_to_json") {
+        SECTION("session_pro_backend_generate_pro_proof_request_build") {
             session_pro_backend_generate_pro_proof_request request = {};
             request.master_pkey = master_pubkey;
             request.rotating_pkey = rotating_pubkey;
@@ -199,12 +203,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             request.rotating_sig = sigs.rotating_sig;
 
             // Valid request
-            auto result = session_pro_backend_generate_pro_proof_request_to_json(&request);
+            auto result = session_pro_backend_generate_pro_proof_request_build(&request);
             {
-                scope_exit result_free{[&]() { session_pro_backend_to_json_free(&result); }};
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.json.data != nullptr);
-                REQUIRE(result.json.size > 0);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
                 // Verify JSON + route match the C++ free-function implementation
                 auto cpp = pro_proof_request(
@@ -212,50 +216,50 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         rotating_privkey.data,
                         session::as_sys_seconds(unix_ts));
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
-                REQUIRE(string8_equals(result.json, cpp.body));
+                REQUIRE(string8_equals(result.data, cpp.data));
             }
 
             // After freeing
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
 
             // Null request
-            result = session_pro_backend_generate_pro_proof_request_to_json(nullptr);
+            result = session_pro_backend_generate_pro_proof_request_build(nullptr);
             REQUIRE(!result.success);
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
         }
 
-        SECTION("session_pro_backend_get_pro_revocations_request_to_json") {
+        SECTION("session_pro_backend_get_pro_revocations_request_build") {
             session_pro_backend_get_pro_revocations_request request = {};
             request.ticket = 123;
 
             // Valid request
-            auto result = session_pro_backend_get_pro_revocations_request_to_json(&request);
+            auto result = session_pro_backend_get_pro_revocations_request_build(&request);
             {
-                scope_exit result_free{[&]() { session_pro_backend_to_json_free(&result); }};
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.json.data != nullptr);
-                REQUIRE(result.json.size > 0);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
                 // Verify JSON + route match the C++ free-function implementation
                 auto cpp = revocations_request(request.ticket);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT);
-                REQUIRE(string8_equals(result.json, cpp.body));
+                REQUIRE(string8_equals(result.data, cpp.data));
             }
 
             // After freeing
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
 
             // Null request
-            result = session_pro_backend_get_pro_revocations_request_to_json(nullptr);
+            result = session_pro_backend_get_pro_revocations_request_build(nullptr);
             REQUIRE(!result.success);
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
         }
 
-        SECTION("session_pro_backend_get_pro_details_request_to_json") {
+        SECTION("session_pro_backend_get_pro_details_request_build") {
             session_pro_backend_get_pro_details_request request = {};
             request.master_pkey = master_pubkey;
             request.ts = unix_ts;
@@ -271,29 +275,29 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             request.master_sig = sig.sig;
 
             // Valid request
-            auto result = session_pro_backend_get_pro_details_request_to_json(&request);
+            auto result = session_pro_backend_get_pro_details_request_build(&request);
             {
-                scope_exit result_free{[&]() { session_pro_backend_to_json_free(&result); }};
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.json.data != nullptr);
-                REQUIRE(result.json.size > 0);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
                 // Verify JSON + route match the C++ free-function implementation
                 auto cpp = payment_details_request(
                         master_privkey.data, session::as_sys_seconds(unix_ts), request.count);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT);
-                REQUIRE(string8_equals(result.json, cpp.body));
+                REQUIRE(string8_equals(result.data, cpp.data));
             }
 
             // After freeing
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
 
             // Null request
-            result = session_pro_backend_get_pro_details_request_to_json(nullptr);
+            result = session_pro_backend_get_pro_details_request_build(nullptr);
             REQUIRE(!result.success);
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
         }
 
         SECTION("session_pro_backend_pro_proof_response_parse") {
@@ -592,10 +596,10 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("Memory management edge cases") {
             // Test freeing null/empty structs
-            session_pro_backend_to_json to_json = {};
-            session_pro_backend_to_json_free(&to_json);
-            REQUIRE(to_json.json.data == nullptr);
-            REQUIRE(to_json.json.size == 0);
+            session_pro_backend_request to_json = {};
+            session_pro_backend_request_free(&to_json);
+            REQUIRE(to_json.data.data == nullptr);
+            REQUIRE(to_json.data.size == 0);
 
             session_pro_backend_pro_proof_response proof_response = {};
             session_pro_backend_pro_proof_response_free(&proof_response);
@@ -610,7 +614,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(pay_response.header.internal_arena_buf_ == nullptr);
         }
 
-        SECTION("session_pro_backend_set_payment_refund_requested_request_to_json") {
+        SECTION("session_pro_backend_set_payment_refund_requested_request_build") {
             session_pro_backend_set_payment_refund_requested_request request = {};
             request.master_pkey = master_pubkey;
             request.ts = unix_ts;
@@ -630,13 +634,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(sig.success);
 
             // Valid request
-            auto result =
-                    session_pro_backend_set_payment_refund_requested_request_to_json(&request);
+            auto result = session_pro_backend_set_payment_refund_requested_request_build(&request);
             {
-                scope_exit result_free{[&]() { session_pro_backend_to_json_free(&result); }};
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.json.data != nullptr);
-                REQUIRE(result.json.size > 0);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
                 // Verify JSON + route match the C++ free-function implementation
                 auto cpp = refund_request(
@@ -648,18 +651,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                 reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
                                 payment_tx.payment_id_count));
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT);
-                REQUIRE(string8_equals(result.json, cpp.body));
+                REQUIRE(string8_equals(result.data, cpp.data));
             }
 
             // After freeing
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
 
             // Null request
-            result = session_pro_backend_set_payment_refund_requested_request_to_json(nullptr);
+            result = session_pro_backend_set_payment_refund_requested_request_build(nullptr);
             REQUIRE(!result.success);
-            REQUIRE(result.json.data == nullptr);
-            REQUIRE(result.json.size == 0);
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
         }
 
         SECTION("session_pro_backend_set_payment_refund_requested_response_parse") {
@@ -811,16 +814,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.master_sig = add_pro_sigs.master_sig;
         request.rotating_sig = add_pro_sigs.rotating_sig;
 
-        session_pro_backend_to_json request_json =
-                session_pro_backend_add_pro_payment_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_add_pro_payment_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/add_pro_payment",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_pro_proof_response response =
@@ -866,16 +869,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.master_sig = pro_sigs.master_sig;
         request.rotating_sig = pro_sigs.rotating_sig;
 
-        session_pro_backend_to_json request_json =
-                session_pro_backend_generate_pro_proof_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_generate_pro_proof_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         // Do CURL request
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/generate_pro_proof",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_pro_proof_response response =
@@ -900,7 +903,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         request.rotating_pkey.data,
                         sizeof(request.rotating_pkey.data)) == 0);
 
-        session_pro_backend_to_json_free(&request_json);
+        session_pro_backend_request_free(&request_json);
         session_pro_backend_pro_proof_response_free(&response);
     }
 
@@ -918,15 +921,15 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.master_sig = sig.sig;
 
         // Do CURL request
-        session_pro_backend_to_json request_json =
-                session_pro_backend_get_pro_details_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_get_pro_details_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/get_pro_details",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_get_pro_details_response response =
@@ -960,15 +963,15 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.master_sig = sig.sig;
 
         // Do CURL request
-        session_pro_backend_to_json request_json =
-                session_pro_backend_get_pro_details_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_get_pro_details_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/get_pro_details",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_get_pro_details_response response =
@@ -1030,16 +1033,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.master_sig = add_pro_sigs.master_sig;
         request.rotating_sig = add_pro_sigs.rotating_sig;
 
-        session_pro_backend_to_json request_json =
-                session_pro_backend_add_pro_payment_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_add_pro_payment_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/add_pro_payment",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_pro_proof_response response =
@@ -1062,16 +1065,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Build request
         session_pro_backend_get_pro_revocations_request request = {};
 
-        session_pro_backend_to_json request_json =
-                session_pro_backend_get_pro_revocations_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_get_pro_revocations_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/get_pro_revocations",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_get_pro_revocations_response response =
@@ -1115,16 +1118,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         request.refund_requested_ts = now_unix_ts;
         request.payment_tx = another_payment_tx;
 
-        session_pro_backend_to_json request_json =
-                session_pro_backend_set_payment_refund_requested_request_to_json(&request);
-        scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
+        session_pro_backend_request request_json =
+                session_pro_backend_set_payment_refund_requested_request_build(&request);
+        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
                 g_test_pro_backend_dev_server_url + "/set_payment_refund_requested",
-                std::string_view(request_json.json.data, request_json.json.size));
+                std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
         session_pro_backend_set_payment_refund_requested_response response =

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -185,7 +185,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
                 for (size_t index = 0; index < result.header.errors_count; index++)
                     INFO(result.header.errors[index].data);
-                REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.proof.expiry_ts == unix_ts);
@@ -236,7 +236,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_pro_proof_response_free(&result); }};
-                REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count != 0);
                 REQUIRE(result.header.errors_count > 0);
                 REQUIRE(result.header.errors != nullptr);
             }
@@ -247,7 +247,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_pro_proof_response_parse(nullptr, 0);
-            REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+            REQUIRE(result.header.errors_count != 0);
             REQUIRE(result.header.errors_count == 1);
             REQUIRE(result.header.errors != nullptr);
 
@@ -280,7 +280,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
                 for (size_t index = 0; index < result.header.errors_count; index++)
                     INFO(result.header.errors[index].data);
-                REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.ticket == 123);
@@ -308,7 +308,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
                 for (size_t index = 0; index < result.header.errors_count; index++)
-                    REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                    REQUIRE(result.header.errors_count != 0);
                 REQUIRE(result.header.errors_count > 0);
                 REQUIRE(result.header.errors != nullptr);
             }
@@ -318,7 +318,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_get_pro_revocations_response_parse(nullptr, 0);
-            REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+            REQUIRE(result.header.errors_count != 0);
             REQUIRE(result.header.errors_count == 1);
             REQUIRE(result.header.errors != nullptr);
         }
@@ -364,7 +364,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 for (size_t index = 0; index < result.header.errors_count; index++)
                     INFO(result.header.errors[index].data);
 
-                REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(std::string_view(result.status, result.status_count) == "expired");
@@ -438,7 +438,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
-                REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count != 0);
                 REQUIRE(result.header.errors_count > 0);
                 REQUIRE(result.header.errors != nullptr);
             }
@@ -449,7 +449,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_get_pro_details_response_parse(nullptr, 0);
-            REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+            REQUIRE(result.header.errors_count != 0);
             REQUIRE(result.header.errors_count == 1);
             REQUIRE(result.header.errors != nullptr);
         }
@@ -528,7 +528,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 }};
                 for (size_t index = 0; index < result.header.errors_count; index++)
                     INFO(result.header.errors[index].data);
-                REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.updated);
@@ -546,7 +546,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     session_pro_backend_set_payment_refund_requested_response_free(&result);
                 }};
                 for (size_t index = 0; index < result.header.errors_count; index++)
-                    REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+                    REQUIRE(result.header.errors_count != 0);
                 REQUIRE(result.header.errors_count > 0);
                 REQUIRE(result.header.errors != nullptr);
             }
@@ -556,7 +556,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_set_payment_refund_requested_response_parse(nullptr, 0);
-            REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
+            REQUIRE(result.header.errors_count != 0);
             REQUIRE(result.header.errors_count == 1);
             REQUIRE(result.header.errors != nullptr);
         }
@@ -722,7 +722,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+        REQUIRE(response.header.errors_count == 0);
 
         // Verify response
         session_protocol_pro_proof proof = response.proof;
@@ -764,7 +764,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+        REQUIRE(response.header.errors_count == 0);
         REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count > 0);
     }
@@ -799,7 +799,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+        REQUIRE(response.header.errors_count == 0);
         REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count == 0);
     }
@@ -877,7 +877,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+        REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.ticket == 0);
         REQUIRE(response.items_count == 0);
     }
@@ -919,7 +919,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
+        REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.updated);
     }
 }

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -709,7 +709,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             nlohmann::json j;
             j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
             j["result"]["updated"] = true;
-            j["result"]["version"] = 0;
             std::string json = j.dump();
 
             // Valid JSON
@@ -725,7 +724,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.updated);
-                REQUIRE(result.version == 0);
             }
 
             // After freeing
@@ -1192,7 +1190,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Verify the response
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
-        REQUIRE(response.version == 0);
         REQUIRE(response.updated);
     }
 }

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -42,14 +42,14 @@ static bool string8_equals(string8 s8, std::string_view str) {
             (int)item.payment_provider_count,
             item.payment_provider);
     fprintf(stderr, "item.auto_renewing: %d\n", item.auto_renewing);
-    fprintf(stderr, "item.unredeemed_ts: %" PRId64 "zu\n", item.unredeemed_ts);
+    fprintf(stderr, "item.purchased_ts: %f\n", item.purchased_ts);
     fprintf(stderr, "item.redeemed_ts: %" PRId64 "zu\n", item.redeemed_ts);
     fprintf(stderr, "item.expiry_ts: %" PRId64 "\n", item.expiry_ts);
     fprintf(stderr, "item.grace_period_duration: %" PRId64 "zu\n", item.grace_period_duration);
     fprintf(stderr,
             "item.platform_refund_expiry_ts: %" PRId64 "zu\n",
             item.platform_refund_expiry_ts);
-    fprintf(stderr, "item.revoked_ts: %" PRId64 "zu\n", item.revoked_ts);
+    fprintf(stderr, "item.revoked_ts: %f\n", item.revoked_ts);
     fprintf(stderr, "item.payment_id: %.*s\n", (int)item.payment_id_count, item.payment_id);
 }
 
@@ -521,12 +521,14 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                {"payment_provider",
                                 SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY},
                                {"auto_renewing", false},
-                               {"unredeemed_ts", unix_ts - 3600},
+                               // purchased_ts/revoked_ts are floats on the wire (sub-second
+                               // precision); libsession truncates to whole seconds.
+                               {"purchased_ts", unix_ts - 3600 + 0.5},
                                {"redeemed_ts", unix_ts - 3600},
                                {"expiry_ts", unix_ts},
                                {"grace_period_duration", 1001},
                                {"platform_refund_expiry_ts", unix_ts + 1},
-                               {"revoked_ts", unix_ts + 3600},
+                               {"revoked_ts", unix_ts + 3600 + 0.75},
                                {"refund_requested_ts", unix_ts + 3601},
                                {"payment_id",
                                 std::string(
@@ -561,12 +563,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                 result.items[0].payment_provider,
                                 result.items[0].payment_provider_count) ==
                         SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY);
-                REQUIRE(result.items[0].unredeemed_ts == unix_ts - 3600);
+                // Sub-second precision preserved through sys_ms (0.5s = 500ms) round-trips exactly
+                REQUIRE(result.items[0].purchased_ts == unix_ts - 3600 + 0.5);
                 REQUIRE(result.items[0].redeemed_ts == unix_ts - 3600);
                 REQUIRE(result.items[0].expiry_ts == unix_ts);
                 REQUIRE(result.items[0].grace_period_duration == 1001);
                 REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
-                REQUIRE(result.items[0].revoked_ts == unix_ts + 3600);
+                REQUIRE(result.items[0].revoked_ts == unix_ts + 3600 + 0.75);  // 750ms preserved
                 REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
                 REQUIRE(result.items[0].payment_id_count == payment_tx.payment_id_count);
                 REQUIRE(std::memcmp(

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -353,7 +353,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                 result_cpp.proof.rotating_pubkey.data(),
                                 result_cpp.proof.rotating_pubkey.size()) == 0);
                 REQUIRE(result.proof.expiry_ts ==
-                        result_cpp.proof.expiry_unix_ts.time_since_epoch().count());
+                        result_cpp.proof.expiry_at.time_since_epoch().count());
                 REQUIRE(std::memcmp(
                                 result.proof.sig.data,
                                 result_cpp.proof.sig.data(),

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -14,8 +14,8 @@ using namespace session::pro_backend;
 // NOTE: This is defined in main.cpp because it accepts a value from the CLI
 extern std::string g_test_pro_backend_dev_server_url;
 
-static bool string8_equals(string8 s8, std::string_view str) {
-    return s8.size == str.size() && std::memcmp(s8.data, str.data(), s8.size) == 0;
+static bool span_u8_equals(span_u8 s, std::string_view str) {
+    return std::string_view{reinterpret_cast<const char*>(s.data), s.size} == str;
 }
 TEST_CASE("Pro Backend C API", "[pro_backend]") {
     // Setup: Generate keys and payment token hash
@@ -69,7 +69,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
                 REQUIRE(std::string_view(result.content_type) == cpp.content_type);
                 REQUIRE(cpp.content_type == "application/json");
-                REQUIRE(string8_equals(result.data, cpp.data));
+                REQUIRE(span_u8_equals(result.data, cpp.data));
             }
 
             // After freeing
@@ -108,7 +108,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         session::as_sys_seconds(unix_ts));
                 REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
-                REQUIRE(string8_equals(result.data, cpp.data));
+                REQUIRE(span_u8_equals(result.data, cpp.data));
             }
             REQUIRE(result.data.data == nullptr);
 
@@ -133,7 +133,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 auto cpp = revocations_request(123);
                 REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT);
-                REQUIRE(string8_equals(result.data, cpp.data));
+                REQUIRE(span_u8_equals(result.data, cpp.data));
             }
             REQUIRE(result.data.data == nullptr);
         }
@@ -150,7 +150,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         master_privkey.data, session::as_sys_seconds(unix_ts), 10'000);
                 REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT);
-                REQUIRE(string8_equals(result.data, cpp.data));
+                REQUIRE(span_u8_equals(result.data, cpp.data));
             }
             REQUIRE(result.data.data == nullptr);
 
@@ -485,7 +485,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         std::span<const uint8_t>(payment_id, payment_id_len));
                 REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT);
-                REQUIRE(string8_equals(result.data, cpp.data));
+                REQUIRE(span_u8_equals(result.data, cpp.data));
             }
             REQUIRE(result.data.data == nullptr);
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -37,91 +37,83 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
         std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
                                       oxenc::to_hex(fake_google_order_id);
 
-        session_pro_backend_add_pro_payment_user_transaction payment_tx = {};
-        payment_tx.provider_code_count =
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
-        std::memcpy(
-                payment_tx.provider_code,
-                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
-        payment_tx.payment_id_count = fake_payment_id.size();
-        std::memcpy(payment_tx.payment_id, fake_payment_id.data(), payment_tx.payment_id_count);
+        const char* provider_code = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY;
+        auto payment_id = reinterpret_cast<const uint8_t*>(fake_payment_id.data());
+        size_t payment_id_len = fake_payment_id.size();
 
         int64_t unix_ts = 1698765432;  // Arbitrary timestamp (unix epoch seconds)
 
-        SECTION("session_pro_backend_add_pro_payment_request_build_sigs") {
-            // Valid inputs
-            session_pro_backend_master_rotating_signatures result =
-                    session_pro_backend_add_pro_payment_request_build_sigs(
-                            master_privkey.data,
-                            sizeof(master_privkey.data),
-                            rotating_privkey.data,
-                            sizeof(rotating_privkey.data),
-                            payment_tx.provider_code,
-                            reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count);
-            INFO(result.error);
-            REQUIRE(result.success);
-            REQUIRE(result.error_count == 0);
-
-            // Verify signatures match C++ implementation
-            auto cpp = add_payment_sigs(
+        SECTION("session_pro_backend_add_pro_payment_request_build") {
+            auto result = session_pro_backend_add_pro_payment_request_build(
                     master_privkey.data,
+                    sizeof(master_privkey.data),
                     rotating_privkey.data,
-                    payment_tx.provider_code,
-                    std::span<const uint8_t>(
-                            reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count));
+                    sizeof(rotating_privkey.data),
+                    provider_code,
+                    payment_id,
+                    payment_id_len);
+            {
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
+                INFO(result.error);
+                REQUIRE(result.success);
+                REQUIRE(result.data.data != nullptr);
+                REQUIRE(result.data.size > 0);
 
-            REQUIRE(std::memcmp(
-                            result.master_sig.data,
-                            cpp.master_sig.data(),
-                            sizeof(result.master_sig.data)) == 0);
-            REQUIRE(std::memcmp(
-                            result.rotating_sig.data,
-                            cpp.rotating_sig.data(),
-                            sizeof(result.rotating_sig.data)) == 0);
+                // Matches the C++ free-function implementation end to end.
+                auto cpp = add_payment_request(
+                        master_privkey.data,
+                        rotating_privkey.data,
+                        provider_code,
+                        std::span<const uint8_t>(payment_id, payment_id_len));
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
+                REQUIRE(std::string_view(result.content_type) == cpp.content_type);
+                REQUIRE(cpp.content_type == "application/json");
+                REQUIRE(string8_equals(result.data, cpp.data));
+            }
 
-            // Invalid master key size
-            result = session_pro_backend_add_pro_payment_request_build_sigs(
+            // After freeing
+            REQUIRE(result.data.data == nullptr);
+            REQUIRE(result.data.size == 0);
+
+            // Invalid key size -> failure, no allocation
+            result = session_pro_backend_add_pro_payment_request_build(
                     master_privkey.data,
                     sizeof(master_privkey.data) - 1,
                     rotating_privkey.data,
                     sizeof(rotating_privkey.data),
-                    payment_tx.provider_code,
-                    reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                    payment_tx.payment_id_count);
+                    provider_code,
+                    payment_id,
+                    payment_id_len);
             REQUIRE(!result.success);
             REQUIRE(result.error_count > 0);
+            REQUIRE(result.data.data == nullptr);
         }
 
-        SECTION("session_pro_backend_generate_pro_proof_request_build_sigs") {
-            session_pro_backend_master_rotating_signatures result = {};
-
-            // Valid inputs
-            result = session_pro_backend_generate_pro_proof_request_build_sigs(
+        SECTION("session_pro_backend_generate_pro_proof_request_build") {
+            auto result = session_pro_backend_generate_pro_proof_request_build(
                     master_privkey.data,
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
                     sizeof(rotating_privkey.data),
                     unix_ts);
-            REQUIRE(result.success);
-            REQUIRE(result.error_count == 0);
+            {
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
+                REQUIRE(result.success);
+                REQUIRE(result.data.size > 0);
 
-            // Verify signatures match C++ implementation
-            auto cpp_sigs = pro_proof_sigs(
-                    master_privkey.data, rotating_privkey.data, session::as_sys_seconds(unix_ts));
-            REQUIRE(std::memcmp(
-                            result.master_sig.data,
-                            cpp_sigs.master_sig.data(),
-                            sizeof(result.master_sig.data)) == 0);
-            REQUIRE(std::memcmp(
-                            result.rotating_sig.data,
-                            cpp_sigs.rotating_sig.data(),
-                            sizeof(result.rotating_sig.data)) == 0);
+                auto cpp = pro_proof_request(
+                        master_privkey.data,
+                        rotating_privkey.data,
+                        session::as_sys_seconds(unix_ts));
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
+                REQUIRE(string8_equals(result.data, cpp.data));
+            }
+            REQUIRE(result.data.data == nullptr);
 
             // Invalid rotating key size
-            result = session_pro_backend_generate_pro_proof_request_build_sigs(
+            result = session_pro_backend_generate_pro_proof_request_build(
                     master_privkey.data,
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
@@ -131,173 +123,42 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.error_count > 0);
         }
 
-        SECTION("session_pro_backend_add_pro_payment_request_build") {
-            session_pro_backend_add_pro_payment_request request = {};
-            request.master_pkey = master_pubkey;
-            request.rotating_pkey = rotating_pubkey;
-            request.payment_tx = payment_tx;
-
-            session_pro_backend_master_rotating_signatures sigs =
-                    session_pro_backend_add_pro_payment_request_build_sigs(
-                            master_privkey.data,
-                            sizeof(master_privkey.data),
-                            rotating_privkey.data,
-                            sizeof(rotating_privkey.data),
-                            payment_tx.provider_code,
-                            reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count);
-
-            request.master_sig = sigs.master_sig;
-            request.rotating_sig = sigs.rotating_sig;
-
-            // Valid request
-            auto result = session_pro_backend_add_pro_payment_request_build(&request);
-            {
-                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
-                REQUIRE(result.success);
-                REQUIRE(result.data.data != nullptr);
-                REQUIRE(result.data.size > 0);
-
-                // Verify JSON + route match the C++ free-function implementation
-                auto cpp = add_payment_request(
-                        master_privkey.data,
-                        rotating_privkey.data,
-                        payment_tx.provider_code,
-                        std::span<const uint8_t>(
-                                reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                                payment_tx.payment_id_count));
-                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
-                REQUIRE(cpp.content_type == "application/json");
-                REQUIRE(string8_equals(result.data, cpp.data));
-                // The C request mirror carries the same endpoint + content_type as the C++ side.
-                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
-                REQUIRE(std::string_view(result.content_type) == cpp.content_type);
-            }
-
-            // After freeing
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
-
-            // Null request
-            result = session_pro_backend_add_pro_payment_request_build(nullptr);
-            REQUIRE(!result.success);
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
-        }
-
-        SECTION("session_pro_backend_generate_pro_proof_request_build") {
-            session_pro_backend_generate_pro_proof_request request = {};
-            request.master_pkey = master_pubkey;
-            request.rotating_pkey = rotating_pubkey;
-            request.ts = unix_ts;
-
-            session_pro_backend_master_rotating_signatures sigs =
-                    session_pro_backend_generate_pro_proof_request_build_sigs(
-                            master_privkey.data,
-                            sizeof(master_privkey.data),
-                            rotating_privkey.data,
-                            sizeof(rotating_privkey.data),
-                            request.ts);
-
-            request.master_sig = sigs.master_sig;
-            request.rotating_sig = sigs.rotating_sig;
-
-            // Valid request
-            auto result = session_pro_backend_generate_pro_proof_request_build(&request);
-            {
-                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
-                REQUIRE(result.success);
-                REQUIRE(result.data.data != nullptr);
-                REQUIRE(result.data.size > 0);
-
-                // Verify JSON + route match the C++ free-function implementation
-                auto cpp = pro_proof_request(
-                        master_privkey.data,
-                        rotating_privkey.data,
-                        session::as_sys_seconds(unix_ts));
-                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
-                REQUIRE(string8_equals(result.data, cpp.data));
-            }
-
-            // After freeing
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
-
-            // Null request
-            result = session_pro_backend_generate_pro_proof_request_build(nullptr);
-            REQUIRE(!result.success);
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
-        }
-
         SECTION("session_pro_backend_get_pro_revocations_request_build") {
-            session_pro_backend_get_pro_revocations_request request = {};
-            request.ticket = 123;
-
-            // Valid request
-            auto result = session_pro_backend_get_pro_revocations_request_build(&request);
+            auto result = session_pro_backend_get_pro_revocations_request_build(123);
             {
                 scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.data.data != nullptr);
                 REQUIRE(result.data.size > 0);
 
-                // Verify JSON + route match the C++ free-function implementation
-                auto cpp = revocations_request(request.ticket);
+                auto cpp = revocations_request(123);
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT);
                 REQUIRE(string8_equals(result.data, cpp.data));
             }
-
-            // After freeing
             REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
-
-            // Null request
-            result = session_pro_backend_get_pro_revocations_request_build(nullptr);
-            REQUIRE(!result.success);
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
         }
 
         SECTION("session_pro_backend_get_pro_details_request_build") {
-            session_pro_backend_get_pro_details_request request = {};
-            request.master_pkey = master_pubkey;
-            request.ts = unix_ts;
-            request.count = 10'000;
-
-            session_pro_backend_signature sig =
-                    session_pro_backend_get_pro_details_request_build_sig(
-                            master_privkey.data,
-                            sizeof(master_privkey.data),
-                            request.ts,
-                            request.count);
-
-            request.master_sig = sig.sig;
-
-            // Valid request
-            auto result = session_pro_backend_get_pro_details_request_build(&request);
+            auto result = session_pro_backend_get_pro_details_request_build(
+                    master_privkey.data, sizeof(master_privkey.data), unix_ts, 10'000);
             {
                 scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.data.data != nullptr);
                 REQUIRE(result.data.size > 0);
 
-                // Verify JSON + route match the C++ free-function implementation
                 auto cpp = payment_details_request(
-                        master_privkey.data, session::as_sys_seconds(unix_ts), request.count);
+                        master_privkey.data, session::as_sys_seconds(unix_ts), 10'000);
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT);
                 REQUIRE(string8_equals(result.data, cpp.data));
             }
-
-            // After freeing
             REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
 
-            // Null request
-            result = session_pro_backend_get_pro_details_request_build(nullptr);
+            // Invalid key size
+            result = session_pro_backend_get_pro_details_request_build(
+                    master_privkey.data, sizeof(master_privkey.data) - 1, unix_ts, 10'000);
             REQUIRE(!result.success);
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
+            REQUIRE(result.error_count > 0);
         }
 
         SECTION("session_pro_backend_pro_proof_response_parse") {
@@ -491,8 +352,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                {"revoked_ts", unix_ts + 3600 + 0.75},
                                {"refund_requested_ts", unix_ts + 3601},
                                {"payment_id",
-                                std::string(
-                                        payment_tx.payment_id, payment_tx.payment_id_count)}}})}};
+                                std::string(fake_payment_id.data(), fake_payment_id.size())}}})}};
             std::string json = j.dump();
 
             // Valid Google JSON
@@ -532,11 +392,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
                 REQUIRE(result.items[0].revoked_ts == unix_ts + 3600 + 0.75);  // 750ms preserved
                 REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
-                REQUIRE(result.items[0].payment_id_count == payment_tx.payment_id_count);
+                REQUIRE(result.items[0].payment_id_count == fake_payment_id.size());
                 REQUIRE(std::memcmp(
                                 result.items[0].payment_id,
-                                payment_tx.payment_id,
-                                payment_tx.payment_id_count) == 0);
+                                fake_payment_id.data(),
+                                fake_payment_id.size()) == 0);
             }
 
             // Tweak JSON for a different provider. payment_id is opaque so nothing
@@ -615,54 +475,42 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
         }
 
         SECTION("session_pro_backend_set_payment_refund_requested_request_build") {
-            session_pro_backend_set_payment_refund_requested_request request = {};
-            request.master_pkey = master_pubkey;
-            request.ts = unix_ts;
-            request.refund_requested_ts = unix_ts + 1;
-            request.payment_tx = payment_tx;
-
-            session_pro_backend_signature sig =
-                    session_pro_backend_set_payment_refund_requested_request_build_sigs(
-                            master_privkey.data,
-                            sizeof(master_privkey.data),
-                            request.ts,
-                            request.refund_requested_ts,
-                            payment_tx.provider_code,
-                            reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count);
-            request.master_sig = sig.sig;
-            REQUIRE(sig.success);
-
-            // Valid request
-            auto result = session_pro_backend_set_payment_refund_requested_request_build(&request);
+            auto result = session_pro_backend_set_payment_refund_requested_request_build(
+                    master_privkey.data,
+                    sizeof(master_privkey.data),
+                    unix_ts,
+                    unix_ts + 1,
+                    provider_code,
+                    payment_id,
+                    payment_id_len);
             {
                 scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
-                REQUIRE(result.data.data != nullptr);
                 REQUIRE(result.data.size > 0);
 
-                // Verify JSON + route match the C++ free-function implementation
                 auto cpp = refund_request(
                         master_privkey.data,
-                        session::as_sys_seconds(request.ts),
-                        session::as_sys_seconds(request.refund_requested_ts),
-                        payment_tx.provider_code,
-                        std::span<const uint8_t>(
-                                reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                                payment_tx.payment_id_count));
+                        session::as_sys_seconds(unix_ts),
+                        session::as_sys_seconds(unix_ts + 1),
+                        provider_code,
+                        std::span<const uint8_t>(payment_id, payment_id_len));
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
                 REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT);
                 REQUIRE(string8_equals(result.data, cpp.data));
             }
-
-            // After freeing
             REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
 
-            // Null request
-            result = session_pro_backend_set_payment_refund_requested_request_build(nullptr);
+            // Invalid key size
+            result = session_pro_backend_set_payment_refund_requested_request_build(
+                    master_privkey.data,
+                    sizeof(master_privkey.data) - 1,
+                    unix_ts,
+                    unix_ts + 1,
+                    provider_code,
+                    payment_id,
+                    payment_id_len);
             REQUIRE(!result.success);
-            REQUIRE(result.data.data == nullptr);
-            REQUIRE(result.data.size == 0);
+            REQUIRE(result.error_count > 0);
         }
 
         SECTION("session_pro_backend_set_payment_refund_requested_response_parse") {
@@ -786,37 +634,17 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
                                       oxenc::to_hex(fake_google_order_id);
 
-        session_pro_backend_add_pro_payment_user_transaction payment_tx = {};
-        payment_tx.provider_code_count =
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
-        std::memcpy(
-                payment_tx.provider_code,
-                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
-        payment_tx.payment_id_count = fake_payment_id.size();
-        std::memcpy(payment_tx.payment_id, fake_payment_id.data(), payment_tx.payment_id_count);
-
-        // Build request
-        session_pro_backend_master_rotating_signatures add_pro_sigs =
-                session_pro_backend_add_pro_payment_request_build_sigs(
+        session_pro_backend_request request_json =
+                session_pro_backend_add_pro_payment_request_build(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        payment_tx.provider_code,
-                        reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                        payment_tx.payment_id_count);
-
-        session_pro_backend_add_pro_payment_request request = {};
-        request.master_pkey = master_pubkey;
-        request.rotating_pkey = rotating_pubkey;
-        request.payment_tx = payment_tx;
-        request.master_sig = add_pro_sigs.master_sig;
-        request.rotating_sig = add_pro_sigs.rotating_sig;
-
-        session_pro_backend_request request_json =
-                session_pro_backend_add_pro_payment_request_build(&request);
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                        reinterpret_cast<const uint8_t*>(fake_payment_id.data()),
+                        fake_payment_id.size());
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
@@ -846,32 +674,22 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 &first_pro_proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
         REQUIRE(std::memcmp(
                         response.proof.rotating_pubkey.data,
-                        request.rotating_pkey.data,
-                        sizeof(request.rotating_pkey.data)) == 0);
+                        rotating_pubkey.data,
+                        sizeof(rotating_pubkey.data)) == 0);
     }
 
     // Authorise new key
     {
         int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
-        // Build request
-        session_pro_backend_master_rotating_signatures pro_sigs =
-                session_pro_backend_generate_pro_proof_request_build_sigs(
+        session_pro_backend_request request_json =
+                session_pro_backend_generate_pro_proof_request_build(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
                         now_unix_ts);
-
-        session_pro_backend_generate_pro_proof_request request = {};
-        request.master_pkey = master_pubkey;
-        request.rotating_pkey = rotating_pubkey;
-        request.ts = now_unix_ts;
-        request.master_sig = pro_sigs.master_sig;
-        request.rotating_sig = pro_sigs.rotating_sig;
-
-        session_pro_backend_request request_json =
-                session_pro_backend_generate_pro_proof_request_build(&request);
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         // Do CURL request
         std::string response_json = curl_do_basic_blocking_post_request(
@@ -900,30 +718,20 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 &proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
         REQUIRE(std::memcmp(
                         response.proof.rotating_pubkey.data,
-                        request.rotating_pkey.data,
-                        sizeof(request.rotating_pkey.data)) == 0);
-
-        session_pro_backend_request_free(&request_json);
-        session_pro_backend_pro_proof_response_free(&response);
+                        rotating_pubkey.data,
+                        sizeof(rotating_pubkey.data)) == 0);
     }
 
     // Get pro status
     {
-        // Build request
-        session_pro_backend_get_pro_details_request request = {};
-        request.master_pkey = master_pubkey;
-        request.ts = session::epoch_seconds(session::sysclock_now_s());
-        request.count = 10'000;
-
-        session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
-                master_privkey.data, sizeof(master_privkey.data), request.ts, request.count);
-        REQUIRE(sig.success);
-        request.master_sig = sig.sig;
-
-        // Do CURL request
         session_pro_backend_request request_json =
-                session_pro_backend_get_pro_details_request_build(&request);
+                session_pro_backend_get_pro_details_request_build(
+                        master_privkey.data,
+                        sizeof(master_privkey.data),
+                        session::epoch_seconds(session::sysclock_now_s()),
+                        10'000);
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
@@ -938,7 +746,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         scope_exit response_free{
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
-        // Verify the response
         INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
             string8 error = response.header.errors[index];
@@ -952,20 +759,14 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
     // Get pro status without history
     {
-        // Build request
-        session_pro_backend_get_pro_details_request request = {};
-        request.master_pkey = master_pubkey;
-        request.ts = session::epoch_seconds(session::sysclock_now_s());
-
-        session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
-                master_privkey.data, sizeof(master_privkey.data), request.ts, request.count);
-        REQUIRE(sig.success);
-        request.master_sig = sig.sig;
-
-        // Do CURL request
         session_pro_backend_request request_json =
-                session_pro_backend_get_pro_details_request_build(&request);
+                session_pro_backend_get_pro_details_request_build(
+                        master_privkey.data,
+                        sizeof(master_privkey.data),
+                        session::epoch_seconds(session::sysclock_now_s()),
+                        0);
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
@@ -985,8 +786,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             string8 error = response.header.errors[index];
             UNSCOPED_INFO("ERROR: " << error.data);
         }
-
-        // Verify the response
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
         REQUIRE(std::string_view(response.status, response.status_count) == "active");
@@ -994,48 +793,26 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     }
 
     // Add _another_ payment, same details
-    session_pro_backend_add_pro_payment_user_transaction another_payment_tx = {};
+    std::string another_payment_id;
     {
         std::array<uint8_t, 8> fake_google_payment_token;
         randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
         std::array<uint8_t, 8> fake_google_order_id;
         randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
-                                      oxenc::to_hex(fake_google_order_id);
+        another_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
+                             oxenc::to_hex(fake_google_order_id);
 
-        another_payment_tx.provider_code_count =
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
-        std::memcpy(
-                another_payment_tx.provider_code,
-                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
-        another_payment_tx.payment_id_count = fake_payment_id.size();
-        std::memcpy(
-                another_payment_tx.payment_id,
-                fake_payment_id.data(),
-                another_payment_tx.payment_id_count);
-
-        // Build request
-        session_pro_backend_master_rotating_signatures add_pro_sigs =
-                session_pro_backend_add_pro_payment_request_build_sigs(
+        session_pro_backend_request request_json =
+                session_pro_backend_add_pro_payment_request_build(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        another_payment_tx.provider_code,
-                        reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
-                        another_payment_tx.payment_id_count);
-
-        session_pro_backend_add_pro_payment_request request = {};
-        request.master_pkey = master_pubkey;
-        request.rotating_pkey = rotating_pubkey;
-        request.payment_tx = another_payment_tx;
-        request.master_sig = add_pro_sigs.master_sig;
-        request.rotating_sig = add_pro_sigs.rotating_sig;
-
-        session_pro_backend_request request_json =
-                session_pro_backend_add_pro_payment_request_build(&request);
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                        reinterpret_cast<const uint8_t*>(another_payment_id.data()),
+                        another_payment_id.size());
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
@@ -1056,18 +833,16 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 &proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
         REQUIRE(std::memcmp(
                         response.proof.rotating_pubkey.data,
-                        request.rotating_pkey.data,
-                        sizeof(request.rotating_pkey.data)) == 0);
+                        rotating_pubkey.data,
+                        sizeof(rotating_pubkey.data)) == 0);
     }
 
     // Get revocation list
     {
-        // Build request
-        session_pro_backend_get_pro_revocations_request request = {};
-
         session_pro_backend_request request_json =
-                session_pro_backend_get_pro_revocations_request_build(&request);
+                session_pro_backend_get_pro_revocations_request_build(0);
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
@@ -1089,8 +864,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             string8 error = response.header.errors[index];
             UNSCOPED_INFO("ERROR: " << error.data);
         }
-
-        // Verify the response
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
         REQUIRE(response.ticket == 0);
@@ -1099,28 +872,18 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
     // Set payment refund requested
     {
-        // Build request
         int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
-        session_pro_backend_signature refund_sig =
-                session_pro_backend_set_payment_refund_requested_request_build_sigs(
+        session_pro_backend_request request_json =
+                session_pro_backend_set_payment_refund_requested_request_build(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         /*ts*/ now_unix_ts,
                         /*refund_requested_ts*/ now_unix_ts,
-                        another_payment_tx.provider_code,
-                        reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
-                        another_payment_tx.payment_id_count);
-
-        session_pro_backend_set_payment_refund_requested_request request = {};
-        request.master_pkey = master_pubkey;
-        request.master_sig = refund_sig.sig;
-        request.ts = now_unix_ts;
-        request.refund_requested_ts = now_unix_ts;
-        request.payment_tx = another_payment_tx;
-
-        session_pro_backend_request request_json =
-                session_pro_backend_set_payment_refund_requested_request_build(&request);
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                        reinterpret_cast<const uint8_t*>(another_payment_id.data()),
+                        another_payment_id.size());
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
+        REQUIRE(request_json.success);
 
         // Do curl request
         std::string response_json = curl_do_basic_blocking_post_request(
@@ -1143,8 +906,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
             string8 error = response.header.errors[index];
             UNSCOPED_INFO("ERROR: " << error.data);
         }
-
-        // Verify the response
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
         REQUIRE(response.updated);

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -378,7 +378,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items != nullptr);
                 REQUIRE(std::string_view(result.items[0].status, result.items[0].status_count) ==
                         "redeemed");
-                REQUIRE(std::string_view(result.items[0].plan, result.items[0].plan_count) == "1m");
+                REQUIRE(result.items[0].plan_count == 1);
+                REQUIRE(result.items[0].plan_unit == SESSION_PRO_BACKEND_PLAN_UNIT_MONTH);
                 REQUIRE(std::string_view(
                                 result.items[0].payment_provider,
                                 result.items[0].payment_provider_count) ==
@@ -595,6 +596,48 @@ TEST_CASE(
     REQUIRE(count == platforms.size());
     for (size_t i = 0; i < count; i++)
         REQUIRE(std::string_view{c[i]} == platforms[i]);
+}
+
+TEST_CASE("Pro Backend parse_plan_period (closed grammar)", "[pro_backend]") {
+    using enum ProPlanUnit;
+    auto ok = [](std::string_view code, int n, ProPlanUnit u) {
+        auto p = parse_plan_period(code);
+        REQUIRE(p.has_value());
+        CHECK(p->count == n);
+        CHECK(p->unit == u);
+    };
+
+    // Every unit; count preserved verbatim.
+    ok("30s", 30, second);
+    ok("14d", 14, day);
+    ok("2w", 2, week);
+    ok("1m", 1, month);
+    ok("3m", 3, month);
+    ok("1y", 1, year);
+    // Unit is preserved, never canonicalized: "12m" stays (12, month), not (1, year).
+    ok("12m", 12, month);
+    // lifetime: count 0, and the invariant count == 0 iff unit == lifetime.
+    ok("lifetime", 0, lifetime);
+
+    // Non-conforming codes -> nullopt (caller treats as a protocol error; no raw pass-through).
+    for (std::string_view bad :
+         {"",
+          "m",
+          "1",
+          "0m",
+          "01m",
+          "1y6m",
+          "-1m",
+          "+1m",
+          "1x",
+          "1 m",
+          "1M",
+          "1mm",
+          "1.5m",
+          "9999999999999999999m",
+          "lifetime2",
+          "Lifetime"})
+        CHECK_FALSE(parse_plan_period(bad).has_value());
 }
 
 #if defined(TEST_PRO_BACKEND_WITH_DEV_SERVER)

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -3,7 +3,6 @@
 #include <sodium.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <cinttypes>
 #include <nlohmann/json.hpp>
 #include <session/pro_backend.hpp>
 #include <string>
@@ -18,49 +17,6 @@ extern std::string g_test_pro_backend_dev_server_url;
 static bool string8_equals(string8 s8, std::string_view str) {
     return s8.size == str.size() && std::memcmp(s8.data, str.data(), s8.size) == 0;
 }
-[[maybe_unused]] static void dump_pro_proof_to_stderr(const session_protocol_pro_proof& proof) {
-    fprintf(stderr, "proof.version: %u\n", proof.version);
-    fprintf(stderr,
-            "proof.revocation_tag: %s\n",
-            oxenc::to_hex(proof.revocation_tag.data, std::end(proof.revocation_tag.data)).c_str());
-    fprintf(stderr,
-            "proof.rotating_pubkey: %s\n",
-            oxenc::to_hex(proof.rotating_pubkey.data, std::end(proof.rotating_pubkey.data))
-                    .c_str());
-    fprintf(stderr, "proof.expiry_ts: %" PRId64 "\n", proof.expiry_ts);
-    fprintf(stderr,
-            "proof.sig: %s\n",
-            oxenc::to_hex(proof.sig.data, std::end(proof.sig.data)).c_str());
-}
-
-[[maybe_unused]] static void dump_pro_payment_item(
-        const session_pro_backend_pro_payment_item& item) {
-    fprintf(stderr, "item.status: %d\n", item.status);
-    fprintf(stderr, "item.plan: %.*s\n", (int)item.plan_count, item.plan);
-    fprintf(stderr,
-            "item.payment_provider: %.*s\n",
-            (int)item.payment_provider_count,
-            item.payment_provider);
-    fprintf(stderr, "item.auto_renewing: %d\n", item.auto_renewing);
-    fprintf(stderr, "item.purchased_ts: %f\n", item.purchased_ts);
-    fprintf(stderr, "item.redeemed_ts: %" PRId64 "zu\n", item.redeemed_ts);
-    fprintf(stderr, "item.expiry_ts: %" PRId64 "\n", item.expiry_ts);
-    fprintf(stderr, "item.grace_period_duration: %" PRId64 "zu\n", item.grace_period_duration);
-    fprintf(stderr,
-            "item.platform_refund_expiry_ts: %" PRId64 "zu\n",
-            item.platform_refund_expiry_ts);
-    fprintf(stderr, "item.revoked_ts: %f\n", item.revoked_ts);
-    fprintf(stderr, "item.payment_id: %.*s\n", (int)item.payment_id_count, item.payment_id);
-}
-
-[[maybe_unused]] static void dump_pro_revocation(
-        const session_pro_backend_pro_revocation_item& item) {
-    fprintf(stderr, "item.effective_ts: %" PRId64 "\n", item.effective_ts);
-    fprintf(stderr,
-            "item.revocation_tag: %s\n",
-            oxenc::to_hex(item.revocation_tag.data, std::end(item.revocation_tag.data)).c_str());
-}
-
 TEST_CASE("Pro Backend C API", "[pro_backend]") {
     // Setup: Generate keys and payment token hash
     bytes32 master_pubkey = {};
@@ -926,11 +882,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         response_json.data(), response_json.size());
         scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
+        INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
-            if (index == 0)
-                fprintf(stderr, "ERROR: JSON response: %s\n", response_json.c_str());
             string8 error = response.header.errors[index];
-            fprintf(stderr, "ERROR: %s\n", error.data);
+            UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
@@ -980,11 +935,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
         // Verify the response
+        INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
-            if (index == 0)
-                fprintf(stderr, "ERROR: JSON response: %s\n", response_json.c_str());
             string8 error = response.header.errors[index];
-            fprintf(stderr, "ERROR: %s\n", error.data);
+            UNSCOPED_INFO("ERROR: " << error.data);
         }
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
@@ -1022,11 +976,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         scope_exit response_free{
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
+        INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
-            if (index == 0)
-                fprintf(stderr, "ERROR: JSON response: %s\n", response_json.c_str());
             string8 error = response.header.errors[index];
-            fprintf(stderr, "ERROR: %s\n", error.data);
+            UNSCOPED_INFO("ERROR: " << error.data);
         }
 
         // Verify the response
@@ -1130,7 +1083,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
             string8 error = response.header.errors[index];
-            fprintf(stderr, "ERROR: %s\n", error.data);
+            UNSCOPED_INFO("ERROR: " << error.data);
         }
 
         // Verify the response
@@ -1184,7 +1137,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         INFO("ERROR: JSON response: " << response_json.c_str());
         for (size_t index = 0; index < response.header.errors_count; index++) {
             string8 error = response.header.errors[index];
-            fprintf(stderr, "ERROR: %s\n", error.data);
+            UNSCOPED_INFO("ERROR: " << error.data);
         }
 
         // Verify the response

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -97,7 +97,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             // Valid inputs
             session_pro_backend_master_rotating_signatures result =
                     session_pro_backend_add_pro_payment_request_build_sigs(
-                            /*version*/ 0,
                             master_privkey.data,
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
@@ -110,8 +109,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.error_count == 0);
 
             // Verify signatures match C++ implementation
-            auto cpp = AddProPaymentRequest::build_sigs(
-                    0,
+            auto cpp = add_payment_sigs(
                     master_privkey.data,
                     rotating_privkey.data,
                     payment_tx.provider_code,
@@ -130,7 +128,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Invalid master key size
             result = session_pro_backend_add_pro_payment_request_build_sigs(
-                    0,
                     master_privkey.data,
                     sizeof(master_privkey.data) - 1,
                     rotating_privkey.data,
@@ -147,7 +144,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Valid inputs
             result = session_pro_backend_generate_pro_proof_request_build_sigs(
-                    0,
                     master_privkey.data,
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
@@ -157,11 +153,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.error_count == 0);
 
             // Verify signatures match C++ implementation
-            auto cpp_sigs = GenerateProProofRequest::build_sigs(
-                    0,
-                    master_privkey.data,
-                    rotating_privkey.data,
-                    session::as_sys_seconds(unix_ts));
+            auto cpp_sigs = pro_proof_sigs(
+                    master_privkey.data, rotating_privkey.data, session::as_sys_seconds(unix_ts));
             REQUIRE(std::memcmp(
                             result.master_sig.data,
                             cpp_sigs.master_sig.data(),
@@ -173,7 +166,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Invalid rotating key size
             result = session_pro_backend_generate_pro_proof_request_build_sigs(
-                    0,
                     master_privkey.data,
                     sizeof(master_privkey.data),
                     rotating_privkey.data,
@@ -185,14 +177,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_add_pro_payment_request_to_json") {
             session_pro_backend_add_pro_payment_request request = {};
-            request.version = 0;
             request.master_pkey = master_pubkey;
             request.rotating_pkey = rotating_pubkey;
             request.payment_tx = payment_tx;
 
             session_pro_backend_master_rotating_signatures sigs =
                     session_pro_backend_add_pro_payment_request_build_sigs(
-                            request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
@@ -212,44 +202,16 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.json.data != nullptr);
                 REQUIRE(result.json.size > 0);
 
-                // Verify JSON matches C++ implementation
-                AddProPaymentRequest cpp = {};
-                static_assert(sizeof(master_pubkey.data) == cpp.master_pkey.max_size());
-                static_assert(sizeof(rotating_pubkey.data) == cpp.rotating_pkey.max_size());
-
-                cpp.version = request.version;
-                std::memcpy(cpp.master_pkey.data(), master_pubkey.data, sizeof(master_pubkey.data));
-                std::memcpy(
-                        cpp.rotating_pkey.data(),
-                        rotating_pubkey.data,
-                        sizeof(rotating_pubkey.data));
-                cpp.payment_tx.provider_code =
-                        std::string(payment_tx.provider_code, payment_tx.provider_code_count);
-                cpp.payment_tx.payment_id =
-                        std::string(payment_tx.payment_id, payment_tx.payment_id_count);
-                std::memcpy(
-                        cpp.master_sig.data(), sigs.master_sig.data, sizeof(sigs.master_sig.data));
-                std::memcpy(
-                        cpp.rotating_sig.data(),
-                        sigs.rotating_sig.data,
-                        sizeof(sigs.rotating_sig.data));
-                std::string cpp_json = cpp.to_json();
-                REQUIRE(string8_equals(result.json, cpp_json));
-
-                // Verify that the helper one-shot-to-json function generates the same payload
-                auto one_shot = session_pro_backend_add_pro_payment_request_build_to_json(
-                        request.version,
+                // Verify JSON + route match the C++ free-function implementation
+                auto cpp = add_payment_request(
                         master_privkey.data,
-                        sizeof(master_privkey.data),
                         rotating_privkey.data,
-                        sizeof(rotating_privkey.data),
-                        request.payment_tx.provider_code,
-                        reinterpret_cast<const unsigned char*>(request.payment_tx.payment_id),
-                        request.payment_tx.payment_id_count);
-                REQUIRE(one_shot.success);
-                REQUIRE(one_shot.json.size == result.json.size);
-                INFO("One shot: " << one_shot.json.data << "\n\nJSON: " << result.json.data);
-                REQUIRE(memcmp(one_shot.json.data, result.json.data, result.json.size) == 0);
+                        payment_tx.provider_code,
+                        std::span<const uint8_t>(
+                                reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
+                                payment_tx.payment_id_count));
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
+                REQUIRE(string8_equals(result.json, cpp.body));
             }
 
             // After freeing
@@ -265,14 +227,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_generate_pro_proof_request_to_json") {
             session_pro_backend_generate_pro_proof_request request = {};
-            request.version = 0;
             request.master_pkey = master_pubkey;
             request.rotating_pkey = rotating_pubkey;
             request.ts = unix_ts;
 
             session_pro_backend_master_rotating_signatures sigs =
                     session_pro_backend_generate_pro_proof_request_build_sigs(
-                            request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
@@ -290,36 +250,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.json.data != nullptr);
                 REQUIRE(result.json.size > 0);
 
-                // Verify JSON matches C++ implementation
-                GenerateProProofRequest cpp = {};
-                cpp.version = request.version;
-                std::memcpy(cpp.master_pkey.data(), master_pubkey.data, sizeof(master_pubkey.data));
-                std::memcpy(
-                        cpp.rotating_pkey.data(),
-                        rotating_pubkey.data,
-                        sizeof(rotating_pubkey.data));
-                cpp.unix_ts = session::as_sys_seconds(unix_ts);
-                std::memcpy(
-                        cpp.master_sig.data(), sigs.master_sig.data, sizeof(sigs.master_sig.data));
-                std::memcpy(
-                        cpp.rotating_sig.data(),
-                        sigs.rotating_sig.data,
-                        sizeof(sigs.rotating_sig.data));
-                std::string cpp_json = cpp.to_json();
-                REQUIRE(string8_equals(result.json, cpp_json));
-
-                // Verify that the helper one-shot-to-json function generates the same payload
-                auto one_shot = session_pro_backend_generate_pro_proof_request_build_to_json(
-                        request.version,
+                // Verify JSON + route match the C++ free-function implementation
+                auto cpp = pro_proof_request(
                         master_privkey.data,
-                        sizeof(master_privkey.data),
                         rotating_privkey.data,
-                        sizeof(rotating_privkey.data),
-                        request.ts);
-                REQUIRE(one_shot.success);
-                REQUIRE(one_shot.json.size == result.json.size);
-                INFO("One shot: " << one_shot.json.data << "\n\nJSON: " << result.json.data);
-                REQUIRE(memcmp(one_shot.json.data, result.json.data, result.json.size) == 0);
+                        session::as_sys_seconds(unix_ts));
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
+                REQUIRE(string8_equals(result.json, cpp.body));
             }
 
             // After freeing
@@ -335,7 +272,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_get_pro_revocations_request_to_json") {
             session_pro_backend_get_pro_revocations_request request = {};
-            request.version = 0;
             request.ticket = 123;
 
             // Valid request
@@ -346,12 +282,10 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.json.data != nullptr);
                 REQUIRE(result.json.size > 0);
 
-                // Verify JSON matches C++ implementation
-                GetProRevocationsRequest cpp = {};
-                cpp.version = request.version;
-                cpp.ticket = request.ticket;
-                std::string cpp_json = cpp.to_json();
-                REQUIRE(string8_equals(result.json, cpp_json));
+                // Verify JSON + route match the C++ free-function implementation
+                auto cpp = revocations_request(request.ticket);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_REVOCATIONS_ENDPOINT);
+                REQUIRE(string8_equals(result.json, cpp.body));
             }
 
             // After freeing
@@ -367,14 +301,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_get_pro_details_request_to_json") {
             session_pro_backend_get_pro_details_request request = {};
-            request.version = 0;
             request.master_pkey = master_pubkey;
             request.ts = unix_ts;
             request.count = 10'000;
 
             session_pro_backend_signature sig =
                     session_pro_backend_get_pro_details_request_build_sig(
-                            request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
                             request.ts,
@@ -390,27 +322,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.json.data != nullptr);
                 REQUIRE(result.json.size > 0);
 
-                // Verify JSON matches C++ implementation
-                GetProDetailsRequest cpp = {};
-                cpp.version = 0;
-                std::memcpy(cpp.master_pkey.data(), master_pubkey.data, sizeof(master_pubkey.data));
-                std::memcpy(cpp.master_sig.data(), sig.sig.data, sizeof(sig.sig.data));
-                cpp.unix_ts = session::as_sys_seconds(unix_ts);
-                cpp.count = request.count;
-                std::string cpp_json = cpp.to_json();
-                REQUIRE(string8_equals(result.json, cpp_json));
-
-                // Verify that the helper one-shot-to-json function generates the same payload
-                auto one_shot = session_pro_backend_get_pro_details_request_build_to_json(
-                        request.version,
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        request.ts,
-                        request.count);
-                REQUIRE(one_shot.success);
-                REQUIRE(one_shot.json.size == result.json.size);
-                INFO("One shot: " << one_shot.json.data << "\n\nJSON: " << result.json.data);
-                REQUIRE(memcmp(one_shot.json.data, result.json.data, result.json.size) == 0);
+                // Verify JSON + route match the C++ free-function implementation
+                auto cpp = payment_details_request(
+                        master_privkey.data, session::as_sys_seconds(unix_ts), request.count);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT);
+                REQUIRE(string8_equals(result.json, cpp.body));
             }
 
             // After freeing
@@ -424,7 +340,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.json.size == 0);
         }
 
-        SECTION("session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse") {
+        SECTION("session_pro_backend_pro_proof_response_parse") {
             std::array<uint8_t, 32> fake_revocation_tag;
             randombytes_buf(fake_revocation_tag.data(), fake_revocation_tag.size());
 
@@ -440,14 +356,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             std::string json = j.dump();
 
             // Valid JSON
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response result =
-                    session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
-                            json.data(), json.size());
+            session_pro_backend_pro_proof_response result =
+                    session_pro_backend_pro_proof_response_parse(json.data(), json.size());
             {
-                scope_exit result_free{[&]() {
-                    session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(
-                            &result);
-                }};
+                scope_exit result_free{
+                        [&]() { session_pro_backend_pro_proof_response_free(&result); }};
 
                 for (size_t index = 0; index < result.header.errors_count; index++)
                     INFO(result.header.errors[index].data);
@@ -471,7 +384,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 // Here we also create the CPP version, we will run the conversion functions into
                 // pro proofs (both C and CPP variants) and then compare the two structures to make
                 // sure the conversion functions are sound.
-                auto result_cpp = AddProPaymentOrGenerateProProofResponse::parse(json);
+                auto result_cpp = parse_add_payment(json);
 
                 // Validate C and CPP variants
                 REQUIRE(result.proof.version == result_cpp.proof.version);
@@ -498,25 +411,21 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Invalid JSON
             json = "{invalid}";
-            result = session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
-                    json.data(), json.size());
+            result = session_pro_backend_pro_proof_response_parse(json.data(), json.size());
             {
-                scope_exit result_free{[&]() {
-                    session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(
-                            &result);
-                }};
+                scope_exit result_free{
+                        [&]() { session_pro_backend_pro_proof_response_free(&result); }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
                 REQUIRE(result.header.errors_count > 0);
                 REQUIRE(result.header.errors != nullptr);
             }
 
             // After freeing
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(&result);
+            session_pro_backend_pro_proof_response_free(&result);
             REQUIRE(result.header.internal_arena_buf_ == nullptr);
 
             // Null JSON
-            result = session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
-                    nullptr, 0);
+            result = session_pro_backend_pro_proof_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_STATUS_SUCCESS);
             REQUIRE(result.header.errors_count == 1);
             REQUIRE(result.header.errors != nullptr);
@@ -728,9 +637,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(to_json.json.data == nullptr);
             REQUIRE(to_json.json.size == 0);
 
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response proof_response = {};
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(
-                    &proof_response);
+            session_pro_backend_pro_proof_response proof_response = {};
+            session_pro_backend_pro_proof_response_free(&proof_response);
             REQUIRE(proof_response.header.internal_arena_buf_ == nullptr);
 
             session_pro_backend_get_pro_revocations_response rev_response = {};
@@ -744,14 +652,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_set_payment_refund_requested_request_to_json") {
             session_pro_backend_set_payment_refund_requested_request request = {};
-            request.version = 0;
             request.master_pkey = master_pubkey;
             request.ts = unix_ts;
             request.refund_requested_ts = unix_ts + 1;
+            request.payment_tx = payment_tx;
 
             session_pro_backend_signature sig =
                     session_pro_backend_set_payment_refund_requested_request_build_sigs(
-                            request.version,
                             master_privkey.data,
                             sizeof(master_privkey.data),
                             request.ts,
@@ -771,22 +678,17 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.json.data != nullptr);
                 REQUIRE(result.json.size > 0);
 
-                // Verify JSON matches C++ implementation
-                SetPaymentRefundRequestedRequest cpp = {};
-                cpp.version = request.version;
-                std::memcpy(
-                        cpp.master_pkey.data(),
-                        request.master_pkey.data,
-                        sizeof(request.master_pkey.data));
-                cpp.unix_ts = session::as_sys_seconds(unix_ts);
-                cpp.refund_requested_unix_ts = session::as_sys_seconds(request.refund_requested_ts);
-                std::memcpy(
-                        cpp.master_sig.data(),
-                        request.master_sig.data,
-                        sizeof(request.master_sig.data));
-
-                std::string cpp_json = cpp.to_json();
-                REQUIRE(string8_equals(result.json, cpp_json));
+                // Verify JSON + route match the C++ free-function implementation
+                auto cpp = refund_request(
+                        master_privkey.data,
+                        session::as_sys_seconds(request.ts),
+                        session::as_sys_seconds(request.refund_requested_ts),
+                        payment_tx.provider_code,
+                        std::span<const uint8_t>(
+                                reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
+                                payment_tx.payment_id_count));
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT);
+                REQUIRE(string8_equals(result.json, cpp.body));
             }
 
             // After freeing
@@ -936,7 +838,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Build request
         session_pro_backend_master_rotating_signatures add_pro_sigs =
                 session_pro_backend_add_pro_payment_request_build_sigs(
-                        /*version*/ 0,
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
@@ -946,7 +847,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         payment_tx.payment_id_count);
 
         session_pro_backend_add_pro_payment_request request = {};
-        request.version = 0;
         request.master_pkey = master_pubkey;
         request.rotating_pkey = rotating_pubkey;
         request.payment_tx = payment_tx;
@@ -965,12 +865,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 std::string_view(request_json.json.data, request_json.json.size));
 
         // Parse response
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response response =
-                session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
+        session_pro_backend_pro_proof_response response =
+                session_pro_backend_pro_proof_response_parse(
                         response_json.data(), response_json.size());
-        scope_exit response_free{[&]() {
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(&response);
-        }};
+        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
         for (size_t index = 0; index < response.header.errors_count; index++) {
             string8 error = response.header.errors[index];
@@ -997,7 +895,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Build request
         session_pro_backend_master_rotating_signatures pro_sigs =
                 session_pro_backend_generate_pro_proof_request_build_sigs(
-                        /*version*/ 0,
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
@@ -1005,7 +902,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         now_unix_ts);
 
         session_pro_backend_generate_pro_proof_request request = {};
-        request.version = 0;
         request.master_pkey = master_pubkey;
         request.rotating_pkey = rotating_pubkey;
         request.ts = now_unix_ts;
@@ -1024,12 +920,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 std::string_view(request_json.json.data, request_json.json.size));
 
         // Parse response
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response response =
-                session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
+        session_pro_backend_pro_proof_response response =
+                session_pro_backend_pro_proof_response_parse(
                         response_json.data(), response_json.size());
-        scope_exit response_free{[&]() {
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(&response);
-        }};
+        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
         for (size_t index = 0; index < response.header.errors_count; index++) {
             if (index == 0)
@@ -1050,24 +944,19 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(request.rotating_pkey.data)) == 0);
 
         session_pro_backend_to_json_free(&request_json);
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(&response);
+        session_pro_backend_pro_proof_response_free(&response);
     }
 
     // Get pro status
     {
         // Build request
         session_pro_backend_get_pro_details_request request = {};
-        request.version = 0;
         request.master_pkey = master_pubkey;
         request.ts = session::epoch_seconds(session::sysclock_now_s());
         request.count = 10'000;
 
         session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
-                request.version,
-                master_privkey.data,
-                sizeof(master_privkey.data),
-                request.ts,
-                request.count);
+                master_privkey.data, sizeof(master_privkey.data), request.ts, request.count);
         REQUIRE(sig.success);
         request.master_sig = sig.sig;
 
@@ -1106,16 +995,11 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     {
         // Build request
         session_pro_backend_get_pro_details_request request = {};
-        request.version = 0;
         request.master_pkey = master_pubkey;
         request.ts = session::epoch_seconds(session::sysclock_now_s());
 
         session_pro_backend_signature sig = session_pro_backend_get_pro_details_request_build_sig(
-                request.version,
-                master_privkey.data,
-                sizeof(master_privkey.data),
-                request.ts,
-                request.count);
+                master_privkey.data, sizeof(master_privkey.data), request.ts, request.count);
         REQUIRE(sig.success);
         request.master_sig = sig.sig;
 
@@ -1176,7 +1060,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Build request
         session_pro_backend_master_rotating_signatures add_pro_sigs =
                 session_pro_backend_add_pro_payment_request_build_sigs(
-                        /*version*/ 0,
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
@@ -1186,7 +1069,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         another_payment_tx.payment_id_count);
 
         session_pro_backend_add_pro_payment_request request = {};
-        request.version = 0;
         request.master_pkey = master_pubkey;
         request.rotating_pkey = rotating_pubkey;
         request.payment_tx = another_payment_tx;
@@ -1205,12 +1087,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 std::string_view(request_json.json.data, request_json.json.size));
 
         // Parse response
-        session_pro_backend_add_pro_payment_or_generate_pro_proof_response response =
-                session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse(
+        session_pro_backend_pro_proof_response response =
+                session_pro_backend_pro_proof_response_parse(
                         response_json.data(), response_json.size());
-        scope_exit response_free{[&]() {
-            session_pro_backend_add_pro_payment_or_generate_pro_proof_response_free(&response);
-        }};
+        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
         // Verify response
         session_protocol_pro_proof proof = response.proof;
@@ -1226,7 +1106,6 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     {
         // Build request
         session_pro_backend_get_pro_revocations_request request = {};
-        request.version = 0;
 
         session_pro_backend_to_json request_json =
                 session_pro_backend_get_pro_revocations_request_to_json(&request);
@@ -1264,9 +1143,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     {
         // Build request
         int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
-        session_pro_backend_to_json request_json =
-                session_pro_backend_set_payment_refund_requested_request_build_to_json(
-                        /*version*/ 0,
+        session_pro_backend_signature refund_sig =
+                session_pro_backend_set_payment_refund_requested_request_build_sigs(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         /*ts*/ now_unix_ts,
@@ -1275,6 +1153,15 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
                         another_payment_tx.payment_id_count);
 
+        session_pro_backend_set_payment_refund_requested_request request = {};
+        request.master_pkey = master_pubkey;
+        request.master_sig = refund_sig.sig;
+        request.ts = now_unix_ts;
+        request.refund_requested_ts = now_unix_ts;
+        request.payment_tx = another_payment_tx;
+
+        session_pro_backend_to_json request_json =
+                session_pro_backend_set_payment_refund_requested_request_to_json(&request);
         scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
 
         // Do curl request

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -183,11 +183,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_pro_proof_response_free(&result); }};
 
-                if (result.header.error.data)
-                    INFO(result.header.error.data);
+                if (result.header.error)
+                    INFO(result.header.error);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error.data == nullptr);
+                REQUIRE(result.header.error == nullptr);
                 REQUIRE(result.proof.expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
                                 result.proof.revocation_tag.data,
@@ -226,8 +226,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             }
 
             // After freeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
-            REQUIRE(result.header.error.data == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
+            REQUIRE(result.header.error == nullptr);
             REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
 
             // Invalid JSON
@@ -237,19 +237,19 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_pro_proof_response_free(&result); }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error_code.data != nullptr);
-                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
             }
 
             // After freeing
             session_pro_backend_pro_proof_response_free(&result);
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
 
             // Null JSON
             result = session_pro_backend_pro_proof_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-            REQUIRE(result.header.error_code.data != nullptr);
-            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
 
             // No need to free, as errors point to static memory
         }
@@ -278,11 +278,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
-                if (result.header.error.data)
-                    INFO(result.header.error.data);
+                if (result.header.error)
+                    INFO(result.header.error);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error.data == nullptr);
+                REQUIRE(result.header.error == nullptr);
                 REQUIRE(result.ticket == 123);
                 REQUIRE(result.retry_in == 3600);
                 REQUIRE(result.retain_for == 2592000);
@@ -290,13 +290,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items != nullptr);
                 REQUIRE(result.items[0].effective_ts == unix_ts);
                 REQUIRE(std::memcmp(
-                                result.items[0].revocation_tag.data,
+                                result.items[0].revocation_tag,
                                 fake_revocation_tag.data(),
                                 fake_revocation_tag.size()) == 0);
             }
 
             // After freeeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
             REQUIRE(result.items == nullptr);
             REQUIRE(result.items_count == 0);
 
@@ -308,18 +308,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error_code.data != nullptr);
-                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
             }
 
             // After freeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
 
             // Null JSON
             result = session_pro_backend_get_pro_revocations_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-            REQUIRE(result.header.error_code.data != nullptr);
-            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
         }
 
         SECTION("session_pro_backend_get_pro_details_response_parse") {
@@ -360,13 +360,13 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
-                if (result.header.error.data)
-                    INFO(result.header.error.data);
+                if (result.header.error)
+                    INFO(result.header.error);
 
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error.data == nullptr);
-                REQUIRE(std::string_view(result.status, result.status_count) == "expired");
+                REQUIRE(result.header.error == nullptr);
+                REQUIRE(std::string_view(result.status) == "expired");
                 REQUIRE(result.error_report ==
                         SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR);
                 REQUIRE(result.items_count == 1);
@@ -376,13 +376,10 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.refund_requested_ts == unix_ts + 3602);
                 REQUIRE(result.payments_total == 3);
                 REQUIRE(result.items != nullptr);
-                REQUIRE(std::string_view(result.items[0].status, result.items[0].status_count) ==
-                        "redeemed");
+                REQUIRE(std::string_view(result.items[0].status) == "redeemed");
                 REQUIRE(result.items[0].plan_count == 1);
                 REQUIRE(result.items[0].plan_unit == SESSION_PRO_BACKEND_PLAN_UNIT_MONTH);
-                REQUIRE(std::string_view(
-                                result.items[0].payment_provider,
-                                result.items[0].payment_provider_count) ==
+                REQUIRE(std::string_view(result.items[0].payment_provider) ==
                         SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY);
                 // Sub-second precision preserved through sys_ms (0.5s = 500ms) round-trips exactly
                 REQUIRE(result.items[0].purchased_ts == unix_ts - 3600 + 0.5);
@@ -392,11 +389,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
                 REQUIRE(result.items[0].revoked_ts == unix_ts + 3600 + 0.75);  // 750ms preserved
                 REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
-                REQUIRE(result.items[0].payment_id_count == fake_payment_id.size());
-                REQUIRE(std::memcmp(
-                                result.items[0].payment_id,
-                                fake_payment_id.data(),
-                                fake_payment_id.size()) == 0);
+                REQUIRE(std::string_view(result.items[0].payment_id) == fake_payment_id);
             }
 
             // Tweak JSON for a different provider. payment_id is opaque so nothing
@@ -413,22 +406,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{[&]() {
                     session_pro_backend_get_pro_details_response_free(&result_rangeproof);
                 }};
-                if (result_rangeproof.header.error.data)
-                    INFO(result_rangeproof.header.error.data);
+                if (result_rangeproof.header.error)
+                    INFO(result_rangeproof.header.error);
 
                 // Only check what we expect to be different
-                REQUIRE(std::string_view(
-                                result_rangeproof.items[0].payment_provider,
-                                result_rangeproof.items[0].payment_provider_count) ==
+                REQUIRE(std::string_view(result_rangeproof.items[0].payment_provider) ==
                         SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF);
-                REQUIRE(std::string_view(
-                                result_rangeproof.items[0].payment_id,
-                                result_rangeproof.items[0].payment_id_count) ==
+                REQUIRE(std::string_view(result_rangeproof.items[0].payment_id) ==
                         "rangeproof-opaque-id");
             }
 
             // After freeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
             REQUIRE(result.items == nullptr);
             REQUIRE(result.items_count == 0);
 
@@ -439,19 +428,19 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error_code.data != nullptr);
-                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
             }
 
             // After freeing
             session_pro_backend_get_pro_details_response_free(&result);
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
 
             // Null JSON
             result = session_pro_backend_get_pro_details_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-            REQUIRE(result.header.error_code.data != nullptr);
-            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
         }
 
         SECTION("Memory management edge cases") {
@@ -463,15 +452,15 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             session_pro_backend_pro_proof_response proof_response = {};
             session_pro_backend_pro_proof_response_free(&proof_response);
-            REQUIRE(proof_response.header.internal_arena_buf_ == nullptr);
+            REQUIRE(proof_response.header.internal_ == nullptr);
 
             session_pro_backend_get_pro_revocations_response rev_response = {};
             session_pro_backend_get_pro_revocations_response_free(&rev_response);
-            REQUIRE(rev_response.header.internal_arena_buf_ == nullptr);
+            REQUIRE(rev_response.header.internal_ == nullptr);
 
             session_pro_backend_get_pro_details_response pay_response = {};
             session_pro_backend_get_pro_details_response_free(&pay_response);
-            REQUIRE(pay_response.header.internal_arena_buf_ == nullptr);
+            REQUIRE(pay_response.header.internal_ == nullptr);
         }
 
         SECTION("session_pro_backend_set_payment_refund_requested_request_build") {
@@ -526,16 +515,16 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{[&]() {
                     session_pro_backend_set_payment_refund_requested_response_free(&result);
                 }};
-                if (result.header.error.data)
-                    INFO(result.header.error.data);
+                if (result.header.error)
+                    INFO(result.header.error);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error.data == nullptr);
+                REQUIRE(result.header.error == nullptr);
                 REQUIRE(result.updated);
             }
 
             // After freeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
 
             // Invalid JSON
             json = "{invalid}";
@@ -546,18 +535,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     session_pro_backend_set_payment_refund_requested_response_free(&result);
                 }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.error_code.data != nullptr);
-                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
+                REQUIRE(result.header.error_code != nullptr);
             }
 
             // After freeing
-            REQUIRE(result.header.internal_arena_buf_ == nullptr);
+            REQUIRE(result.header.internal_ == nullptr);
 
             // Null JSON
             result = session_pro_backend_set_payment_refund_requested_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-            REQUIRE(result.header.error_code.data != nullptr);
-            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
+            REQUIRE(result.header.error_code != nullptr);
         }
     }
 }
@@ -736,8 +725,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         response_json.data(), response_json.size());
         scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
-        if (response.header.error.data)
-            INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            INFO("ERROR: " << response.header.error);
 
         // Verify response
         first_pro_proof = response.proof;
@@ -780,8 +769,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error.data)
-            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
 
@@ -820,11 +809,11 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error.data)
-            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(std::string_view(response.status, response.status_count) == "active");
+        REQUIRE(std::string_view(response.status) == "active");
         REQUIRE(response.items_count > 0);
     }
 
@@ -853,11 +842,11 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error.data)
-            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(std::string_view(response.status, response.status_count) == "active");
+        REQUIRE(std::string_view(response.status) == "active");
         REQUIRE(response.items_count == 0);
     }
 
@@ -929,8 +918,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
         // Verify response
         INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error.data)
-            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.ticket == 0);
@@ -969,8 +958,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
         // Verify response
         INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error.data)
-            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        if (response.header.error)
+            UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.updated);

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -36,8 +36,11 @@ static bool string8_equals(string8 s8, std::string_view str) {
 [[maybe_unused]] static void dump_pro_payment_item(
         const session_pro_backend_pro_payment_item& item) {
     fprintf(stderr, "item.status: %d\n", item.status);
-    fprintf(stderr, "item.plan: %d\n", item.plan);
-    fprintf(stderr, "item.payment_provider: %d\n", item.payment_provider);
+    fprintf(stderr, "item.plan: %.*s\n", (int)item.plan_count, item.plan);
+    fprintf(stderr,
+            "item.payment_provider: %.*s\n",
+            (int)item.payment_provider_count,
+            item.payment_provider);
     fprintf(stderr, "item.auto_renewing: %d\n", item.auto_renewing);
     fprintf(stderr, "item.unredeemed_ts: %" PRId64 "zu\n", item.unredeemed_ts);
     fprintf(stderr, "item.redeemed_ts: %" PRId64 "zu\n", item.redeemed_ts);
@@ -47,23 +50,7 @@ static bool string8_equals(string8 s8, std::string_view str) {
             "item.platform_refund_expiry_ts: %" PRId64 "zu\n",
             item.platform_refund_expiry_ts);
     fprintf(stderr, "item.revoked_ts: %" PRId64 "zu\n", item.revoked_ts);
-    fprintf(stderr,
-            "item.google_payment_token: %.*s\n",
-            (int)item.google_payment_token_count,
-            item.google_payment_token);
-    fprintf(stderr,
-            "item.apple_original_tx_id: %.*s\n",
-            (int)item.apple_original_tx_id_count,
-            item.apple_original_tx_id);
-    fprintf(stderr, "item.apple_tx_id: %.*s\n", (int)item.apple_tx_id_count, item.apple_tx_id);
-    fprintf(stderr,
-            "item.apple_web_line_order_id: %.*s\n",
-            (int)item.apple_web_line_order_id_count,
-            item.apple_web_line_order_id);
-    fprintf(stderr,
-            "item.rangeproof_order_id: %.*s\n",
-            (int)item.rangeproof_order_id_count,
-            item.rangeproof_order_id);
+    fprintf(stderr, "item.payment_id: %.*s\n", (int)item.payment_id_count, item.payment_id);
 }
 
 [[maybe_unused]] static void dump_pro_revocation(
@@ -87,23 +74,22 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
     {
         std::array<uint8_t, 8> fake_google_payment_token;
         randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
-        std::string fake_google_payment_token_hex =
-                "DEV." + oxenc::to_hex(fake_google_payment_token);
-
         std::array<uint8_t, 8> fake_google_order_id;
         randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        std::string fake_google_order_id_hex = "DEV." + oxenc::to_hex(fake_google_order_id);
+        // Google's composite payment_id is "<payment_token>|<order_id>"; libsession treats the
+        // whole thing as one opaque value.
+        std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
+                                      oxenc::to_hex(fake_google_order_id);
 
         session_pro_backend_add_pro_payment_user_transaction payment_tx = {};
-        payment_tx.provider = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE;
-        payment_tx.payment_id_count = fake_google_payment_token_hex.size();
-        payment_tx.order_id_count = fake_google_order_id_hex.size();
+        payment_tx.provider_code_count =
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
         std::memcpy(
-                payment_tx.payment_id,
-                fake_google_payment_token_hex.data(),
-                payment_tx.payment_id_count);
-        std::memcpy(
-                payment_tx.order_id, fake_google_order_id_hex.data(), payment_tx.order_id_count);
+                payment_tx.provider_code,
+                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
+        payment_tx.payment_id_count = fake_payment_id.size();
+        std::memcpy(payment_tx.payment_id, fake_payment_id.data(), payment_tx.payment_id_count);
 
         int64_t unix_ts = 1698765432;  // Arbitrary timestamp (unix epoch seconds)
 
@@ -116,11 +102,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
                             sizeof(rotating_privkey.data),
-                            payment_tx.provider,
+                            payment_tx.provider_code,
                             reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count,
-                            reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                            payment_tx.order_id_count);
+                            payment_tx.payment_id_count);
             INFO(result.error);
             REQUIRE(result.success);
             REQUIRE(result.error_count == 0);
@@ -130,13 +114,10 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     0,
                     master_privkey.data,
                     rotating_privkey.data,
-                    payment_tx.provider,
+                    payment_tx.provider_code,
                     std::span<const uint8_t>(
                             reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count),
-                    std::span<const uint8_t>(
-                            reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                            payment_tx.order_id_count));
+                            payment_tx.payment_id_count));
 
             REQUIRE(std::memcmp(
                             result.master_sig.data,
@@ -154,11 +135,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     sizeof(master_privkey.data) - 1,
                     rotating_privkey.data,
                     sizeof(rotating_privkey.data),
-                    payment_tx.provider,
+                    payment_tx.provider_code,
                     reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                    payment_tx.payment_id_count,
-                    reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                    payment_tx.order_id_count);
+                    payment_tx.payment_id_count);
             REQUIRE(!result.success);
             REQUIRE(result.error_count > 0);
         }
@@ -218,11 +197,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                             sizeof(master_privkey.data),
                             rotating_privkey.data,
                             sizeof(rotating_privkey.data),
-                            payment_tx.provider,
+                            payment_tx.provider_code,
                             reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count,
-                            reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                            payment_tx.order_id_count);
+                            payment_tx.payment_id_count);
 
             request.master_sig = sigs.master_sig;
             request.rotating_sig = sigs.rotating_sig;
@@ -246,11 +223,10 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         cpp.rotating_pkey.data(),
                         rotating_pubkey.data,
                         sizeof(rotating_pubkey.data));
-                cpp.payment_tx.provider = payment_tx.provider;
+                cpp.payment_tx.provider_code =
+                        std::string(payment_tx.provider_code, payment_tx.provider_code_count);
                 cpp.payment_tx.payment_id =
                         std::string(payment_tx.payment_id, payment_tx.payment_id_count);
-                cpp.payment_tx.order_id =
-                        std::string(payment_tx.order_id, payment_tx.order_id_count);
                 std::memcpy(
                         cpp.master_sig.data(), sigs.master_sig.data, sizeof(sigs.master_sig.data));
                 std::memcpy(
@@ -267,11 +243,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        request.payment_tx.provider,
+                        request.payment_tx.provider_code,
                         reinterpret_cast<const unsigned char*>(request.payment_tx.payment_id),
-                        request.payment_tx.payment_id_count,
-                        reinterpret_cast<const unsigned char*>(request.payment_tx.order_id),
-                        request.payment_tx.order_id_count);
+                        request.payment_tx.payment_id_count);
                 REQUIRE(one_shot.success);
                 REQUIRE(one_shot.json.size == result.json.size);
                 INFO("One shot: " << one_shot.json.data << "\n\nJSON: " << result.json.data);
@@ -634,9 +608,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     {"items",
                      nlohmann::json::array(
                              {{{"status", SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED},
-                               {"plan", SESSION_PRO_BACKEND_PLAN_ONE_MONTH},
+                               {"plan", "1m"},
                                {"payment_provider",
-                                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE},
+                                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY},
                                {"auto_renewing", false},
                                {"unredeemed_ts", unix_ts - 3600},
                                {"redeemed_ts", unix_ts - 3600},
@@ -645,10 +619,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                                {"platform_refund_expiry_ts", unix_ts + 1},
                                {"revoked_ts", unix_ts + 3600},
                                {"refund_requested_ts", unix_ts + 3601},
-                               {"google_payment_token",
-                                std::string(payment_tx.payment_id, payment_tx.payment_id_count)},
-                               {"google_order_id",
-                                std::string(payment_tx.order_id, payment_tx.order_id_count)}}})}};
+                               {"payment_id",
+                                std::string(
+                                        payment_tx.payment_id, payment_tx.payment_id_count)}}})}};
             std::string json = j.dump();
 
             // Valid Google JSON
@@ -674,9 +647,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.payments_total == 3);
                 REQUIRE(result.items != nullptr);
                 REQUIRE(result.items[0].status == SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED);
-                REQUIRE(result.items[0].plan == SESSION_PRO_BACKEND_PLAN_ONE_MONTH);
-                REQUIRE(result.items[0].payment_provider ==
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE);
+                REQUIRE(std::string_view(result.items[0].plan, result.items[0].plan_count) == "1m");
+                REQUIRE(std::string_view(
+                                result.items[0].payment_provider,
+                                result.items[0].payment_provider_count) ==
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY);
                 REQUIRE(result.items[0].unredeemed_ts == unix_ts - 3600);
                 REQUIRE(result.items[0].redeemed_ts == unix_ts - 3600);
                 REQUIRE(result.items[0].expiry_ts == unix_ts);
@@ -684,25 +659,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
                 REQUIRE(result.items[0].revoked_ts == unix_ts + 3600);
                 REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
-                REQUIRE(result.items[0].google_payment_token_count == payment_tx.payment_id_count);
+                REQUIRE(result.items[0].payment_id_count == payment_tx.payment_id_count);
                 REQUIRE(std::memcmp(
-                                result.items[0].google_payment_token,
+                                result.items[0].payment_id,
                                 payment_tx.payment_id,
                                 payment_tx.payment_id_count) == 0);
-                REQUIRE(result.items[0].google_order_id_count == payment_tx.order_id_count);
-                REQUIRE(std::memcmp(
-                                result.items[0].google_order_id,
-                                payment_tx.order_id,
-                                payment_tx.order_id_count) == 0);
             }
 
-            // Tweak JSON for Rangeproof
+            // Tweak JSON for a different provider. payment_id is opaque so nothing
+            // provider-specific changes in how libsession parses it.
             j["result"]["items"][0]["payment_provider"] =
-                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_RANGEPROOF;
-            j["result"]["items"][0].erase("google_payment_token");
-            j["result"]["items"][0].erase("google_order_id");
-            j["result"]["items"][0]["rangeproof_order_id"] =
-                    std::string(payment_tx.order_id, payment_tx.order_id_count);
+                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF;
+            j["result"]["items"][0]["payment_id"] = "rangeproof-opaque-id";
             json = j.dump();
 
             // Valid Rangeproof JSON
@@ -716,12 +684,14 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     INFO(result_rangeproof.header.errors[index].data);
 
                 // Only check what we expect to be different
-                REQUIRE(result_rangeproof.items[0].rangeproof_order_id_count ==
-                        payment_tx.order_id_count);
-                REQUIRE(std::memcmp(
-                                result_rangeproof.items[0].rangeproof_order_id,
-                                payment_tx.order_id,
-                                payment_tx.order_id_count) == 0);
+                REQUIRE(std::string_view(
+                                result_rangeproof.items[0].payment_provider,
+                                result_rangeproof.items[0].payment_provider_count) ==
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF);
+                REQUIRE(std::string_view(
+                                result_rangeproof.items[0].payment_id,
+                                result_rangeproof.items[0].payment_id_count) ==
+                        "rangeproof-opaque-id");
             }
 
             // After freeing
@@ -786,11 +756,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                             sizeof(master_privkey.data),
                             request.ts,
                             request.refund_requested_ts,
-                            payment_tx.provider,
+                            payment_tx.provider_code,
                             reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                            payment_tx.payment_id_count,
-                            reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                            payment_tx.order_id_count);
+                            payment_tx.payment_id_count);
             request.master_sig = sig.sig;
             REQUIRE(sig.success);
 
@@ -948,23 +916,22 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     {
         std::array<uint8_t, 8> fake_google_payment_token;
         randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
-        std::string fake_google_payment_token_hex =
-                "DEV." + oxenc::to_hex(fake_google_payment_token);
-
         std::array<uint8_t, 8> fake_google_order_id;
         randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        std::string fake_google_order_id_hex = "DEV." + oxenc::to_hex(fake_google_order_id);
+        // Google's composite payment_id is "<payment_token>|<order_id>"; libsession treats the
+        // whole thing as one opaque value.
+        std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
+                                      oxenc::to_hex(fake_google_order_id);
 
         session_pro_backend_add_pro_payment_user_transaction payment_tx = {};
-        payment_tx.provider = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE;
-        payment_tx.payment_id_count = fake_google_payment_token_hex.size();
-        payment_tx.order_id_count = fake_google_order_id_hex.size();
+        payment_tx.provider_code_count =
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
         std::memcpy(
-                payment_tx.payment_id,
-                fake_google_payment_token_hex.data(),
-                payment_tx.payment_id_count);
-        std::memcpy(
-                payment_tx.order_id, fake_google_order_id_hex.data(), payment_tx.order_id_count);
+                payment_tx.provider_code,
+                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
+        payment_tx.payment_id_count = fake_payment_id.size();
+        std::memcpy(payment_tx.payment_id, fake_payment_id.data(), payment_tx.payment_id_count);
 
         // Build request
         session_pro_backend_master_rotating_signatures add_pro_sigs =
@@ -974,11 +941,9 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        payment_tx.provider,
+                        payment_tx.provider_code,
                         reinterpret_cast<const uint8_t*>(payment_tx.payment_id),
-                        payment_tx.payment_id_count,
-                        reinterpret_cast<const uint8_t*>(payment_tx.order_id),
-                        payment_tx.order_id_count);
+                        payment_tx.payment_id_count);
 
         session_pro_backend_add_pro_payment_request request = {};
         request.version = 0;
@@ -1191,24 +1156,22 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
     {
         std::array<uint8_t, 8> fake_google_payment_token;
         randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
-        std::string fake_google_payment_token_hex =
-                "DEV." + oxenc::to_hex(fake_google_payment_token);
-
         std::array<uint8_t, 8> fake_google_order_id;
         randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        std::string fake_google_order_id_hex = "DEV." + oxenc::to_hex(fake_google_order_id);
+        std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
+                                      oxenc::to_hex(fake_google_order_id);
 
-        another_payment_tx.provider = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_GOOGLE_PLAY_STORE;
-        another_payment_tx.payment_id_count = fake_google_payment_token_hex.size();
-        another_payment_tx.order_id_count = fake_google_order_id_hex.size();
+        another_payment_tx.provider_code_count =
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY) - 1;
+        std::memcpy(
+                another_payment_tx.provider_code,
+                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
+                sizeof(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
+        another_payment_tx.payment_id_count = fake_payment_id.size();
         std::memcpy(
                 another_payment_tx.payment_id,
-                fake_google_payment_token_hex.data(),
+                fake_payment_id.data(),
                 another_payment_tx.payment_id_count);
-        std::memcpy(
-                another_payment_tx.order_id,
-                fake_google_order_id_hex.data(),
-                another_payment_tx.order_id_count);
 
         // Build request
         session_pro_backend_master_rotating_signatures add_pro_sigs =
@@ -1218,11 +1181,9 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(master_privkey.data),
                         rotating_privkey.data,
                         sizeof(rotating_privkey.data),
-                        another_payment_tx.provider,
+                        another_payment_tx.provider_code,
                         reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
-                        another_payment_tx.payment_id_count,
-                        reinterpret_cast<const uint8_t*>(another_payment_tx.order_id),
-                        another_payment_tx.order_id_count);
+                        another_payment_tx.payment_id_count);
 
         session_pro_backend_add_pro_payment_request request = {};
         request.version = 0;
@@ -1310,11 +1271,9 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(master_privkey.data),
                         /*ts*/ now_unix_ts,
                         /*refund_requested_ts*/ now_unix_ts,
-                        another_payment_tx.provider,
+                        another_payment_tx.provider_code,
                         reinterpret_cast<const uint8_t*>(another_payment_tx.payment_id),
-                        another_payment_tx.payment_id_count,
-                        reinterpret_cast<const uint8_t*>(another_payment_tx.order_id),
-                        another_payment_tx.order_id_count);
+                        another_payment_tx.payment_id_count);
 
         scope_exit request_json_free{[&]() { session_pro_backend_to_json_free(&request_json); }};
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -462,7 +462,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             nlohmann::json j;
             j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
             j["result"] = {
-                    {"status", SESSION_PRO_BACKEND_USER_PRO_STATUS_EXPIRED},
+                    {"status", "expired"},
                     {"error_report",
                      SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR},
                     {"auto_renewing", true},
@@ -472,7 +472,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     {"payments_total", 3},
                     {"items",
                      nlohmann::json::array(
-                             {{{"status", SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED},
+                             {{{"status", "redeemed"},
                                {"plan", "1m"},
                                {"payment_provider",
                                 SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY},
@@ -503,7 +503,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
-                REQUIRE(result.status == SESSION_PRO_BACKEND_USER_PRO_STATUS_EXPIRED);
+                REQUIRE(std::string_view(result.status, result.status_count) == "expired");
                 REQUIRE(result.error_report ==
                         SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR);
                 REQUIRE(result.items_count == 1);
@@ -513,7 +513,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.refund_requested_ts == unix_ts + 3602);
                 REQUIRE(result.payments_total == 3);
                 REQUIRE(result.items != nullptr);
-                REQUIRE(result.items[0].status == SESSION_PRO_BACKEND_PAYMENT_STATUS_REDEEMED);
+                REQUIRE(std::string_view(result.items[0].status, result.items[0].status_count) ==
+                        "redeemed");
                 REQUIRE(std::string_view(result.items[0].plan, result.items[0].plan_count) == "1m");
                 REQUIRE(std::string_view(
                                 result.items[0].payment_provider,
@@ -942,7 +943,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         }
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
-        REQUIRE(response.status == SESSION_PRO_BACKEND_USER_PRO_STATUS_ACTIVE);
+        REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count > 0);
     }
 
@@ -985,7 +986,7 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         // Verify the response
         REQUIRE(response.header.errors_count == 0);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_STATUS_SUCCESS);
-        REQUIRE(response.status == SESSION_PRO_BACKEND_USER_PRO_STATUS_ACTIVE);
+        REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count == 0);
     }
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -166,7 +166,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             randombytes_buf(fake_revocation_tag.data(), fake_revocation_tag.size());
 
             nlohmann::json j;
-            j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
+            j["status"] = "ok";
             j["result"] = {
                     {"version", 0},
                     {"expiry_ts", unix_ts},
@@ -183,11 +183,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{
                         [&]() { session_pro_backend_pro_proof_response_free(&result); }};
 
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    INFO(result.header.errors[index].data);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors == nullptr);
+                if (result.header.error.data)
+                    INFO(result.header.error.data);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error.data == nullptr);
                 REQUIRE(result.proof.expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
                                 result.proof.revocation_tag.data,
@@ -227,8 +227,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // After freeing
             REQUIRE(result.header.internal_arena_buf_ == nullptr);
-            REQUIRE(result.header.errors == nullptr);
-            REQUIRE(result.header.errors_count == 0);
+            REQUIRE(result.header.error.data == nullptr);
+            REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
 
             // Invalid JSON
             json = "{invalid}";
@@ -236,9 +236,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_pro_proof_response_free(&result); }};
-                REQUIRE(result.header.errors_count != 0);
-                REQUIRE(result.header.errors_count > 0);
-                REQUIRE(result.header.errors != nullptr);
+                REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code.data != nullptr);
             }
 
             // After freeing
@@ -247,16 +247,16 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_pro_proof_response_parse(nullptr, 0);
-            REQUIRE(result.header.errors_count != 0);
-            REQUIRE(result.header.errors_count == 1);
-            REQUIRE(result.header.errors != nullptr);
+            REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code.data != nullptr);
 
             // No need to free, as errors point to static memory
         }
 
         SECTION("session_pro_backend_get_pro_revocations_response_parse") {
             nlohmann::json j;
-            j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
+            j["status"] = "ok";
             j["result"]["ticket"] = 123;
             j["result"]["retry_in"] = 3600;
             j["result"]["retain_for"] = 2592000;
@@ -278,11 +278,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    INFO(result.header.errors[index].data);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors == nullptr);
+                if (result.header.error.data)
+                    INFO(result.header.error.data);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error.data == nullptr);
                 REQUIRE(result.ticket == 123);
                 REQUIRE(result.retry_in == 3600);
                 REQUIRE(result.retain_for == 2592000);
@@ -307,10 +307,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                         json.data(), json.size());
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_revocations_response_free(&result); }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    REQUIRE(result.header.errors_count != 0);
-                REQUIRE(result.header.errors_count > 0);
-                REQUIRE(result.header.errors != nullptr);
+                REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code.data != nullptr);
             }
 
             // After freeing
@@ -318,16 +317,16 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_get_pro_revocations_response_parse(nullptr, 0);
-            REQUIRE(result.header.errors_count != 0);
-            REQUIRE(result.header.errors_count == 1);
-            REQUIRE(result.header.errors != nullptr);
+            REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code.data != nullptr);
         }
 
         SECTION("session_pro_backend_get_pro_details_response_parse") {
             nlohmann::json j;
-            j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
+            j["status"] = "ok";
             j["result"] = {
-                    {"status", "expired"},
+                    {"user_status", "expired"},
                     {"error_report",
                      SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR},
                     {"auto_renewing", true},
@@ -361,12 +360,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    INFO(result.header.errors[index].data);
+                if (result.header.error.data)
+                    INFO(result.header.error.data);
 
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors == nullptr);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error.data == nullptr);
                 REQUIRE(std::string_view(result.status, result.status_count) == "expired");
                 REQUIRE(result.error_report ==
                         SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR);
@@ -413,8 +412,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{[&]() {
                     session_pro_backend_get_pro_details_response_free(&result_rangeproof);
                 }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    INFO(result_rangeproof.header.errors[index].data);
+                if (result_rangeproof.header.error.data)
+                    INFO(result_rangeproof.header.error.data);
 
                 // Only check what we expect to be different
                 REQUIRE(std::string_view(
@@ -438,9 +437,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             {
                 scope_exit result_free{
                         [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
-                REQUIRE(result.header.errors_count != 0);
-                REQUIRE(result.header.errors_count > 0);
-                REQUIRE(result.header.errors != nullptr);
+                REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code.data != nullptr);
             }
 
             // After freeing
@@ -449,9 +448,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_get_pro_details_response_parse(nullptr, 0);
-            REQUIRE(result.header.errors_count != 0);
-            REQUIRE(result.header.errors_count == 1);
-            REQUIRE(result.header.errors != nullptr);
+            REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code.data != nullptr);
         }
 
         SECTION("Memory management edge cases") {
@@ -515,7 +514,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
         SECTION("session_pro_backend_set_payment_refund_requested_response_parse") {
             nlohmann::json j;
-            j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
+            j["status"] = "ok";
             j["result"]["updated"] = true;
             std::string json = j.dump();
 
@@ -526,11 +525,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{[&]() {
                     session_pro_backend_set_payment_refund_requested_response_free(&result);
                 }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    INFO(result.header.errors[index].data);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors_count == 0);
-                REQUIRE(result.header.errors == nullptr);
+                if (result.header.error.data)
+                    INFO(result.header.error.data);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error.data == nullptr);
                 REQUIRE(result.updated);
             }
 
@@ -545,10 +544,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 scope_exit result_free{[&]() {
                     session_pro_backend_set_payment_refund_requested_response_free(&result);
                 }};
-                for (size_t index = 0; index < result.header.errors_count; index++)
-                    REQUIRE(result.header.errors_count != 0);
-                REQUIRE(result.header.errors_count > 0);
-                REQUIRE(result.header.errors != nullptr);
+                REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error_code.data != nullptr);
+                REQUIRE(result.header.error_code.data != nullptr);
             }
 
             // After freeing
@@ -556,9 +554,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Null JSON
             result = session_pro_backend_set_payment_refund_requested_response_parse(nullptr, 0);
-            REQUIRE(result.header.errors_count != 0);
-            REQUIRE(result.header.errors_count == 1);
-            REQUIRE(result.header.errors != nullptr);
+            REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+            REQUIRE(result.header.error_code.data != nullptr);
+            REQUIRE(result.header.error_code.data != nullptr);
         }
     }
 }
@@ -671,10 +669,8 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         response_json.data(), response_json.size());
         scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            INFO("ERROR: " << error.data);
-        }
+        if (response.header.error.data)
+            INFO("ERROR: " << response.header.error.data);
 
         // Verify response
         first_pro_proof = response.proof;
@@ -717,12 +713,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
         scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            UNSCOPED_INFO("ERROR: " << error.data);
-        }
-        REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.errors_count == 0);
+        if (response.header.error.data)
+            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
 
         // Verify response
         session_protocol_pro_proof proof = response.proof;
@@ -759,12 +753,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            UNSCOPED_INFO("ERROR: " << error.data);
-        }
-        REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.errors_count == 0);
+        if (response.header.error.data)
+            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count > 0);
     }
@@ -794,12 +786,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                 [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            UNSCOPED_INFO("ERROR: " << error.data);
-        }
-        REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.errors_count == 0);
+        if (response.header.error.data)
+            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(std::string_view(response.status, response.status_count) == "active");
         REQUIRE(response.items_count == 0);
     }
@@ -872,12 +862,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
         // Verify response
         INFO("ERROR: JSON response: " << response_json.c_str());
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            UNSCOPED_INFO("ERROR: " << error.data);
-        }
-        REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.errors_count == 0);
+        if (response.header.error.data)
+            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.ticket == 0);
         REQUIRE(response.items_count == 0);
     }
@@ -914,12 +902,10 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
 
         // Verify response
         INFO("ERROR: JSON response: " << response_json.c_str());
-        for (size_t index = 0; index < response.header.errors_count; index++) {
-            string8 error = response.header.errors[index];
-            UNSCOPED_INFO("ERROR: " << error.data);
-        }
-        REQUIRE(response.header.errors_count == 0);
-        REQUIRE(response.header.errors_count == 0);
+        if (response.header.error.data)
+            UNSCOPED_INFO("ERROR: " << response.header.error.data);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(response.updated);
     }
 }

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -68,7 +68,7 @@ static bool string8_equals(string8 s8, std::string_view str) {
 
 [[maybe_unused]] static void dump_pro_revocation(
         const session_pro_backend_pro_revocation_item& item) {
-    fprintf(stderr, "item.expiry_unix_ts: %" PRId64 "zu\n", item.expiry_ts);
+    fprintf(stderr, "item.effective_ts: %" PRId64 "\n", item.effective_ts);
     fprintf(stderr,
             "item.revocation_tag: %s\n",
             oxenc::to_hex(item.revocation_tag.data, std::end(item.revocation_tag.data)).c_str());
@@ -554,13 +554,15 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             nlohmann::json j;
             j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
             j["result"]["ticket"] = 123;
+            j["result"]["retry_in"] = 3600;
+            j["result"]["retain_for"] = 2592000;
             j["result"]["items"] = nlohmann::json::array();
 
             std::array<uint8_t, 32> fake_revocation_tag;
             randombytes_buf(fake_revocation_tag.data(), fake_revocation_tag.size());
 
             auto obj = nlohmann::json::object();
-            obj["expiry_ts"] = unix_ts;
+            obj["effective_ts"] = unix_ts;
             obj["revocation_tag"] = oxenc::to_hex(fake_revocation_tag);
             j["result"]["items"].push_back(obj);
 
@@ -578,9 +580,11 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.header.errors_count == 0);
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.ticket == 123);
+                REQUIRE(result.retry_in == 3600);
+                REQUIRE(result.retain_for == 2592000);
                 REQUIRE(result.items_count == 1);
                 REQUIRE(result.items != nullptr);
-                REQUIRE(result.items[0].expiry_ts == unix_ts);
+                REQUIRE(result.items[0].effective_ts == unix_ts);
                 REQUIRE(std::memcmp(
                                 result.items[0].revocation_tag.data,
                                 fake_revocation_tag.data(),

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -138,25 +138,56 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.data.data == nullptr);
         }
 
-        SECTION("session_pro_backend_get_pro_details_request_build") {
-            auto result = session_pro_backend_get_pro_details_request_build(
-                    master_privkey.data, sizeof(master_privkey.data), unix_ts, 10'000);
+        SECTION("session_pro_backend_get_pro_status_request_build") {
+            auto result = session_pro_backend_get_pro_status_request_build(
+                    master_privkey.data, sizeof(master_privkey.data), unix_ts);
+            {
+                scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
+                REQUIRE(result.success);
+                REQUIRE(result.data.size > 0);
+
+                auto cpp =
+                        pro_status_request(master_privkey.data, session::as_sys_seconds(unix_ts));
+                REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_STATUS_ENDPOINT);
+                REQUIRE(span_u8_equals(result.data, cpp.data));
+            }
+            REQUIRE(result.data.data == nullptr);
+
+            // Invalid key size
+            result = session_pro_backend_get_pro_status_request_build(
+                    master_privkey.data, sizeof(master_privkey.data) - 1, unix_ts);
+            REQUIRE(!result.success);
+            REQUIRE(result.error_count > 0);
+        }
+
+        SECTION("session_pro_backend_get_payment_details_request_build") {
+            auto result = session_pro_backend_get_payment_details_request_build(
+                    master_privkey.data, sizeof(master_privkey.data), unix_ts, 100, "");
             {
                 scope_exit result_free{[&]() { session_pro_backend_request_free(&result); }};
                 REQUIRE(result.success);
                 REQUIRE(result.data.size > 0);
 
                 auto cpp = payment_details_request(
-                        master_privkey.data, session::as_sys_seconds(unix_ts), 10'000);
+                        master_privkey.data, session::as_sys_seconds(unix_ts), 100, "");
                 REQUIRE(std::string_view(result.endpoint) == cpp.endpoint);
-                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PRO_DETAILS_ENDPOINT);
+                REQUIRE(cpp.endpoint == SESSION_PRO_BACKEND_GET_PAYMENT_DETAILS_ENDPOINT);
                 REQUIRE(span_u8_equals(result.data, cpp.data));
+
+                // A NULL cursor is equivalent to the empty (newest-page) cursor.
+                auto result_null = session_pro_backend_get_payment_details_request_build(
+                        master_privkey.data, sizeof(master_privkey.data), unix_ts, 100, nullptr);
+                scope_exit result_null_free{
+                        [&]() { session_pro_backend_request_free(&result_null); }};
+                REQUIRE(result_null.success);
+                REQUIRE(span_u8_equals(result_null.data, cpp.data));
             }
             REQUIRE(result.data.data == nullptr);
 
             // Invalid key size
-            result = session_pro_backend_get_pro_details_request_build(
-                    master_privkey.data, sizeof(master_privkey.data) - 1, unix_ts, 10'000);
+            result = session_pro_backend_get_payment_details_request_build(
+                    master_privkey.data, sizeof(master_privkey.data) - 1, unix_ts, 100, "");
             REQUIRE(!result.success);
             REQUIRE(result.error_count > 0);
         }
@@ -322,98 +353,164 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             REQUIRE(result.header.error_code != nullptr);
         }
 
-        SECTION("session_pro_backend_get_pro_details_response_parse") {
+        // A single payment item (shared by the get-pro-status latest_payment and the
+        // get-payment-details items[] tests). purchased_ts/revoked_ts are floats on the wire
+        // (sub-second precision); the rest are whole-second integers.
+        auto make_payment_item = [&](std::string payment_id) {
+            return nlohmann::json{
+                    {"status", "redeemed"},
+                    {"plan", "1m"},
+                    {"payment_provider", SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY},
+                    {"auto_renewing", false},
+                    {"purchased_ts", unix_ts - 3600 + 0.5},
+                    {"redeemed_ts", unix_ts - 3600},
+                    {"expiry_ts", unix_ts},
+                    {"grace_period_duration", 1001},
+                    {"platform_refund_expiry_ts", unix_ts + 1},
+                    {"revoked_ts", unix_ts + 3600 + 0.75},
+                    {"refund_requested_ts", unix_ts + 3601},
+                    {"payment_id", std::move(payment_id)}};
+        };
+        auto check_payment_item = [&](const session_pro_backend_pro_payment_item& item,
+                                      std::string_view payment_id) {
+            REQUIRE(std::string_view(item.status) == "redeemed");
+            REQUIRE(item.plan_count == 1);
+            REQUIRE(item.plan_unit == SESSION_PRO_BACKEND_PLAN_UNIT_MONTH);
+            REQUIRE(std::string_view(item.payment_provider) ==
+                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY);
+            // Sub-second precision preserved through sys_ms (0.5s = 500ms) round-trips exactly
+            REQUIRE(item.purchased_ts == unix_ts - 3600 + 0.5);
+            REQUIRE(item.redeemed_ts == unix_ts - 3600);
+            REQUIRE(item.expiry_ts == unix_ts);
+            REQUIRE(item.grace_period_duration == 1001);
+            REQUIRE(item.platform_refund_expiry_ts == unix_ts + 1);
+            REQUIRE(item.revoked_ts == unix_ts + 3600 + 0.75);  // 750ms preserved
+            REQUIRE(item.refund_requested_ts == unix_ts + 3601);
+            REQUIRE(std::string_view(item.payment_id) == payment_id);
+        };
+
+        SECTION("session_pro_backend_get_pro_status_response_parse") {
             nlohmann::json j;
             j["status"] = "ok";
             j["result"] = {
                     {"user_status", "expired"},
-                    {"error_report",
-                     SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR},
+                    {"error_report", SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR},
                     {"auto_renewing", true},
                     {"expiry_ts", unix_ts + 2},
                     {"grace_period_duration", 1000},
                     {"refund_requested_ts", unix_ts + 3602},
-                    {"payments_total", 3},
-                    {"items",
-                     nlohmann::json::array(
-                             {{{"status", "redeemed"},
-                               {"plan", "1m"},
-                               {"payment_provider",
-                                SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY},
-                               {"auto_renewing", false},
-                               // purchased_ts/revoked_ts are floats on the wire (sub-second
-                               // precision); libsession truncates to whole seconds.
-                               {"purchased_ts", unix_ts - 3600 + 0.5},
-                               {"redeemed_ts", unix_ts - 3600},
-                               {"expiry_ts", unix_ts},
-                               {"grace_period_duration", 1001},
-                               {"platform_refund_expiry_ts", unix_ts + 1},
-                               {"revoked_ts", unix_ts + 3600 + 0.75},
-                               {"refund_requested_ts", unix_ts + 3601},
-                               {"payment_id",
-                                std::string(fake_payment_id.data(), fake_payment_id.size())}}})}};
+                    {"latest_payment",
+                     make_payment_item(
+                             std::string(fake_payment_id.data(), fake_payment_id.size()))}};
             std::string json = j.dump();
 
-            // Valid Google JSON
+            // Valid response with a latest payment
             auto result =
-                    session_pro_backend_get_pro_details_response_parse(json.data(), json.size());
+                    session_pro_backend_get_pro_status_response_parse(json.data(), json.size());
             {
                 scope_exit result_free{
-                        [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
+                        [&]() { session_pro_backend_get_pro_status_response_free(&result); }};
                 if (result.header.error)
                     INFO(result.header.error);
 
                 REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.error == nullptr);
                 REQUIRE(std::string_view(result.status) == "expired");
                 REQUIRE(result.error_report ==
-                        SESSION_PRO_BACKEND_GET_PRO_DETAILS_ERROR_REPORT_GENERIC_ERROR);
-                REQUIRE(result.items_count == 1);
+                        SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR);
                 REQUIRE(result.auto_renewing == true);
                 REQUIRE(result.grace_period_duration == 1000);
                 REQUIRE(result.expiry_ts == unix_ts + 2);
                 REQUIRE(result.refund_requested_ts == unix_ts + 3602);
-                REQUIRE(result.payments_total == 3);
-                REQUIRE(result.items != nullptr);
-                REQUIRE(std::string_view(result.items[0].status) == "redeemed");
-                REQUIRE(result.items[0].plan_count == 1);
-                REQUIRE(result.items[0].plan_unit == SESSION_PRO_BACKEND_PLAN_UNIT_MONTH);
-                REQUIRE(std::string_view(result.items[0].payment_provider) ==
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY);
-                // Sub-second precision preserved through sys_ms (0.5s = 500ms) round-trips exactly
-                REQUIRE(result.items[0].purchased_ts == unix_ts - 3600 + 0.5);
-                REQUIRE(result.items[0].redeemed_ts == unix_ts - 3600);
-                REQUIRE(result.items[0].expiry_ts == unix_ts);
-                REQUIRE(result.items[0].grace_period_duration == 1001);
-                REQUIRE(result.items[0].platform_refund_expiry_ts == unix_ts + 1);
-                REQUIRE(result.items[0].revoked_ts == unix_ts + 3600 + 0.75);  // 750ms preserved
-                REQUIRE(result.items[0].refund_requested_ts == unix_ts + 3601);
-                REQUIRE(std::string_view(result.items[0].payment_id) == fake_payment_id);
+                REQUIRE(result.has_latest_payment);
+                check_payment_item(result.latest_payment, fake_payment_id);
             }
 
-            // Tweak JSON for a different provider. payment_id is opaque so nothing
-            // provider-specific changes in how libsession parses it.
+            // A null latest_payment (account with no payments)
+            j["result"]["latest_payment"] = nullptr;
+            json = j.dump();
+            auto result_empty =
+                    session_pro_backend_get_pro_status_response_parse(json.data(), json.size());
+            {
+                scope_exit result_free{
+                        [&]() { session_pro_backend_get_pro_status_response_free(&result_empty); }};
+                if (result_empty.header.error)
+                    INFO(result_empty.header.error);
+                REQUIRE(result_empty.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result_empty.has_latest_payment == false);
+            }
+
+            // After freeing
+            REQUIRE(result.header.internal_ == nullptr);
+
+            // Invalid JSON
+            json = "{invalid}";
+            result = session_pro_backend_get_pro_status_response_parse(json.data(), json.size());
+            {
+                scope_exit result_free{
+                        [&]() { session_pro_backend_get_pro_status_response_free(&result); }};
+                REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error_code != nullptr);
+            }
+            session_pro_backend_get_pro_status_response_free(&result);
+            REQUIRE(result.header.internal_ == nullptr);
+
+            // Null JSON
+            result = session_pro_backend_get_pro_status_response_parse(nullptr, 0);
+            REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+            REQUIRE(result.header.error_code != nullptr);
+        }
+
+        SECTION("session_pro_backend_get_payment_details_response_parse") {
+            nlohmann::json j;
+            j["status"] = "ok";
+            j["result"] = {
+                    {"payments_total", 3},
+                    {"items",
+                     nlohmann::json::array({make_payment_item(
+                             std::string(fake_payment_id.data(), fake_payment_id.size()))})},
+                    {"next_cursor", "opaque-cursor-token"}};
+            std::string json = j.dump();
+
+            // Valid page with a cursor
+            auto result = session_pro_backend_get_payment_details_response_parse(
+                    json.data(), json.size());
+            {
+                scope_exit result_free{
+                        [&]() { session_pro_backend_get_payment_details_response_free(&result); }};
+                if (result.header.error)
+                    INFO(result.header.error);
+
+                REQUIRE(result.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(result.header.error == nullptr);
+                REQUIRE(result.payments_total == 3);
+                REQUIRE(result.items_count == 1);
+                REQUIRE(result.items != nullptr);
+                check_payment_item(result.items[0], fake_payment_id);
+                REQUIRE(result.next_cursor != nullptr);
+                REQUIRE(std::string_view(result.next_cursor) == "opaque-cursor-token");
+            }
+
+            // End-of-data: null next_cursor, and payment_id is opaque so a different provider's
+            // value passes through unchanged.
             j["result"]["items"][0]["payment_provider"] =
                     SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF;
             j["result"]["items"][0]["payment_id"] = "rangeproof-opaque-id";
+            j["result"]["next_cursor"] = nullptr;
             json = j.dump();
-
-            // Valid Rangeproof JSON
-            auto result_rangeproof =
-                    session_pro_backend_get_pro_details_response_parse(json.data(), json.size());
+            auto result_end = session_pro_backend_get_payment_details_response_parse(
+                    json.data(), json.size());
             {
                 scope_exit result_free{[&]() {
-                    session_pro_backend_get_pro_details_response_free(&result_rangeproof);
+                    session_pro_backend_get_payment_details_response_free(&result_end);
                 }};
-                if (result_rangeproof.header.error)
-                    INFO(result_rangeproof.header.error);
-
-                // Only check what we expect to be different
-                REQUIRE(std::string_view(result_rangeproof.items[0].payment_provider) ==
+                if (result_end.header.error)
+                    INFO(result_end.header.error);
+                REQUIRE(result_end.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
+                REQUIRE(std::string_view(result_end.items[0].payment_provider) ==
                         SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF);
-                REQUIRE(std::string_view(result_rangeproof.items[0].payment_id) ==
-                        "rangeproof-opaque-id");
+                REQUIRE(std::string_view(result_end.items[0].payment_id) == "rangeproof-opaque-id");
+                REQUIRE(result_end.next_cursor == nullptr);  // end-of-data
             }
 
             // After freeing
@@ -423,23 +520,20 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
 
             // Invalid JSON
             json = "{invalid}";
-            result = session_pro_backend_get_pro_details_response_parse(json.data(), json.size());
+            result = session_pro_backend_get_payment_details_response_parse(
+                    json.data(), json.size());
             {
                 scope_exit result_free{
-                        [&]() { session_pro_backend_get_pro_details_response_free(&result); }};
+                        [&]() { session_pro_backend_get_payment_details_response_free(&result); }};
                 REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(result.header.error_code != nullptr);
-                REQUIRE(result.header.error_code != nullptr);
             }
-
-            // After freeing
-            session_pro_backend_get_pro_details_response_free(&result);
+            session_pro_backend_get_payment_details_response_free(&result);
             REQUIRE(result.header.internal_ == nullptr);
 
             // Null JSON
-            result = session_pro_backend_get_pro_details_response_parse(nullptr, 0);
+            result = session_pro_backend_get_payment_details_response_parse(nullptr, 0);
             REQUIRE(result.header.status != SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-            REQUIRE(result.header.error_code != nullptr);
             REQUIRE(result.header.error_code != nullptr);
         }
 
@@ -458,8 +552,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             session_pro_backend_get_pro_revocations_response_free(&rev_response);
             REQUIRE(rev_response.header.internal_ == nullptr);
 
-            session_pro_backend_get_pro_details_response pay_response = {};
-            session_pro_backend_get_pro_details_response_free(&pay_response);
+            session_pro_backend_get_pro_status_response status_response = {};
+            session_pro_backend_get_pro_status_response_free(&status_response);
+            REQUIRE(status_response.header.internal_ == nullptr);
+
+            session_pro_backend_get_payment_details_response pay_response = {};
+            session_pro_backend_get_payment_details_response_free(&pay_response);
             REQUIRE(pay_response.header.internal_ == nullptr);
         }
 
@@ -784,70 +882,67 @@ TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
                         sizeof(rotating_pubkey.data)) == 0);
     }
 
-    // Get pro status
+    // Get pro status (the hot path: account status + single latest payment)
     {
-        session_pro_backend_request request_json =
-                session_pro_backend_get_pro_details_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        session::epoch_seconds(session::sysclock_now_s()),
-                        10'000);
+        session_pro_backend_request request_json = session_pro_backend_get_pro_status_request_build(
+                master_privkey.data,
+                sizeof(master_privkey.data),
+                session::epoch_seconds(session::sysclock_now_s()));
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
         REQUIRE(request_json.success);
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
-                g_test_pro_backend_dev_server_url + "/get_pro_details",
+                g_test_pro_backend_dev_server_url + "/get_pro_status",
                 std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
-        session_pro_backend_get_pro_details_response response =
-                session_pro_backend_get_pro_details_response_parse(
+        session_pro_backend_get_pro_status_response response =
+                session_pro_backend_get_pro_status_response_parse(
                         response_json.data(), response_json.size());
         scope_exit response_free{
-                [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
+                [&]() { session_pro_backend_get_pro_status_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
         if (response.header.error)
             UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
         REQUIRE(std::string_view(response.status) == "active");
-        REQUIRE(response.items_count > 0);
+        REQUIRE(response.has_latest_payment);
     }
 
-    // Get pro status without history
+    // Get payment history (paginated) -- newest page
     {
         session_pro_backend_request request_json =
-                session_pro_backend_get_pro_details_request_build(
+                session_pro_backend_get_payment_details_request_build(
                         master_privkey.data,
                         sizeof(master_privkey.data),
                         session::epoch_seconds(session::sysclock_now_s()),
-                        0);
+                        100,
+                        "");
         scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
         REQUIRE(request_json.success);
 
         std::string response_json = curl_do_basic_blocking_post_request(
                 curl,
                 curl_headers,
-                g_test_pro_backend_dev_server_url + "/get_pro_details",
+                g_test_pro_backend_dev_server_url + "/get_payment_details",
                 std::string_view(request_json.data.data, request_json.data.size));
 
         // Parse response
-        session_pro_backend_get_pro_details_response response =
-                session_pro_backend_get_pro_details_response_parse(
+        session_pro_backend_get_payment_details_response response =
+                session_pro_backend_get_payment_details_response_parse(
                         response_json.data(), response_json.size());
         scope_exit response_free{
-                [&]() { session_pro_backend_get_pro_details_response_free(&response); }};
+                [&]() { session_pro_backend_get_payment_details_response_free(&response); }};
 
         INFO("ERROR: JSON response: " << response_json.c_str());
         if (response.header.error)
             UNSCOPED_INFO("ERROR: " << response.header.error);
         REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(std::string_view(response.status) == "active");
-        REQUIRE(response.items_count == 0);
+        REQUIRE(response.items_count > 0);
+        REQUIRE(response.payments_total > 0);
     }
 
     // Add _another_ payment, same details

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -573,6 +573,30 @@ TEST_CASE("Pro Backend X25519 pubkey matches the converted Ed25519 pubkey", "[pr
             0);
 }
 
+TEST_CASE(
+        "Pro Backend visible_platforms lists purchasable stores, excludes rangeproof",
+        "[pro_backend]") {
+    auto platforms = visible_platforms();
+    auto has = [](std::span<const std::string_view> v, std::string_view s) {
+        for (auto x : v)
+            if (x == s)
+                return true;
+        return false;
+    };
+    REQUIRE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
+    REQUIRE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE));
+    // Hidden mechanisms are handled but never listed.
+    REQUIRE_FALSE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF));
+    REQUIRE(platforms.size() == 2);
+
+    // The C export returns the same slugs, in the same order (it is derived from the C++ list).
+    size_t count = 0;
+    const char* const* c = session_pro_backend_visible_platforms(&count);
+    REQUIRE(count == platforms.size());
+    for (size_t i = 0; i < count; i++)
+        REQUIRE(std::string_view{c[i]} == platforms[i]);
+}
+
 #if defined(TEST_PRO_BACKEND_WITH_DEV_SERVER)
 #include <curl/curl.h>
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -563,6 +563,18 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
     }
 }
 
+TEST_CASE("Pro Backend X25519 pubkey matches the converted Ed25519 pubkey", "[pro_backend]") {
+    // PUBKEY_X25519 is a hardcoded convenience constant; assert it equals the runtime conversion of
+    // the Ed25519 PUBKEY so the two can never silently drift.
+    unsigned char converted[32] = {};
+    REQUIRE(crypto_sign_ed25519_pk_to_curve25519(converted, PUBKEY.data()) == 0);
+    REQUIRE(std::memcmp(converted, PUBKEY_X25519.data(), sizeof(converted)) == 0);
+    // The C export points at the same bytes.
+    REQUIRE(std::memcmp(
+                    SESSION_PRO_BACKEND_PUBKEY_X25519, PUBKEY_X25519.data(), sizeof(converted)) ==
+            0);
+}
+
 #if defined(TEST_PRO_BACKEND_WITH_DEV_SERVER)
 #include <curl/curl.h>
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -21,8 +21,8 @@ static bool string8_equals(string8 s8, std::string_view str) {
 [[maybe_unused]] static void dump_pro_proof_to_stderr(const session_protocol_pro_proof& proof) {
     fprintf(stderr, "proof.version: %u\n", proof.version);
     fprintf(stderr,
-            "proof.gen_index_hash: %s\n",
-            oxenc::to_hex(proof.gen_index_hash.data, std::end(proof.gen_index_hash.data)).c_str());
+            "proof.revocation_tag: %s\n",
+            oxenc::to_hex(proof.revocation_tag.data, std::end(proof.revocation_tag.data)).c_str());
     fprintf(stderr,
             "proof.rotating_pubkey: %s\n",
             oxenc::to_hex(proof.rotating_pubkey.data, std::end(proof.rotating_pubkey.data))
@@ -70,8 +70,8 @@ static bool string8_equals(string8 s8, std::string_view str) {
         const session_pro_backend_pro_revocation_item& item) {
     fprintf(stderr, "item.expiry_unix_ts: %" PRId64 "zu\n", item.expiry_ts);
     fprintf(stderr,
-            "item.gen_index_hash: %s\n",
-            oxenc::to_hex(item.gen_index_hash.data, std::end(item.gen_index_hash.data)).c_str());
+            "item.revocation_tag: %s\n",
+            oxenc::to_hex(item.revocation_tag.data, std::end(item.revocation_tag.data)).c_str());
 }
 
 TEST_CASE("Pro Backend C API", "[pro_backend]") {
@@ -451,15 +451,15 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
         }
 
         SECTION("session_pro_backend_add_pro_payment_or_generate_pro_proof_response_parse") {
-            std::array<uint8_t, 32> fake_gen_index_hash;
-            randombytes_buf(fake_gen_index_hash.data(), fake_gen_index_hash.size());
+            std::array<uint8_t, 32> fake_revocation_tag;
+            randombytes_buf(fake_revocation_tag.data(), fake_revocation_tag.size());
 
             nlohmann::json j;
             j["status"] = SESSION_PRO_BACKEND_STATUS_SUCCESS;
             j["result"] = {
                     {"version", 0},
                     {"expiry_ts", unix_ts},
-                    {"gen_index_hash", oxenc::to_hex(fake_gen_index_hash)},
+                    {"revocation_tag", oxenc::to_hex(fake_revocation_tag)},
                     {"rotating_pkey",
                      oxenc::to_hex(rotating_pubkey.data, std::end(rotating_pubkey.data))},
                     {"sig", oxenc::to_hex(master_privkey.data, std::end(master_privkey.data))}};
@@ -482,9 +482,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.header.errors == nullptr);
                 REQUIRE(result.proof.expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
-                                result.proof.gen_index_hash.data,
-                                fake_gen_index_hash.data(),
-                                fake_gen_index_hash.size()) == 0);
+                                result.proof.revocation_tag.data,
+                                fake_revocation_tag.data(),
+                                fake_revocation_tag.size()) == 0);
                 REQUIRE(std::memcmp(
                                 result.proof.rotating_pubkey.data,
                                 rotating_pubkey.data,
@@ -502,9 +502,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 // Validate C and CPP variants
                 REQUIRE(result.proof.version == result_cpp.proof.version);
                 REQUIRE(std::memcmp(
-                                result.proof.gen_index_hash.data,
-                                result_cpp.proof.gen_index_hash.data(),
-                                result_cpp.proof.gen_index_hash.size()) == 0);
+                                result.proof.revocation_tag.data,
+                                result_cpp.proof.revocation_tag.data(),
+                                result_cpp.proof.revocation_tag.size()) == 0);
                 REQUIRE(std::memcmp(
                                 result.proof.rotating_pubkey.data,
                                 result_cpp.proof.rotating_pubkey.data(),
@@ -556,12 +556,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             j["result"]["ticket"] = 123;
             j["result"]["items"] = nlohmann::json::array();
 
-            std::array<uint8_t, 32> fake_gen_index_hash;
-            randombytes_buf(fake_gen_index_hash.data(), fake_gen_index_hash.size());
+            std::array<uint8_t, 32> fake_revocation_tag;
+            randombytes_buf(fake_revocation_tag.data(), fake_revocation_tag.size());
 
             auto obj = nlohmann::json::object();
             obj["expiry_ts"] = unix_ts;
-            obj["gen_index_hash"] = oxenc::to_hex(fake_gen_index_hash);
+            obj["revocation_tag"] = oxenc::to_hex(fake_revocation_tag);
             j["result"]["items"].push_back(obj);
 
             std::string json = j.dump();
@@ -582,9 +582,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.items != nullptr);
                 REQUIRE(result.items[0].expiry_ts == unix_ts);
                 REQUIRE(std::memcmp(
-                                result.items[0].gen_index_hash.data,
-                                fake_gen_index_hash.data(),
-                                fake_gen_index_hash.size()) == 0);
+                                result.items[0].revocation_tag.data,
+                                fake_revocation_tag.data(),
+                                fake_revocation_tag.size()) == 0);
             }
 
             // After freeeing

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -64,7 +64,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
     // Create protobuf `Content.proMessage.proof`
     SessionProtos::ProProof* proto_proof = pro->mutable_proof();
     proto_proof->set_version(result.proof.version);
-    proto_proof->set_genindexhash(
+    proto_proof->set_revocationtag(
             result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
     proto_proof->set_rotatingpublickey(
             result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -68,9 +68,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
             result.proof.gen_index_hash.data(), result.proof.gen_index_hash.size());
     proto_proof->set_rotatingpublickey(
             result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());
-    proto_proof->set_expiryunixts(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                          result.proof.expiry_unix_ts.time_since_epoch())
-                                          .count());
+    proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_unix_ts));
     proto_proof->set_sig(result.proof.sig.data(), result.proof.sig.size());
 
     // Generate the plaintext
@@ -768,7 +766,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decoded_community_message decoded = session_protocol_decode_for_community(
                 encoded.ciphertext.data,
                 encoded.ciphertext.size,
-                timestamp_ms.time_since_epoch().count(),
+                timestamp_s.time_since_epoch().count(),
                 pro_backend_ed_pk.data(),
                 pro_backend_ed_pk.size(),
                 error,
@@ -791,7 +789,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decoded_community_message decoded = session_protocol_decode_for_community(
                 encoded.ciphertext.data,
                 encoded.ciphertext.size,
-                timestamp_ms.time_since_epoch().count(),
+                timestamp_s.time_since_epoch().count(),
                 pro_backend_ed_pk.data(),
                 pro_backend_ed_pk.size(),
                 error,
@@ -812,7 +810,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decoded_community_message decoded = session_protocol_decode_for_community(
                 envelope_plaintext.data(),
                 envelope_plaintext.size(),
-                timestamp_ms.time_since_epoch().count(),
+                timestamp_s.time_since_epoch().count(),
                 pro_backend_ed_pk.data(),
                 pro_backend_ed_pk.size(),
                 error,
@@ -836,7 +834,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decoded_community_message decoded = session_protocol_decode_for_community(
                 envelope_plaintext.data(),
                 envelope_plaintext.size(),
-                timestamp_ms.time_since_epoch().count(),
+                timestamp_s.time_since_epoch().count(),
                 pro_backend_ed_pk.data(),
                 pro_backend_ed_pk.size(),
                 error,
@@ -902,7 +900,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decoded_community_message decoded = session_protocol_decode_for_community(
                 decrypted_cipher.data(),
                 decrypted_cipher.size(),
-                timestamp_ms.time_since_epoch().count(),
+                timestamp_s.time_since_epoch().count(),
                 pro_backend_ed_pk.data(),
                 pro_backend_ed_pk.size(),
                 error,

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -19,9 +19,7 @@ struct SerialisedProtobufContentWithProForTesting {
     std::vector<uint8_t> plaintext_padded;
     array_uc64 sig_over_plaintext_with_user_pro_key;
     array_uc64 sig_over_plaintext_padded_with_user_pro_key;
-    array_uc32 pro_proof_hash;
     bytes64 sig_over_plaintext_with_user_pro_key_c;
-    bytes32 pro_proof_hash_c;
 };
 
 static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_session_pro(
@@ -47,13 +45,13 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
     crypto_sign_ed25519_sk_to_pk(result.proof.rotating_pubkey.data(), user_rotating_privkey.data());
     result.proof.expiry_at = pro_expiry_at;
 
-    // Sign the proof by the dummy "Session Pro Backend" key
-    result.pro_proof_hash = result.proof.hash();
+    // Sign the proof by the dummy "Session Pro Backend" key (Ed25519 over the message directly)
+    auto proof_msg = result.proof.signed_message();
     crypto_sign_ed25519_detached(
             result.proof.sig.data(),
             nullptr,
-            result.pro_proof_hash.data(),
-            result.pro_proof_hash.size(),
+            proof_msg.data(),
+            proof_msg.size(),
             pro_backend_privkey.data());
 
     // Create protobuf `Content.proMessage`
@@ -97,10 +95,6 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
             result.sig_over_plaintext_with_user_pro_key_c.data,
             result.sig_over_plaintext_with_user_pro_key.data(),
             sizeof(result.sig_over_plaintext_with_user_pro_key_c.data));
-    std::memcpy(
-            result.pro_proof_hash_c.data,
-            result.pro_proof_hash.data(),
-            sizeof(result.pro_proof_hash_c.data));
     return result;
 }
 
@@ -284,17 +278,15 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
 
         // Verify pro
         ProProof nil_proof = {};
-        array_uc32 nil_hash = nil_proof.hash();
-        bytes32 decrypt_result_pro_hash =
-                session_protocol_pro_proof_hash(&decrypt_result.pro.proof);
         REQUIRE(decrypt_result.pro.status ==
                 SESSION_PROTOCOL_PRO_STATUS_NIL);  // Pro was not attached
         REQUIRE(decrypt_result.pro.msg_bitset.data == 0);
         REQUIRE(decrypt_result.pro.profile_bitset.data == 0);
+        // No proof was attached, so the decoded proof is empty (matches a default-constructed one).
         REQUIRE(std::memcmp(
-                        decrypt_result_pro_hash.data,
-                        nil_hash.data(),
-                        sizeof(decrypt_result_pro_hash.data)) == 0);
+                        decrypt_result.pro.proof.sig.data,
+                        nil_proof.sig.data(),
+                        sizeof(decrypt_result.pro.proof.sig.data)) == 0);
 
         // Verify it is decryptable
         SessionProtos::Content decrypt_content = {};
@@ -404,9 +396,12 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         // Verify pro
         REQUIRE(decrypt_result.pro.status ==
                 SESSION_PROTOCOL_PRO_STATUS_VALID);  // Pro was attached
-        bytes32 hash = session_protocol_pro_proof_hash(&decrypt_result.pro.proof);
-        REQUIRE(std::memcmp(hash.data, protobuf_content.pro_proof_hash.data(), sizeof(hash.data)) ==
-                0);
+        // The proof survived the encode/decode round-trip: its authenticating signature is
+        // unchanged (Ed25519 is deterministic over the canonical message).
+        REQUIRE(std::memcmp(
+                        decrypt_result.pro.proof.sig.data,
+                        protobuf_content.proof.sig.data(),
+                        sizeof(decrypt_result.pro.proof.sig.data)) == 0);
         REQUIRE(decrypt_result.pro.msg_bitset.data == 0);      // No features requested
         REQUIRE(decrypt_result.pro.profile_bitset.data == 0);  // No features requested
 
@@ -480,9 +475,12 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         // Verify pro
         REQUIRE(decrypt_result.pro.status ==
                 SESSION_PROTOCOL_PRO_STATUS_VALID);  // Pro was attached
-        bytes32 hash = session_protocol_pro_proof_hash(&decrypt_result.pro.proof);
-        REQUIRE(std::memcmp(hash.data, protobuf_content.pro_proof_hash.data(), sizeof(hash.data)) ==
-                0);
+        // The proof survived the encode/decode round-trip: its authenticating signature is
+        // unchanged (Ed25519 is deterministic over the canonical message).
+        REQUIRE(std::memcmp(
+                        decrypt_result.pro.proof.sig.data,
+                        protobuf_content.proof.sig.data(),
+                        sizeof(decrypt_result.pro.proof.sig.data)) == 0);
         REQUIRE(session_protocol_pro_profile_bitset_is_set(
                 decrypt_result.pro.profile_bitset,
                 SESSION_PROTOCOL_PRO_PROFILE_FEATURES_PRO_BADGE));
@@ -622,10 +620,12 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
             // Verify pro
             REQUIRE(decrypt_result.pro.status ==
                     SESSION_PROTOCOL_PRO_STATUS_VALID);  // Pro was attached
-            bytes32 hash = session_protocol_pro_proof_hash(&decrypt_result.pro.proof);
+            // The proof survived the encode/decode round-trip: its authenticating signature is
+            // unchanged (Ed25519 is deterministic over the canonical message).
             REQUIRE(std::memcmp(
-                            hash.data, protobuf_content.pro_proof_hash.data(), sizeof(hash.data)) ==
-                    0);
+                            decrypt_result.pro.proof.sig.data,
+                            protobuf_content.proof.sig.data(),
+                            sizeof(decrypt_result.pro.proof.sig.data)) == 0);
             REQUIRE(decrypt_result.pro.msg_bitset.data == 0);      // No features requested
             REQUIRE(decrypt_result.pro.profile_bitset.data == 0);  // No features requested
 

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
     SECTION("Ensure get pro fetaures detects large message") {
         // Try a message below the size threshold
         {
-            auto msg = std::string(SESSION_PROTOCOL_PRO_STANDARD_CHARACTER_LIMIT, 'a');
+            auto msg = std::string(SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT, 'a');
             session_protocol_pro_features_for_msg pro_msg =
                     session_protocol_pro_features_for_utf8(msg.data(), msg.size());
             REQUIRE(pro_msg.status == SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_SUCCESS);
@@ -124,7 +124,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
 
         // Try a message exceeding the standard size threshold
         {
-            auto msg = std::string(SESSION_PROTOCOL_PRO_STANDARD_CHARACTER_LIMIT + 1, 'a');
+            auto msg = std::string(SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT + 1, 'a');
             session_protocol_pro_features_for_msg pro_msg =
                     session_protocol_pro_features_for_utf8(msg.data(), msg.size());
             REQUIRE(pro_msg.status == SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_SUCCESS);
@@ -417,7 +417,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
 
     SECTION("Encrypt/decrypt for contact in default namespace with Pro + features") {
         std::string large_message;
-        large_message.resize(SESSION_PROTOCOL_PRO_STANDARD_CHARACTER_LIMIT + 1);
+        large_message.resize(SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT + 1);
 
         session_protocol_pro_features_for_msg pro_msg =
                 session_protocol_pro_features_for_utf8(large_message.data(), large_message.size());

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -65,7 +65,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
     SessionProtos::ProProof* proto_proof = pro->mutable_proof();
     proto_proof->set_version(result.proof.version);
     proto_proof->set_genindexhash(
-            result.proof.gen_index_hash.data(), result.proof.gen_index_hash.size());
+            result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
     proto_proof->set_rotatingpublickey(
             result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());
     proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_unix_ts));

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -36,9 +36,9 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
 
     // Create protobuf `Content.dataMessage`
     SessionProtos::Content content = {};
-    content.set_sigtimestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                     content_at.time_since_epoch())
-                                     .count());
+    content.set_sigtimestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>(content_at.time_since_epoch())
+                    .count());
 
     SessionProtos::DataMessage* data = content.mutable_datamessage();
     data->set_body(std::string(data_body));

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -119,7 +119,8 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                     session_protocol_pro_features_for_utf8(msg.data(), msg.size());
             REQUIRE(pro_msg.status ==
                     SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_UTF_DECODING_ERROR);
-            REQUIRE(pro_msg.error.size);
+            REQUIRE(pro_msg.error != nullptr);
+            REQUIRE(pro_msg.error[0] != '\0');
         }
 
         // Try a message exceeding the standard size threshold

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -28,8 +28,8 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
         std::string_view data_body,
         const array_uc64& user_rotating_privkey,
         const array_uc64& pro_backend_privkey,
-        std::chrono::sys_seconds content_unix_ts,
-        std::chrono::sys_seconds pro_expiry_unix_ts,
+        std::chrono::sys_seconds content_at,
+        std::chrono::sys_seconds pro_expiry_at,
         session_protocol_pro_message_bitset msg_bitset,
         session_protocol_pro_profile_bitset profile_bitset) {
     SerialisedProtobufContentWithProForTesting result = {};
@@ -37,7 +37,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
     // Create protobuf `Content.dataMessage`
     SessionProtos::Content content = {};
     content.set_sigtimestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                     content_unix_ts.time_since_epoch())
+                                     content_at.time_since_epoch())
                                      .count());
 
     SessionProtos::DataMessage* data = content.mutable_datamessage();
@@ -45,7 +45,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
 
     // Generate a dummy proof
     crypto_sign_ed25519_sk_to_pk(result.proof.rotating_pubkey.data(), user_rotating_privkey.data());
-    result.proof.expiry_unix_ts = pro_expiry_unix_ts;
+    result.proof.expiry_at = pro_expiry_at;
 
     // Sign the proof by the dummy "Session Pro Backend" key
     result.pro_proof_hash = result.proof.hash();
@@ -68,7 +68,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
             result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
     proto_proof->set_rotatingpublickey(
             result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());
-    proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_unix_ts));
+    proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_at));
     proto_proof->set_sig(result.proof.sig.data(), result.proof.sig.size());
 
     // Generate the plaintext
@@ -313,8 +313,8 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                     /*data_body*/ data_body,
                     /*user_rotating_privkey*/ user_pro_ed_sk,
                     /*pro_backend_privkey*/ pro_backend_ed_sk,
-                    /*content_unix_ts=*/timestamp_s,
-                    /*pro_expiry_unix_ts*/ timestamp_s,
+                    /*content_at=*/timestamp_s,
+                    /*pro_expiry_at*/ timestamp_s,
                     /*msg_bitset*/ {},
                     /*profile_bitset*/ {});
 
@@ -438,8 +438,8 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                         /*data_body*/ large_message,
                         /*user_rotating_privkey*/ user_pro_ed_sk,
                         /*pro_backend_privkey*/ pro_backend_ed_sk,
-                        /*content_unix_ts*/ timestamp_s,
-                        /*pro_expiry_unix_ts*/ timestamp_s,
+                        /*content_at*/ timestamp_s,
+                        /*pro_expiry_at*/ timestamp_s,
                         /*msg_bitset*/ pro_msg.bitset,
                         /*proilfe_bitset*/ profile_bitset);
 
@@ -645,7 +645,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
             // user's "Session Pro" key into `sig_over_plaintext_with_user_pro_key`
             std::chrono::milliseconds bad_timestamp_ms =
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                            protobuf_content.proof.expiry_unix_ts.time_since_epoch()) +
+                            protobuf_content.proof.expiry_at.time_since_epoch()) +
                     std::chrono::seconds(1);
 
             SerialisedProtobufContentWithProForTesting bad_protobuf_content =
@@ -653,11 +653,11 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                             /*data_body*/ data_body,
                             /*user_rotating_privkey*/ user_pro_ed_sk,
                             /*pro_backend_privkey*/ pro_backend_ed_sk,
-                            /*content_unix_ts=*/
+                            /*content_at=*/
                             std::chrono::sys_seconds(
                                     std::chrono::duration_cast<std::chrono::seconds>(
                                             bad_timestamp_ms)),
-                            /*pro_expiry_unix_ts*/ timestamp_s,
+                            /*pro_expiry_at*/ timestamp_s,
                             /*msg_bitset*/ {},
                             /*profile_bitset*/ {});
 

--- a/utils/test-bigendian.sh
+++ b/utils/test-bigendian.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Occasional big-endian sanity audit for libsession-util. NOT wired into CI — run it by hand now and
+# then (especially after touching hashing or any wire/config serialization).
+#
+# Most of libsession runs only on little-endian hosts, so endian-sensitive byte serialization — the
+# Pro signed-digest encoding, config data, protobuf packing — normally never exercises its big-endian
+# path. This script builds and runs the test suite inside an emulated big-endian target (s390x) so
+# those paths run for real.
+#
+# Cost: everything runs under qemu-user emulation, so the build is slow (tens of minutes) — the
+# submodule-built networking stack (oxen-libquic / session-router) is the bulk of it. That's fine for
+# an occasional manual audit; it is deliberately not in CI.
+#
+# Requires: Docker able to run foreign-arch images via qemu-user/binfmt. Run from the repo root with
+# submodules checked out.
+set -euo pipefail
+
+# Register qemu-user binfmt handlers for s390x (idempotent; needs --privileged once per boot).
+docker run --privileged --rm tonistiigi/binfmt --install s390x
+
+# Build + test inside an emulated s390x Debian. BUILD_STATIC_DEPS=OFF pulls the heavy deps
+# (libsodium, protobuf, curl, sqlite, zstd) as prebuilt s390x apt packages rather than compiling them
+# from source under emulation.
+docker run --platform=linux/s390x --rm -v "$PWD:/src" -w /src s390x/debian:bookworm bash -euxc '
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        g++ cmake ninja-build pkg-config git ca-certificates \
+        libsodium-dev libprotobuf-dev protobuf-compiler libcurl4-openssl-dev \
+        libsqlite3-dev libzstd-dev
+    cmake -B build-bigendian -G Ninja -DBUILD_STATIC_DEPS=OFF -DCMAKE_BUILD_TYPE=Release
+    cmake --build build-bigendian --target testAll
+    # These tags exercise byte serialization on this big-endian host. Drop the filter for a full run.
+    ./build-bigendian/tests/testAll "[endian],[hash],[pro_backend],[session_protocol],[config]"
+'
+echo "big-endian audit passed"

--- a/utils/test-bigendian.sh
+++ b/utils/test-bigendian.sh
@@ -12,17 +12,24 @@
 # submodule-built networking stack (oxen-libquic / session-router) is the bulk of it. That's fine for
 # an occasional manual audit; it is deliberately not in CI.
 #
-# Requires: Docker able to run foreign-arch images via qemu-user/binfmt. Run from the repo root with
-# submodules checked out.
+# Requires: Docker, plus a one-time host install of qemu-user-static + binfmt-support (see below).
+# Run from the repo root with submodules checked out.
 set -euo pipefail
 
-# Register qemu-user binfmt handlers for s390x (idempotent; needs --privileged once per boot).
-docker run --privileged --rm tonistiigi/binfmt --install s390x
+# One-time host prerequisite (Debian/Ubuntu):
+#     sudo apt install qemu-user-static binfmt-support
+# That registers the binfmt_misc handlers with the "F" (fix-binary) flag, which is what lets Docker
+# transparently run foreign-arch images under emulation from inside a container — no privileged helper
+# container needed.
+if [ ! -e /proc/sys/fs/binfmt_misc/qemu-s390x ]; then
+    echo "s390x binfmt handler not registered; run: sudo apt install qemu-user-static binfmt-support" >&2
+    exit 1
+fi
 
 # Build + test inside an emulated s390x Debian. BUILD_STATIC_DEPS=OFF pulls the heavy deps
 # (libsodium, protobuf, curl, sqlite, zstd) as prebuilt s390x apt packages rather than compiling them
 # from source under emulation.
-docker run --platform=linux/s390x --rm -v "$PWD:/src" -w /src s390x/debian:bookworm bash -euxc '
+docker run --platform=linux/s390x --rm -v "$PWD:/src" -w /src debian:sid bash -euxc '
     apt-get update
     apt-get install -y --no-install-recommends \
         g++ cmake ninja-build pkg-config git ca-certificates \

--- a/utils/test-bigendian.sh
+++ b/utils/test-bigendian.sh
@@ -8,9 +8,13 @@
 # path. This script builds and runs the test suite inside an emulated big-endian target (s390x) so
 # those paths run for real.
 #
-# Cost: everything runs under qemu-user emulation, so the build is slow (tens of minutes) — the
-# submodule-built networking stack (oxen-libquic / session-router) is the bulk of it. That's fine for
-# an occasional manual audit; it is deliberately not in CI.
+# session-router (the onion-routing layer) is endian-irrelevant to what we test and drags in the
+# heaviest deps, so we build with -DENABLE_NETWORKING_SROUTER=OFF. oxen::quic itself can't be turned
+# off (a couple of ungated backend-session test sources include its headers), so it still builds — we
+# satisfy it with libngtcp2 + gnutls from apt (nghttp3 is not needed; libquic uses raw QUIC).
+#
+# Cost: everything runs under qemu-user emulation, so expect a slow build (oxen-libquic is the bulk of
+# it). Fine for an occasional manual audit; it is deliberately not in CI.
 #
 # Requires: Docker, plus a one-time host install of qemu-user-static + binfmt-support (see below).
 # Run from the repo root with submodules checked out.
@@ -26,18 +30,27 @@ if [ ! -e /proc/sys/fs/binfmt_misc/qemu-s390x ]; then
     exit 1
 fi
 
-# Build + test inside an emulated s390x Debian. BUILD_STATIC_DEPS=OFF pulls the heavy deps
-# (libsodium, protobuf, curl, sqlite, zstd) as prebuilt s390x apt packages rather than compiling them
-# from source under emulation.
+# Build + test inside an emulated s390x Debian. BUILD_STATIC_DEPS=OFF pulls the heavy deps (libsodium,
+# protobuf, sqlite, zstd, and the oxen::quic deps libngtcp2/gnutls/libevent) as prebuilt s390x apt
+# packages rather than compiling them from source under emulation.
 docker run --platform=linux/s390x --rm -v "$PWD:/src" -w /src debian:sid bash -euxc '
     apt-get update
     apt-get install -y --no-install-recommends \
         g++ cmake ninja-build pkg-config git ca-certificates \
         libsodium-dev libprotobuf-dev protobuf-compiler libcurl4-openssl-dev \
-        libsqlite3-dev libzstd-dev
-    cmake -B build-bigendian -G Ninja -DBUILD_STATIC_DEPS=OFF -DCMAKE_BUILD_TYPE=Release
+        libsqlite3-dev libzstd-dev \
+        libngtcp2-dev libngtcp2-crypto-gnutls-dev libgnutls28-dev libevent-dev
+    rm -rf build-bigendian   # fresh configure each run; the dir lives in the mounted tree and would otherwise reuse a stale CMake cache
+    cmake -B build-bigendian -G Ninja -DBUILD_STATIC_DEPS=OFF -DENABLE_NETWORKING_SROUTER=OFF -DCMAKE_BUILD_TYPE=Release
     cmake --build build-bigendian --target testAll
-    # These tags exercise byte serialization on this big-endian host. Drop the filter for a full run.
-    ./build-bigendian/tests/testAll "[endian],[hash],[pro_backend],[session_protocol],[config]"
+    # Run the endian-sensitive tags on this big-endian host. Catch2 exits 0 even when a filter clause
+    # matches no tests, so capture the output and fail loudly if any tag went unmatched — that guards
+    # against a tag rename silently shrinking the audit. ([endian] is a pfs-only test, not present here.)
+    out=$(./build-bigendian/tests/testAll "[hash],[session-protocol],[pro_backend],[config]")
+    echo "$out"
+    if echo "$out" | grep -q "No test cases matched"; then
+        echo "ERROR: a filter tag matched no tests — the audit under-ran (tag renamed?)" >&2
+        exit 1
+    fi
 '
 echo "big-endian audit passed"


### PR DESCRIPTION
This PR updates libsession-util for compatibility with the changes made in https://github.com/session-foundation/session-pro-backend/pull/2, along with some related refactoring for integrating the changes with Session clients.

# Session Pro: finalize the pre-launch wire/proof protocol + redesign the `pro_backend` API

## Overview

This branch finalizes the Session Pro wire protocol and reworks libsession's
`pro_backend` / `session_protocol` code to match, ahead of launch. It is developed
**in lockstep with the authoritative spec** (`session-pro-backend/docs/pro-wire-protocol.md`)
and the backend implementation — every wire-affecting change here has a matching
backend change, and the pairing is validated end-to-end (see **Testing**).

Net effect: a smaller, simpler, more consistent API (**+2,122 / −3,559**), an opaque
request/response boundary so clients never parse the wire, and a signing scheme that no
longer depends on BLAKE2b.

> A sibling branch (`pro-backend-updates-pfs`) carries the same changes on top of PR #90, adapted to the
> post-quantum/`std::byte` primitives; it will be PRed separately.

## Wire-protocol changes (coordinated with the backend spec)

These change bytes on the wire and/or in signatures, and land in lockstep with the backend:

- **Time is integer seconds, not milliseconds.** Every Pro timestamp/duration is UNIX-epoch
  **seconds** as a signed `int64_t`. The only exceptions are the two upstream-provider event
  instants (`purchased_ts`, `revoked_ts`), emitted as JSON **floats** to preserve sub-second
  precision (kept internally as `sys_ms` / `double`).
- **Signatures sign the message directly — no BLAKE2b, no pre-hash** (spec §1.1/§2/§3). All five
  Ed25519 signatures (the offline proof + four signed requests) are now `Ed25519(key, M)` where `M`
  is built by a single rule: 16-byte domain prefix, raw fixed-width keys/tags (self-delimiting),
  integers as canonical decimal ASCII (`std::to_chars`), strings verbatim (UTF-8), and one `\0`
  between adjacent variable-length fields. New `src/pro_message.hpp` implements this.
- **No `version` on requests; the proof keeps a plaintext `version`.** Request shapes are
  domain-separated by endpoint + domain prefix, so requests carry no version at all. The proof
  (free-floating, offline-verified) keeps a **plaintext** `version` that selects its domain prefix
  (`v0` → `ProProof_v0_____`) — it is a verification input, never a signed byte.
- **`gen_index_hash` → `revocation_tag`.** Renamed everywhere (C/C++ structs + protobuf field);
  it is now a stored random 32-byte value, not a computed hash — clients compare it for equality
  only.
- **Payments collapse to one opaque `payment_id`.** The per-provider typed ID fields and the
  `provider`/`plan` integer enums are gone; the wire carries an opaque `payment_id` string plus
  string `provider_code` / `plan` codes. Item `status` and account `user_status` are parsed as
  opaque pass-through strings.
- **Revocation list reshaped.** Dropped the absurd per-entry entitlement-expiry; added per-entry
  `effective_ts` (the real gate) and a single list-level `retain_for` (memory-only aging) plus
  `retry_in`. Revocation ticket widened to 64-bit.
- **Response envelope redesigned** (spec §5): `status` is a **closed** string enum
  (`ok`/`fail`/`error`), with an open/additive `error_code` slug and a single diagnostic `error`
  string (was an int status + `errors[]`). `add_pro_payment` is idempotent (re-claim = success);
  `already_redeemed` is gone.
- Removed the dead `SeshProBackend__` personalisation constant and the historical salted
  generation-token hashing.

## API changes (libsession surface)

- **`pro_backend` is now free functions returning an opaque `ProRequest`.** Each builder
  (`add_payment_request`, `pro_proof_request`, `payment_details_request`, `refund_request`,
  `revocations_request`) takes loose args (keys, `provider_code`, `payment_id`, timestamps) and
  returns `ProRequest{ endpoint, content_type, data }`. Clients relay `data` **verbatim** under
  `content_type` and never parse it — libsession owns the wire encoding. Response parsing is the
  symmetric set of free functions (`parse_*`).
- **The C request API is a thin shim over the C++ one** — the C `..._request_build` functions own a
  C++ `ProRequest` via an opaque handle and point `endpoint`/`content_type`/`data` into it
  (zero-copy); freeing deletes it. No duplicated request-building logic, no input structs.
- **`ResponseBase`** carries `ResponseStatus status` (closed `Ok`/`Fail`/`Error`), plus
  `std::optional<std::string> error_code` / `error`; `explicit operator bool()` for success.
- **Removed** `ProProof::hash()` and C `session_protocol_pro_proof_hash()` — the 32-byte signed
  digest no longer exists. `ProProof::signed_message()` returns the exact bytes signed, if needed.
- **New constants/accessors, owned by libsession** (single source of truth, so clients stop
  hardcoding): backend base `URL`, the backend signing `PUBKEY` (+ `PUBKEY_X25519`), per-provider
  support/management `provider_urls()`, and `visible_platforms()` — the user-visible purchasable
  provider slugs (`google_play`, `app_store`; excludes the hidden `rangeproof`) for building the
  "purchase via …" list. Signing domain prefixes moved into C++ `std::string_view` constants.
- Renamed `*_unix_ts` members to `*_at` where the value is a `sys_seconds` (raw-integer unix
  timestamps keep `_unix_ts`); `ProRequest` gained an explicit `content_type`.

## Notable design decisions

- **Clients never touch the wire or sign anything.** The request boundary is opaque bytes; proof
  verification is `verify_signature()` / `status()`. This means the signing rework above is
  **invisible to client code** — no client changes required for it.
- **Domain separation over versioning-in-hash.** A new request shape earns a new endpoint; the
  proof binds its version via the domain prefix it selects. No version byte is signed.
- **`std::to_chars` decimal integers**, explicitly not locale-aware formatters, so the signed bytes
  are identical across languages/platforms and need no endian handling.

## Testing

- Full unit suite green on the branch.
- **Live cross-implementation validation:** a companion integration harness round-trips signed
  requests and proofs against a real backend clone (with the matching spec commit) — this catches
  wire/signing drift (field order, integer encoding, framing, domain prefix) that self-consistent
  unit tests cannot. Both the signing rework and the envelope redesign pass end-to-end.
- **Big-endian audit:** `utils/test-bigendian.sh` builds and runs the hash/protocol/pro/config
  suites under emulated s390x (local `qemu-user-static`) to guard against host-byte-order
  assumptions.

## Client migration notes

- Swap any direct JSON building/parsing for the `pro_backend` `*_request()` / `parse_*` functions;
  relay `ProRequest.data` under `ProRequest.content_type` unmodified.
- Response handling: branch on `status` (`ok`/`fail`/`error`); map `error_code` slugs to localized
  strings (the `error` string is an English diagnostic, not user-facing). Drop any
  already-redeemed special-casing.
- Read backend `URL`/`PUBKEY`/provider URLs/purchasable platforms from libsession instead of local
  copies.
- No action needed for the signing change itself — it is entirely inside libsession.