### PR TITLE
Pro backend integration tests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -38,6 +38,18 @@ local add_stf_repo(image) = [
   'eatmydata ' + apt_get_quiet + ' update',
 ];
 
+// Fresh-container apt bootstrap shared by every post-build test step: eatmydata, optional STF repo,
+// upgrade, then install `pkgs`. When `pkgs` is empty the repo/upgrade block is skipped entirely
+// (only eatmydata is installed), matching the original inline behaviour.
+local apt_setup(image, pkgs, stf_repo=true) =
+  [apt_get_quiet + ' install -y eatmydata'] +
+  (if std.length(pkgs) > 0 then
+     (if stf_repo then add_stf_repo(image) else []) + [
+       'eatmydata ' + apt_get_quiet + ' update',
+       'eatmydata ' + apt_get_quiet + ' dist-upgrade -y',
+       'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y ' + std.join(' ', pkgs),
+     ] else []);
+
 // Do something on a debian-like system
 local debian_pipeline(name,
                       image,
@@ -102,6 +114,7 @@ local debian_build(name,
                    stf_repo=true,
                    kitware_repo=''/* ubuntu codename, if wanted */,
                    extra_setup=[],
+                   extra_steps=[],
                    allow_fail=false)
       = debian_pipeline(
   name,
@@ -131,21 +144,12 @@ local debian_build(name,
                    image: image,
                    pull: 'always',
                    [if allow_fail then 'failure']: 'ignore',
-                   commands:
-                     [apt_get_quiet + ' install -y eatmydata'] + (
-                       if std.length(test_deps) > 0 then (
-                         if stf_repo then add_stf_repo(image) else []
-                       ) + [
-                         'eatmydata ' + apt_get_quiet + ' update',
-                         'eatmydata ' + apt_get_quiet + ' dist-upgrade -y',
-                         'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y ' + std.join(' ', test_deps),
-                       ] else []
-                     ) + [
-                       'cd build',
-                       './tests/testLogging --colour-mode ansi -d yes',
-                       './tests/testAll --colour-mode ansi -d yes',
-                     ],
-                 }] else [])
+                   commands: apt_setup(image, test_deps, stf_repo=stf_repo) + [
+                     'cd build',
+                     './tests/testLogging --colour-mode ansi -d yes',
+                     './tests/testAll --colour-mode ansi -d yes',
+                   ],
+                 }] else []) + extra_steps
 );
 // windows cross compile on debian
 local windows_cross_pipeline(name,
@@ -195,6 +199,56 @@ local windows_cross_pipeline(name,
                      'wine-stable ./tests/testAll.exe --colour-mode ansi -d yes',
                    ],
                  }] else [])
+);
+
+// Live Pro-backend integration test: build testAll with the dev-server hook, stand up an ephemeral
+// backend (throwaway postgres + flask, provider_dry_run) via tests/pro_backend/run-dev-backend.sh,
+// and run the [pro_live] suite against it. The backend is a separate Python service, checked out at
+// a pinned ref (repos stay decoupled — CI keeps its own clone).
+local pro_backend_git = 'https://github.com/session-foundation/session-pro-backend.git';
+local pro_backend_ref = 'phase2-foundation';  // bump/pin as the backend advances in lockstep
+
+// Extra apt packages (beyond the standard test deps) the live Pro-backend step needs: postgres, the
+// session-router key tool, the backend's python3-* runtime, and clone/venv tooling.
+local pro_backend_pkgs = [
+  'postgresql',
+  'session-router-bin',
+  'python3-session-util',
+  'python3-nacl',
+  'python3-psycopg',
+  'python3-flask',
+  'python3-venv',
+  'python3-pip',
+  'git',
+  'curl',
+  'ca-certificates',
+] + default_test_deps;
+
+local pro_backend_live_pipeline(name, image) = debian_build(
+  name,
+  image,
+  // tests=false suppresses the default no-server testAll step; WITH_TESTS=ON (later -D wins) still
+  // builds testAll so the live step below can run it. The step goes through debian_build's own
+  // extra_steps hook -- no manual `steps` surgery.
+  tests=false,
+  cmake_extra='-DWITH_TESTS=ON -DTEST_PRO_BACKEND_WITH_DEV_SERVER=ON ',
+  extra_steps=[{
+    name: 'pro-backend live tests',
+    image: image,
+    pull: 'always',
+    commands: apt_setup(image, pro_backend_pkgs) + [
+      // Check out + provision the backend (venv reuses the apt-installed python3-* via system site
+      // packages; only the pip-only provider libraries are installed).
+      'git clone --depth=1 --branch ' + pro_backend_ref + ' ' + pro_backend_git + ' /opt/pro-backend',
+      'python3 -m venv --system-site-packages /opt/pro-backend/.venv',
+      '/opt/pro-backend/.venv/bin/pip install --no-input app-store-server-library google-cloud-pubsub google-api-python-client',
+      // initdb/pg_ctl refuse to run as root, so run the whole launcher as a non-root user; its temp
+      // dirs (postgres cluster, key) are created by that user, so initdb is satisfied.
+      'useradd -m pro && chown -R pro /opt/pro-backend',
+      'ws="$(pwd)"',
+      'su pro -c "cd $ws && SESSION_PRO_BACKEND_DIR=/opt/pro-backend PRO_BACKEND_PORT=5544 tests/pro_backend/run-dev-backend.sh ./build/tests/testAll --colour-mode ansi -d yes \'[pro_live]\'"',
+    ],
+  }],
 );
 
 local clang(version) = debian_build(
@@ -351,6 +405,10 @@ local static_build(name,
 
   // Various debian builds
   debian_build('Debian sid', docker_base + 'debian-sid'),
+
+  // Live Pro-backend integration tests (ephemeral backend + [pro_live]).
+  pro_backend_live_pipeline('Debian sid (Pro backend live)', docker_base + 'debian-sid'),
+
   debian_build('Debian sid/Debug', docker_base + 'debian-sid', build_type='Debug'),
   debian_build('Debian testing', docker_base + 'debian-testing'),
   clang(19),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -206,7 +206,7 @@ local windows_cross_pipeline(name,
 // and run the [pro_live] suite against it. The backend is a separate Python service, checked out at
 // a pinned ref (repos stay decoupled — CI keeps its own clone).
 local pro_backend_git = 'https://github.com/session-foundation/session-pro-backend.git';
-local pro_backend_ref = 'phase2-foundation';  // bump/pin as the backend advances in lockstep
+local pro_backend_ref = 'dev';  // track upstream mainline (session-foundation dev) -- the [pro_live] drift check is meant to follow it
 
 // Extra apt packages (beyond the standard test deps) the live Pro-backend step needs: postgres, the
 // session-router key tool, the backend's python3-* runtime, and clone/venv tooling.

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -216,6 +216,7 @@ local pro_backend_pkgs = [
   'python3-session-util',
   'python3-nacl',
   'python3-psycopg',
+  'python3-psycopg-pool',
   'python3-flask',
   'python3-venv',
   'python3-pip',

--- a/tests/pro_backend/gen_kat.py
+++ b/tests/pro_backend/gen_kat.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Generate the known-answer vectors asserted by the [pro_kat] test in tests/test_pro_backend.cpp.
+
+These pin libsession's signed-message construction (wire spec 1.1 / 2 / 3.1-3.4, Delta #13). The
+vectors are produced here from the *backend's* independent implementation (backend.signed_message +
+the make_*_message / build_proof_message builders) for fixed, deterministic inputs, then hand-verified
+against the spec field layout before being frozen into the C++ test. Re-run this if the signed-message
+format ever changes (it is a deliberate, both-sides wire change) and update the constants + the
+hand-verification in the test to match.
+
+Run with the backend clone's venv python; requires env:
+  PRO_BACKEND_DIR   path to the backend checkout (for importing backend/base)
+
+  PRO_BACKEND_DIR=~/src/session-pro-backend .venv/bin/python gen_kat.py
+"""
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.environ["PRO_BACKEND_DIR"])
+
+import nacl.signing  # noqa: E402
+
+import backend  # noqa: E402
+import base  # noqa: E402
+
+
+def hx(b):
+    return bytes(b).hex()
+
+
+def main():
+    # Fixed deterministic keypairs from 32-byte seeds (backend signing key 0x03).
+    master = nacl.signing.SigningKey(bytes([1] * 32))
+    rotating = nacl.signing.SigningKey(bytes([2] * 32))
+    backkey = nacl.signing.SigningKey(bytes([3] * 32))
+    mpk, rpk = master.verify_key, rotating.verify_key
+
+    ts = datetime.datetime.fromtimestamp(1700000000, datetime.timezone.utc)
+    refund = datetime.datetime.fromtimestamp(1700000123, datetime.timezone.utc)
+    expiry = datetime.datetime.fromtimestamp(1704067200, datetime.timezone.utc)
+    limit = 10
+    before_cursor = "0a1b2c3d4e5f"  # opaque to the signed input; any fixed non-empty string works
+    provider = base.PaymentProvider.GooglePlayStore
+    pid = "test-payment-id-123"
+    rtag = bytes([0x11] * 32)
+
+    add_msg = backend.signed_message(
+        backend.ADD_PRO_PAYMENT_DOMAIN, mpk, rpk, provider.value, pid)
+    gen_msg = backend.make_generate_pro_proof_message(mpk, rpk, ts)
+    # Delta #15: get_pro_details split into get_pro_status + paginated get_payment_details.
+    status_msg = backend.make_get_pro_status_message(mpk, ts)
+    # Two payment_details cases: empty `before` (newest page) ends in the adjacency `\0`;
+    # a non-empty `before` appends the opaque cursor verbatim as the final field (no trailing sep).
+    details_empty_msg = backend.make_get_payment_details_message(mpk, ts, limit, "")
+    details_cursor_msg = backend.make_get_payment_details_message(mpk, ts, limit, before_cursor)
+    ref_msg = backend.signed_message(
+        backend.SET_PAYMENT_REFUND_REQUESTED_DOMAIN, mpk, ts, refund, provider.value, pid)
+    prf_msg = backend.build_proof_message(rtag, rpk, expiry)
+
+    print("master_pkey  =", hx(mpk.encode()))
+    print("rotating_pkey=", hx(rpk.encode()))
+    print("backend_pkey =", hx(backkey.verify_key.encode()))
+    print()
+    for name, m in [("add", add_msg), ("gen", gen_msg), ("status", status_msg),
+                    ("details_empty", details_empty_msg), ("details_cursor", details_cursor_msg),
+                    ("refund", ref_msg), ("proof", prf_msg)]:
+        print(f"{name}_msg_hex = {hx(m)}")
+        print(f"    repr     = {m!r}")
+    print()
+    print("add_master_sig =", hx(master.sign(add_msg).signature))
+    print("add_rotating_sig =", hx(rotating.sign(add_msg).signature))
+    print("proof_sig =", hx(backkey.sign(prf_msg).signature))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pro_backend/gen_kat.py
+++ b/tests/pro_backend/gen_kat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Generate the known-answer vectors asserted by the [pro_kat] test in tests/test_pro_backend.cpp.
 
-These pin libsession's signed-message construction (wire spec 1.1 / 2 / 3.1-3.4, Delta #13). The
+These pin libsession's signed-message construction (wire spec §1.1 / §2 / §3). The
 vectors are produced here from the *backend's* independent implementation (backend.signed_message +
 the make_*_message / build_proof_message builders) for fixed, deterministic inputs, then hand-verified
 against the spec field layout before being frozen into the C++ test. Re-run this if the signed-message
@@ -48,7 +48,7 @@ def main():
     add_msg = backend.signed_message(
         backend.ADD_PRO_PAYMENT_DOMAIN, mpk, rpk, provider.value, pid)
     gen_msg = backend.make_generate_pro_proof_message(mpk, rpk, ts)
-    # Delta #15: get_pro_details split into get_pro_status + paginated get_payment_details.
+    # get_pro_details read request is split (§3.4) into get_pro_status + paginated get_payment_details.
     status_msg = backend.make_get_pro_status_message(mpk, ts)
     # Two payment_details cases: empty `before` (newest page) ends in the adjacency `\0`;
     # a non-empty `before` appends the opaque cursor verbatim as the final field (no trailing sep).

--- a/tests/pro_backend/run-dev-backend.sh
+++ b/tests/pro_backend/run-dev-backend.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Stand up an ephemeral, hermetic Session Pro backend and run the libsession [pro_live] integration
+# tests against it, then tear everything down. No CTest, no Docker: this script IS the entry point.
+#
+#   run-dev-backend.sh <path-to-testAll> [catch2 args...]
+#
+# It:
+#   1. generates an ephemeral Ed25519 signing key   (session-router-config -k)
+#   2. spins up a throwaway PostgreSQL cluster       (initdb + pg_ctl, unix socket in a temp dir)
+#   3. starts the backend                            (flask --app main, KEY_PATH, no dev mode)
+#   4. polls /status until ready
+#   5. runs testAll against it (default filter [pro_live])
+#   6. tears it all down on exit
+#
+# Env overrides:
+#   SESSION_PRO_BACKEND_DIR   backend repo         (default ~/src/session-pro-backend-itest)
+#   PRO_BACKEND_PORT          flask + pg port      (default 5055)
+#
+# NB: SESSION_PRO_BACKEND_DIR should be our OWN tracking clone of the backend (with its own .venv),
+# NOT the backend agent's live working repo -- that repo is actively edited and may be mid-change.
+# Update the clone deliberately (git -C <clone> pull) when we want to track the backend's latest.
+#
+set -euo pipefail
+
+TESTALL="${1:?usage: run-dev-backend.sh <testAll binary> [catch2 args...]}"
+shift || true
+BACKEND_DIR="${SESSION_PRO_BACKEND_DIR:-$HOME/src/session-pro-backend-itest}"
+PORT="${PRO_BACKEND_PORT:-5055}"
+PGBIN="$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -V | tail -1)"
+VENV_PY="$BACKEND_DIR/.venv/bin/python"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[ -x "$TESTALL" ] || { echo "!! testAll not executable: $TESTALL" >&2; exit 2; }
+[ -x "$VENV_PY" ] || { echo "!! backend venv python missing: $VENV_PY" >&2; exit 2; }
+[ -n "$PGBIN" ]   || { echo "!! postgres bin dir not found under /usr/lib/postgresql" >&2; exit 2; }
+command -v session-router-config >/dev/null || { echo "!! session-router-config not on PATH" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+PGDATA="$WORK/pgdata"
+KEYFILE="$WORK/backend.key"
+FLASK_LOG="$WORK/flask.log"
+PG_LOG="$WORK/pg.log"
+FLASK_PID=""
+
+cleanup() {
+    rc=$?
+    [ -n "$FLASK_PID" ] && kill "$FLASK_PID" 2>/dev/null || true
+    [ -d "$PGDATA" ] && "$PGBIN/pg_ctl" -D "$PGDATA" -m immediate stop >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+    exit $rc
+}
+trap cleanup EXIT INT TERM
+
+echo ">> ephemeral signing key: $KEYFILE"
+session-router-config -f -k "$KEYFILE" >/dev/null
+
+echo ">> initdb: $PGDATA"
+"$PGBIN/initdb" -D "$PGDATA" --auth-local=trust --no-instructions -U "$USER" >/dev/null
+
+echo ">> start postgres (unix socket in $WORK, port $PORT)"
+"$PGBIN/pg_ctl" -D "$PGDATA" -l "$PG_LOG" \
+    -o "-c listen_addresses= -k $WORK -p $PORT" -w start >/dev/null
+createdb -h "$WORK" -p "$PORT" -U "$USER" pro_backend
+
+export SESH_PRO_BACKEND_DB_URL="postgresql:///pro_backend?host=$WORK&port=$PORT&user=$USER"
+export SESH_PRO_BACKEND_KEY_PATH="$KEYFILE"
+# Stub all payment-provider egress so a real add_pro_payment redeems (google/app_store/rangeproof)
+# without contacting Google/Apple. Landed backend-side (base.PROVIDER_DRY_RUN). No platform creds and
+# no with_platform_* needed: the provider comes from the seeded row, not from platform config.
+export SESH_PRO_BACKEND_PROVIDER_DRY_RUN=1
+
+echo ">> start flask on 127.0.0.1:$PORT (log: $FLASK_LOG)"
+( cd "$BACKEND_DIR" && exec "$VENV_PY" -m flask --app main run --port "$PORT" ) >"$FLASK_LOG" 2>&1 &
+FLASK_PID=$!
+
+echo ">> waiting for /status ..."
+ready=""
+for _ in $(seq 1 60); do
+    if curl -fsS "http://127.0.0.1:$PORT/status" >/dev/null 2>&1; then ready=1; break; fi
+    if ! kill -0 "$FLASK_PID" 2>/dev/null; then
+        echo "!! flask exited during startup:" >&2; cat "$FLASK_LOG" >&2; exit 3
+    fi
+    sleep 0.5
+done
+[ "$ready" = 1 ] || { echo "!! backend not ready in time:" >&2; cat "$FLASK_LOG" >&2; exit 3; }
+echo ">> backend ready"
+
+# Expose the seeding helper to the test process (it shells out to inject witnessed payments /
+# revocations directly into the DB). DB URL is already exported above and inherited by testAll.
+export PRO_BACKEND_DIR="$BACKEND_DIR"
+export PRO_SEED_PYTHON="$VENV_PY"
+export PRO_SEED_SCRIPT="$SCRIPT_DIR/seed_payment.py"
+
+echo ">> running: $TESTALL ${*:-[pro_live]}"
+set +e
+"$TESTALL" --pro-backend-dev-server-url="http://127.0.0.1:$PORT" "${@:-[pro_live]}"
+rc=$?
+set -e
+echo ">> testAll exited $rc"
+exit $rc

--- a/tests/pro_backend/run-dev-backend.sh
+++ b/tests/pro_backend/run-dev-backend.sh
@@ -23,6 +23,14 @@
 #
 set -euo pipefail
 
+# Force a UTF-8 locale for the ephemeral cluster and every DB client. Backend migration SQL contains
+# non-ASCII bytes (e.g. an em-dash in a comment); psycopg encodes each query with the connection's
+# client encoding, which follows the DB/locale. A minimal CI container often runs a C/POSIX locale ->
+# ASCII client encoding -> `UnicodeEncodeError: 'ascii' codec can't encode '—'` while bootstrapping
+# the DB. C.UTF-8 is always present in glibc (no locale-gen needed), so this makes initdb build a UTF8
+# cluster and flask/seed/psql all speak UTF-8, matching production. Overrides any inherited C locale.
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
 TESTALL="${1:?usage: run-dev-backend.sh <testAll binary> [catch2 args...]}"
 shift || true
 BACKEND_DIR="${SESSION_PRO_BACKEND_DIR:-$HOME/src/session-pro-backend-itest}"
@@ -56,7 +64,7 @@ echo ">> ephemeral signing key: $KEYFILE"
 session-router-config -f -k "$KEYFILE" >/dev/null
 
 echo ">> initdb: $PGDATA"
-"$PGBIN/initdb" -D "$PGDATA" --auth-local=trust --no-instructions -U "$USER" >/dev/null
+"$PGBIN/initdb" -D "$PGDATA" --encoding=UTF8 --auth-local=trust --no-instructions -U "$USER" >/dev/null
 
 echo ">> start postgres (unix socket in $WORK, port $PORT)"
 "$PGBIN/pg_ctl" -D "$PGDATA" -l "$PG_LOG" \

--- a/tests/pro_backend/seed_payment.py
+++ b/tests/pro_backend/seed_payment.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Seed backend DB state for the libsession [pro_live] integration tests.
+
+Injects the "as if a provider purchase notification was witnessed" state straight into postgres, so
+a subsequent *real* add_pro_payment from the client redeems it -- no dev-mode, no fake provider
+egress (provider_dry_run stubs the egress; this just supplies the witnessed row the egress would
+otherwise have created). This mirrors what the backend's own test.py does in-process
+(test_provider_dry_run_redeems_google_without_egress / test_server_add_payment_flow), except we run
+out-of-process against the same DB.
+
+Run with the backend clone's venv python. Requires env:
+  SESH_PRO_BACKEND_DB_URL   postgres DSN (same one the backend uses)
+  PRO_BACKEND_DIR           path to the backend clone (for importing base/backend/db)
+
+Usage:
+  seed_payment.py payment --provider {google_play,app_store,rangeproof} --payment-id ID
+                          --master-pubkey HEX64 [--plan 1m|3m|1y] [--expiry-days N]
+  seed_payment.py revoke  --provider {google_play,app_store} --payment-id ID
+"""
+import argparse
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.environ["PRO_BACKEND_DIR"])
+
+import nacl.signing  # noqa: E402
+
+import backend  # noqa: E402
+import base  # noqa: E402
+import db  # noqa: E402
+
+
+def _open():
+    err = base.ErrorSink()
+    url = os.environ["SESH_PRO_BACKEND_DB_URL"]
+    # bootstrap_db no longer takes/uses an ErrorSink (it raises on failure); the err sink is still
+    # used by the add_unredeemed_payment / add_*_revocation calls below.
+    engine = backend.bootstrap_db(database_url=url)
+    if engine is None:
+        sys.exit("seed: bootstrap_db failed")
+    return engine, engine.getconn(), err
+
+
+def _payment_tx(provider, payment_id):
+    tx = base.PaymentProviderTransaction()
+    if provider == "google_play":
+        tx.provider = base.PaymentProvider.GooglePlayStore
+        # Google's composite payment_id is "<token>|<order_id>", split once on the first '|'
+        # (matches the backend's own split).
+        token, _, order = payment_id.partition("|")
+        tx.google_payment_token = token
+        tx.google_order_id = order
+    elif provider == "app_store":
+        tx.provider = base.PaymentProvider.iOSAppStore
+        # The wire payment_id is the transaction id; the backend row also wants the original tx id
+        # (same value for a first purchase) and a web-line order id (empty).
+        tx.apple_tx_id = payment_id
+        tx.apple_original_tx_id = payment_id
+        tx.apple_web_line_order_tx_id = ""
+    elif provider == "rangeproof":
+        tx.provider = base.PaymentProvider.Rangeproof
+        tx.rangeproof_order_id = payment_id
+    else:
+        sys.exit(f"seed: unknown provider {provider}")
+    return tx
+
+
+def _obfuscated_id(provider, vk):
+    if provider == "google_play":
+        return backend.google_obfuscated_account_id_from_master_pkey(vk)
+    if provider == "app_store":
+        return backend.apple_obfuscated_account_id_from_master_pkey(vk)
+    return b""
+
+
+def cmd_payment(args):
+    engine, conn, err = _open()
+    try:
+        vk = nacl.signing.VerifyKey(bytes.fromhex(args.master_pubkey))
+        now = datetime.datetime.now(datetime.timezone.utc)
+        plan = base.ProPlan.from_string(args.plan)
+        if plan is None:
+            sys.exit(f"seed: bad plan {args.plan}")
+        # add_unredeemed_payment is @db.transactional: pass the connection positionally (it opens a
+        # transaction for the call). The wrapper's first param is named `tx`, so `conn=` won't bind.
+        backend.add_unredeemed_payment(
+            conn,
+            payment_tx=_payment_tx(args.provider, args.payment_id),
+            plan=plan,
+            purchased_at=now,
+            expires_at=base.round_datetime_to_next_day(now)
+            + datetime.timedelta(days=args.expiry_days),
+            platform_refund_expires_at=base.EPOCH,
+            platform_obfuscated_account_id=_obfuscated_id(args.provider, vk),
+            err=err,
+        )
+        if err.msg_list:
+            sys.exit(f"seed: add_unredeemed_payment failed: {err.msg_list}")
+    finally:
+        engine.putconn(conn)
+        engine.close()
+
+
+def cmd_revoke(args):
+    # Revocation is keyed by the *provider* payment identifier (the generations-table refactor
+    # replaced the old master-pkey-keyed set_revocation_tx). Revoking the payment marks its
+    # generation revoked (revoked_at set, terminal), which is what get_pro_revocations surfaces.
+    engine, conn, err = _open()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with db.transaction(conn) as tx:
+            if args.provider == "app_store":
+                ok = backend.add_apple_revocation(
+                    tx, apple_original_tx_id=args.payment_id, revoke_at=now, err=err
+                )
+            elif args.provider == "google_play":
+                token, _, _ = args.payment_id.partition("|")
+                ok = backend.add_google_revocation(
+                    tx, google_payment_token=token, revoke_at=now, err=err
+                )
+            else:
+                sys.exit(f"seed: revoke unsupported for provider {args.provider}")
+        if err.msg_list or not ok:
+            sys.exit(f"seed: revoke failed (ok={ok}): {err.msg_list}")
+    finally:
+        engine.putconn(conn)
+        engine.close()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("payment", help="seed a witnessed-unredeemed payment")
+    p.add_argument("--provider", required=True,
+                   choices=["google_play", "app_store", "rangeproof"])
+    p.add_argument("--payment-id", required=True)
+    p.add_argument("--master-pubkey", required=True, help="64 hex chars")
+    p.add_argument("--plan", default="1m")
+    p.add_argument("--expiry-days", type=int, default=30)
+    p.set_defaults(fn=cmd_payment)
+
+    r = sub.add_parser("revoke", help="revoke the generation for a provider payment")
+    r.add_argument("--provider", required=True, choices=["google_play", "app_store"])
+    r.add_argument("--payment-id", required=True,
+                   help="same id used to seed the payment (app_store: tx id; google: <token>|<order>)")
+    r.set_defaults(fn=cmd_revoke)
+
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -727,6 +727,157 @@ TEST_CASE("Pro Backend parse_plan_period (closed grammar)", "[pro_backend]") {
         CHECK_FALSE(parse_plan_period(bad).has_value());
 }
 
+// ---------------------------------------------------------------------------
+// Known-answer vectors (tag [pro_kat]) -- SERVER-LESS (runs in an ordinary testAll build).
+//
+// These pin libsession's signed-message construction (wire spec 1.1 / 2 / 3.1-3.4, Delta #13) to
+// fixed byte vectors that were generated from the backend's *independent* implementation and then
+// hand-verified against the spec layout (generator: tests/pro_backend/gen_kat.py). The live
+// [pro_live] suite catches libsession<->backend *drift*; a KAT additionally catches a fault where
+// BOTH sides share the same wrong construction (they would still agree with each other), needs no
+// running backend, and freezes the wire format against silent future drift. Ed25519 is
+// deterministic (RFC 8032), so a signature over a fixed message under a fixed key is itself a known
+// answer.
+//
+// Fixed inputs: keypairs from 32-byte seeds 0x01.. / 0x02.. (backend key 0x03..), ts=1700000000,
+// refund_ts=1700000123, expiry=1704067200, count=10, provider="google_play",
+// payment_id="test-payment-id-123", revocation_tag=0x11 x32.
+TEST_CASE("Pro backend known-answer vectors", "[pro_backend][pro_kat]") {
+    auto keypair = [](unsigned char seed_byte) {
+        std::array<unsigned char, 32> pk{};
+        std::array<unsigned char, 64> sk{};
+        std::array<unsigned char, 32> seed{};
+        seed.fill(seed_byte);
+        crypto_sign_seed_keypair(pk.data(), sk.data(), seed.data());
+        return std::pair{pk, sk};
+    };
+    auto [master_pk, master_sk] = keypair(0x01);
+    auto [rotating_pk, rotating_sk] = keypair(0x02);
+    auto [backend_pk, backend_sk] = keypair(0x03);
+    (void)backend_sk;
+
+    const auto ts = session::as_sys_seconds(1700000000);
+    const auto refund_ts = session::as_sys_seconds(1700000123);
+    const auto expiry = session::as_sys_seconds(1704067200);
+    const std::string provider = "google_play";
+    const std::string payment_id = "test-payment-id-123";
+    auto pid_span = [&]() {
+        return std::span<const uint8_t>{
+                reinterpret_cast<const uint8_t*>(payment_id.data()), payment_id.size()};
+    };
+
+    // Expected signed-message bytes (hex), each hand-verified against the spec field layout.
+    const std::string add_msg_hex =
+            "50726f4164645061796d656e745f5f5f8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01"
+            "b40f6f5c8139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394676f6f676c655f"
+            "70"
+            "6c617900746573742d7061796d656e742d69642d313233";
+    const std::string gen_msg_hex =
+            "50726f47656e657261746550726f6f668a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01"
+            "b40f6f5c8139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b39431373030303030"
+            "303030";
+    // Delta #15: get_pro_details split into get_pro_status (master + ts) and paginated
+    // get_payment_details (master + ts + limit + before). Two details vectors pin the `before`
+    // framing: empty `before` (newest page) ends in the adjacency \0; a non-empty cursor is the
+    // opaque final field (no trailing separator).
+    const std::string status_msg_hex =
+            "50726f47657450726f5374617475735f8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01b40f6f5c31373030303030303030";
+    const std::string details_empty_msg_hex =
+            "50726f47657450617944657461696c738a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01b40f6f5c3137303030303030303000313000";
+    const std::string details_cursor_msg_hex =
+            "50726f47657450617944657461696c738a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01b40f6f5c3137303030303030303000313000306131623263336434653566";
+    const std::string refund_msg_hex =
+            "50726f536574526566756e645265715f8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf37488"
+            "01"
+            "b40f6f5c31373030303030303030003137303030303031323300676f6f676c655f706c617900746573742d"
+            "70"
+            "61796d656e742d69642d313233";
+    const std::string proof_msg_hex =
+            "50726f50726f6f665f76305f5f5f5f5f111111111111111111111111111111111111111111111111111111"
+            "1111"
+            "1111118139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b3943137303430363732"
+            "3030";
+
+    // Assert `field`'s hex signature in request body `body` is a valid Ed25519 signature of the
+    // expected message bytes under `pubkey` -- i.e. libsession signed *exactly* the spec message.
+    auto sig_covers = [](const std::string& body,
+                         const char* field,
+                         const std::string& expected_msg_hex,
+                         const std::array<unsigned char, 32>& pubkey) -> bool {
+        auto j = nlohmann::json::parse(body);
+        if (!j.contains(field))
+            return false;
+        auto sig = oxenc::from_hex(j.at(field).get<std::string>());
+        auto msg = oxenc::from_hex(expected_msg_hex);
+        return sig.size() == 64 && crypto_sign_verify_detached(
+                                           reinterpret_cast<const unsigned char*>(sig.data()),
+                                           reinterpret_cast<const unsigned char*>(msg.data()),
+                                           msg.size(),
+                                           pubkey.data()) == 0;
+    };
+
+    SECTION("add_pro_payment") {
+        auto req = add_payment_request(master_sk, rotating_sk, provider, pid_span());
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_ADD_PRO_PAYMENT_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", add_msg_hex, master_pk));
+        CHECK(sig_covers(req.data, "rotating_sig", add_msg_hex, rotating_pk));
+        // Determinism pin: the exact master signature is itself a known answer.
+        CHECK(nlohmann::json::parse(req.data).at("master_sig").get<std::string>() ==
+              "746861ae1681d996e837d603dbd21c06c9544c5fc536eb4d3e3cad4f13692b79"
+              "0ef2b1282b729aa42f537d560b3b97b231b7f940be7021c0e16f894817a57609");
+    }
+    SECTION("generate_pro_proof") {
+        auto req = pro_proof_request(master_sk, rotating_sk, ts);
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_GENERATE_PRO_PROOF_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", gen_msg_hex, master_pk));
+        CHECK(sig_covers(req.data, "rotating_sig", gen_msg_hex, rotating_pk));
+    }
+    SECTION("get_pro_status") {
+        auto req = pro_status_request(master_sk, ts);
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_GET_PRO_STATUS_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", status_msg_hex, master_pk));
+    }
+    SECTION("get_payment_details (newest page, empty before)") {
+        auto req = payment_details_request(master_sk, ts, 10, "");
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_GET_PAYMENT_DETAILS_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", details_empty_msg_hex, master_pk));
+    }
+    SECTION("get_payment_details (with cursor)") {
+        auto req = payment_details_request(master_sk, ts, 10, "0a1b2c3d4e5f");
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_GET_PAYMENT_DETAILS_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", details_cursor_msg_hex, master_pk));
+    }
+    SECTION("set_payment_refund_requested") {
+        auto req = refund_request(master_sk, ts, refund_ts, provider, pid_span());
+        CHECK(req.endpoint == SESSION_PRO_BACKEND_SET_PAYMENT_REFUND_REQUESTED_ENDPOINT);
+        CHECK(sig_covers(req.data, "master_sig", refund_msg_hex, master_pk));
+    }
+    SECTION("pro proof") {
+        session::ProProof proof;
+        proof.version = 0;
+        std::memset(proof.revocation_tag.data(), 0x11, proof.revocation_tag.size());
+        std::memcpy(proof.rotating_pubkey.data(), rotating_pk.data(), 32);
+        proof.expiry_at = expiry;
+        auto sig = oxenc::from_hex(
+                "767e7f14cec2d04fb67c6407e890cbe6a5cfdb7a0df3e729adda93164b13bc3f"
+                "b20ed4ea1b8f1ffc74115ff2598a51ac52285d923f0864c6bca08bfc771fb708");
+        std::memcpy(proof.sig.data(), sig.data(), 64);
+
+        // Direct pin of the proof (spec section 2) message construction.
+        CHECK(oxenc::to_hex(proof.signed_message()) == proof_msg_hex);
+        // The frozen backend signature (key 0x03 over that message) verifies; a wrong key does not.
+        CHECK(proof.verify_signature(backend_pk));
+        auto wrong = backend_pk;
+        wrong[0] ^= 0x01;
+        CHECK_FALSE(proof.verify_signature(wrong));
+    }
+}
+
 #if defined(TEST_PRO_BACKEND_WITH_DEV_SERVER)
 #include <curl/curl.h>
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -730,7 +730,7 @@ TEST_CASE("Pro Backend parse_plan_period (closed grammar)", "[pro_backend]") {
 // ---------------------------------------------------------------------------
 // Known-answer vectors (tag [pro_kat]) -- SERVER-LESS (runs in an ordinary testAll build).
 //
-// These pin libsession's signed-message construction (wire spec 1.1 / 2 / 3.1-3.4, Delta #13) to
+// These pin libsession's signed-message construction (wire spec §1.1 / §2 / §3) to
 // fixed byte vectors that were generated from the backend's *independent* implementation and then
 // hand-verified against the spec layout (generator: tests/pro_backend/gen_kat.py). The live
 // [pro_live] suite catches libsession<->backend *drift*; a KAT additionally catches a fault where
@@ -778,7 +778,7 @@ TEST_CASE("Pro backend known-answer vectors", "[pro_backend][pro_kat]") {
             "01"
             "b40f6f5c8139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b39431373030303030"
             "303030";
-    // Delta #15: get_pro_details split into get_pro_status (master + ts) and paginated
+    // get_pro_details is split (§3.4) into get_pro_status (master + ts) and paginated
     // get_payment_details (master + ts + limit + before). Two details vectors pin the `before`
     // framing: empty `before` (newest page) ends in the adjacency \0; a non-empty cursor is the
     // opaque final field (no trailing separator).
@@ -1127,7 +1127,7 @@ static std::array<uint8_t, 32> fetch_backend_pubkey(const PostFn& transport) {
 // The core wire-contract flow: build *real* requests with the C++ API, send them over onion to a
 // backend that redeems a witnessed (seeded) payment, and check every response parses + the issued
 // proofs verify against the backend's signing key. Any signed-message drift on either side (field
-// order, integer encoding, `\0` framing, domain prefix -- Delta #13 signs the message bytes
+// order, integer encoding, `\0` framing, domain prefix -- the scheme signs the message bytes
 // directly, no hash) or a renamed JSON key breaks this. Runs the whole flow once per provider via
 // SECTIONs: google_play exercises the composite "token|order_id" payment_id, app_store the plain tx
 // id. Each SECTION uses fresh keys + a freshly-seeded payment, so the runs are independent on the
@@ -1209,7 +1209,7 @@ TEST_CASE("Pro backend live full flow", "[pro_backend][pro_live]") {
     // Same subscription epoch -> the fresh proof shares the add-payment proof's revocation_tag.
     CHECK(gen.proof.revocation_tag == add.proof.revocation_tag);
 
-    // 2) get_pro_status (Delta #15): account ACTIVE, no refund yet, and the single latest payment
+    // 2) get_pro_status: account ACTIVE, no refund yet, and the single latest payment
     //    is our redeemed one.
     ProStatusResponse status = parse_pro_status(send(onion, pro_status_request(master_sk, now)));
     INFO("get_pro_status " << status.error.value_or(""));
@@ -1219,12 +1219,12 @@ TEST_CASE("Pro backend live full flow", "[pro_backend][pro_live]") {
     REQUIRE(status.latest_payment.has_value());
     CHECK(status.latest_payment->payment_id == payment_id);
     CHECK(status.latest_payment->payment_provider == provider);
-    // plan is the parsed billing period (Delta #14): "1m" -> {count 1, month}.
+    // plan is the parsed billing period (§1): "1m" -> {count 1, month}.
     CHECK(status.latest_payment->plan.count == 1);
     CHECK(status.latest_payment->plan.unit == ProPlanUnit::month);
     CHECK(status.latest_payment->status == "redeemed");
 
-    // 2b) get_payment_details (Delta #15): newest page (empty cursor) carries our payment. This
+    // 2b) get_payment_details: newest page (empty cursor) carries our payment. This
     //     master has exactly one payment, so it fits in one page and next_cursor is empty.
     PaymentDetailsResponse det =
             parse_payment_details(send(onion, payment_details_request(master_sk, now, 10, "")));

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -730,6 +730,13 @@ TEST_CASE("Pro Backend parse_plan_period (closed grammar)", "[pro_backend]") {
 #if defined(TEST_PRO_BACKEND_WITH_DEV_SERVER)
 #include <curl/curl.h>
 
+#include <cstdlib>
+#include <functional>
+#include <session/network/key_types.hpp>
+#include <session/network/session_network_types.hpp>
+#include <session/onionreq/builder.hpp>
+#include <session/onionreq/response_parser.hpp>
+
 size_t curl_perform_callback(void* contents, size_t size, size_t nmemb, void* userp) {
     size_t total = size * nmemb;
     auto* response_json = static_cast<std::string*>(userp);
@@ -760,304 +767,437 @@ std::string curl_do_basic_blocking_post_request(
     return result;
 }
 
-TEST_CASE("Pro Backend Dev Server", "[pro_backend][dev_server]") {
-    // Setup: Generate keys and payment token hash
-    bytes32 master_pubkey = {};
-    bytes64 master_privkey = {};
-    crypto_sign_ed25519_keypair(master_pubkey.data, master_privkey.data);
+// ---------------------------------------------------------------------------
+// Dev-server transport helpers.
+//
+// A transport delivers a Pro request body to a named endpoint on the running dev backend and
+// returns the response body (JSON). We drive the identical libsession C++ request builders/parsers
+// through each, so the same test flow can run over the two production request modes on pfs/dev:
+//
+//   * `make_direct_http_transport` -- plain HTTP POST to `<base>/<endpoint>`. This is the faithful
+//     representation of session-router mode, where libsession opens a tunnel to a private local
+//     address and makes unencrypted HTTP through it.
+//   * `make_onion_v4_transport`    -- builds only the innermost v4 onion piece (a zero-hop
+//     `onionreq::Builder` addressed to the backend's x25519 key), POSTs it to
+//     `<base>/oxen/v4/lsrpc`, and decrypts the reply with `onionreq::ResponseParser`. This is
+//     onion-request mode. (The stable backport uses only this transport.)
+//
+// Both move bytes with libcurl. The onion path does not build a real multi-hop route (that is a
+// separate, stable protocol tested elsewhere) -- only the final destination-encrypted layer, which
+// is exactly what `/oxen/v4/lsrpc` decrypts.
+// ---------------------------------------------------------------------------
 
-    bytes32 rotating_pubkey = {};
-    bytes64 rotating_privkey = {};
-    crypto_sign_ed25519_keypair(rotating_pubkey.data, rotating_privkey.data);
+// A transport delivers a request (endpoint + content_type + opaque body) to the backend and returns
+// the response body. `content_type` is what libsession's *_request() builders emit; clients must
+// relay it verbatim (libsession owns the wire encoding and it may change).
+using PostFn = std::function<std::string(
+        std::string_view endpoint, std::string_view content_type, std::string_view body)>;
 
-    const auto DEV_BACKEND_PUBKEY =
-            "fc947730f49eb01427a66e050733294d9e520e545c7a27125a780634e0860a27"_hexbytes;
+// Drive a transport straight from a built ProRequest.
+static std::string send(const PostFn& transport, const ProRequest& r) {
+    return transport(r.endpoint, r.content_type, r.data);
+}
 
-    // Setup CURL
+// Split e.g. "http://127.0.0.1:5000" into protocol / host / port.
+struct ParsedBackendUrl {
+    std::string protocol;
+    std::string host;
+    uint16_t port;
+};
+static ParsedBackendUrl parse_backend_url(std::string_view url) {
+    ParsedBackendUrl r;
+    auto pos = url.find("://");
+    r.protocol = pos == std::string_view::npos ? "http" : std::string{url.substr(0, pos)};
+    std::string_view rest = pos == std::string_view::npos ? url : url.substr(pos + 3);
+    if (auto slash = rest.find('/'); slash != std::string_view::npos)
+        rest = rest.substr(0, slash);
+    if (auto colon = rest.find(':'); colon != std::string_view::npos) {
+        r.host = std::string{rest.substr(0, colon)};
+        r.port = static_cast<uint16_t>(std::stoi(std::string{rest.substr(colon + 1)}));
+    } else {
+        r.host = std::string{rest};
+        r.port = r.protocol == "https" ? 443 : 80;
+    }
+    return r;
+}
+
+static std::string join_url(std::string_view base, std::string_view path) {
+    std::string url{base};
+    if (!url.empty() && url.back() == '/')
+        url.pop_back();
+    if (!path.empty() && path.front() != '/')
+        url += '/';
+    url += path;
+    return url;
+}
+
+// Plain HTTP POST to `<base>/<endpoint>` (session-router tunnel mode), relaying content_type.
+static PostFn make_direct_http_transport(CURL* curl, std::string base_url) {
+    return [curl, base_url = std::move(base_url)](
+                   std::string_view endpoint,
+                   std::string_view content_type,
+                   std::string_view body) {
+        curl_slist* headers =
+                curl_slist_append(nullptr, ("Content-Type: " + std::string{content_type}).c_str());
+        scope_exit free_headers{[&]() { curl_slist_free_all(headers); }};
+        return curl_do_basic_blocking_post_request(
+                curl, headers, join_url(base_url, endpoint), body);
+    };
+}
+
+// Innermost v4 onion piece to `<base>/oxen/v4/lsrpc` (onion-request mode). `backend_ed25519_pubkey`
+// is the backend's signing pubkey (fetched from /status); its x25519 form is the destination key.
+static PostFn make_onion_v4_transport(
+        CURL* curl, std::string base_url, std::span<const uint8_t, 32> backend_ed25519_pubkey) {
+    using namespace session::network;
+    using namespace session::onionreq;
+
+    auto parts = parse_backend_url(base_url);
+    x25519_pubkey backend_x25519 = compute_x25519_pubkey(backend_ed25519_pubkey);
+
+    return [curl, base_url = std::move(base_url), parts, backend_x25519](
+                   std::string_view endpoint,
+                   std::string_view content_type,
+                   std::string_view body) {
+        // Relay content_type as the inner (proxied) request's Content-Type.
+        std::vector<std::pair<std::string, std::string>> inner_headers{
+                {"Content-Type", std::string{content_type}}};
+        ServerDestination dest{
+                parts.protocol,
+                parts.host,
+                backend_x25519,
+                parts.port,
+                std::move(inner_headers),
+                "POST"};
+
+        Builder builder{
+                network_destination{dest},
+                std::string{endpoint},
+                /*nodes=*/{},
+                EncryptType::xchacha20};
+
+        std::vector<unsigned char> body_bytes{
+                reinterpret_cast<const unsigned char*>(body.data()),
+                reinterpret_cast<const unsigned char*>(body.data()) + body.size()};
+        std::vector<unsigned char> blob = builder.generate_onion_blob(std::move(body_bytes));
+
+        // The lsrpc body is the raw encrypted onion blob; post it as opaque bytes. (An unheadered
+        // curl POST defaults to application/x-www-form-urlencoded, which makes Werkzeug consume the
+        // body into request.form and leaves request.data empty -> the backend 400s.)
+        curl_slist* octet_headers =
+                curl_slist_append(nullptr, "Content-Type: application/octet-stream");
+        scope_exit octet_free{[&]() { curl_slist_free_all(octet_headers); }};
+
+        std::string encrypted_response = curl_do_basic_blocking_post_request(
+                curl,
+                octet_headers,
+                join_url(base_url, "/oxen/v4/lsrpc"),
+                std::string_view{reinterpret_cast<const char*>(blob.data()), blob.size()});
+
+        // ResponseParser reuses the builder's saved ephemeral keypair to decrypt the reply.
+        ResponseParser parser{builder};
+        DecryptedResponse resp = parser.decrypted_response(encrypted_response);
+        return resp.body.value_or(std::string{});
+    };
+}
+
+// Live-backend tests (tag [pro_live]), run against an ephemeral dev backend stood up by
+// tests/pro_backend/run-dev-backend.sh: they drive the C++ API over the real request path against a
+// real backend (redemption via provider_dry_run + a DB-seeded witnessed payment). This first case
+// validates the infrastructure + both transports end-to-end via /status.
+TEST_CASE("Pro backend live /status round-trip", "[pro_backend][pro_live]") {
     curl_global_init(CURL_GLOBAL_DEFAULT);
     scope_exit curl_cleanup{[&]() { curl_global_cleanup(); }};
-
     CURL* curl = curl_easy_init();
     REQUIRE(curl);
     scope_exit curl_free{[&]() { curl_easy_cleanup(curl); }};
 
-    struct curl_slist* curl_headers = nullptr;
-    curl_headers = curl_slist_append(curl_headers, "Content-Type: application/json");
-    REQUIRE(curl_headers);
-    scope_exit curl_headers_free{[&]() { curl_slist_free_all(curl_headers); }};
+    const std::string& base_url = g_test_pro_backend_dev_server_url;
 
-    // Add pro payment
-    session_protocol_pro_proof first_pro_proof = {};
-    {
-        std::array<uint8_t, 8> fake_google_payment_token;
-        randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
-        std::array<uint8_t, 8> fake_google_order_id;
-        randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        // Google's composite payment_id is "<payment_token>|<order_id>"; libsession treats the
-        // whole thing as one opaque value.
-        std::string fake_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
-                                      oxenc::to_hex(fake_google_order_id);
+    // Parse the /status success envelope and return the signing pubkey (hex).
+    auto status_pubkey_hex = [](std::string_view response_json) -> std::string {
+        INFO("/status response: " << response_json);
+        auto j = nlohmann::json::parse(response_json);
+        REQUIRE(j.at("status").get<std::string>() == "ok");
+        const auto& result = j.at("result");
+        CHECK(result.contains("version"));
+        CHECK(result.contains("timestamp"));
+        auto pubkey = result.at("signing_pubkey").get<std::string>();
+        REQUIRE(pubkey.size() == 64);
+        REQUIRE(oxenc::is_hex(pubkey));
+        return pubkey;
+    };
 
-        session_pro_backend_request request_json =
-                session_pro_backend_add_pro_payment_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        rotating_privkey.data,
-                        sizeof(rotating_privkey.data),
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                        reinterpret_cast<const uint8_t*>(fake_payment_id.data()),
-                        fake_payment_id.size());
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
+    // 1) Fetch /status over the direct (session-router-style) HTTP transport.
+    PostFn direct = make_direct_http_transport(curl, base_url);
+    std::string direct_pubkey = status_pubkey_hex(direct("status", "application/json", ""));
 
-        // Do curl request
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/add_pro_payment",
-                std::string_view(request_json.data.data, request_json.data.size));
+    // 2) Build the onion transport from the pubkey we just fetched, then re-fetch /status over it:
+    //    this exercises the full v4 onion encrypt/decrypt round-trip against the real backend.
+    auto pubkey_bytes = oxenc::from_hex(direct_pubkey);
+    REQUIRE(pubkey_bytes.size() == 32);
+    std::array<uint8_t, 32> ed_pubkey{};
+    std::memcpy(ed_pubkey.data(), pubkey_bytes.data(), ed_pubkey.size());
 
-        // Parse response
-        session_pro_backend_pro_proof_response response =
-                session_pro_backend_pro_proof_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
+    PostFn onion = make_onion_v4_transport(curl, base_url, ed_pubkey);
+    std::string onion_pubkey = status_pubkey_hex(onion("status", "application/json", ""));
 
-        if (response.header.error)
-            INFO("ERROR: " << response.header.error);
+    // Both transports must report the same signing key.
+    CHECK(onion_pubkey == direct_pubkey);
+}
 
-        // Verify response
-        first_pro_proof = response.proof;
-        INFO("Signature: " << oxenc::to_hex(
-                                      first_pro_proof.sig.data, std::end(first_pro_proof.sig.data))
-                           << ", backend pubkey: " << oxenc::to_hex(DEV_BACKEND_PUBKEY)
-                           << ", response: " << response_json);
-        REQUIRE(session_protocol_pro_proof_verify_signature(
-                &first_pro_proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
-        REQUIRE(std::memcmp(
-                        response.proof.rotating_pubkey.data,
-                        rotating_pubkey.data,
-                        sizeof(rotating_pubkey.data)) == 0);
+// Shell out to the python seeding helper (tests/pro_backend/seed_payment.py) to inject backend DB
+// state (a witnessed-unredeemed payment, or a revocation) directly. The launcher exports
+// PRO_SEED_PYTHON / PRO_SEED_SCRIPT / PRO_BACKEND_DIR and the shared SESH_PRO_BACKEND_DB_URL. Args
+// are test-controlled, so the naive single-quote wrapping is sufficient.
+static void run_seed_helper(const std::vector<std::string>& args) {
+    const char* py = std::getenv("PRO_SEED_PYTHON");
+    const char* script = std::getenv("PRO_SEED_SCRIPT");
+    REQUIRE(py != nullptr);
+    REQUIRE(script != nullptr);
+    std::string cmd = std::string(py) + " " + script;
+    for (const auto& a : args)
+        cmd += " '" + a + "'";
+    INFO("seed: " << cmd);
+    REQUIRE(std::system(cmd.c_str()) == 0);
+}
+
+static std::array<uint8_t, 32> fetch_backend_pubkey(const PostFn& transport) {
+    auto j = nlohmann::json::parse(transport("status", "application/json", ""));
+    REQUIRE(j.at("status").get<std::string>() == "ok");
+    auto hex = j.at("result").at("signing_pubkey").get<std::string>();
+    auto bytes = oxenc::from_hex(hex);
+    REQUIRE(bytes.size() == 32);
+    std::array<uint8_t, 32> out{};
+    std::memcpy(out.data(), bytes.data(), out.size());
+    return out;
+}
+
+// The core wire-contract flow: build *real* requests with the C++ API, send them over onion to a
+// backend that redeems a witnessed (seeded) payment, and check every response parses + the issued
+// proofs verify against the backend's signing key. Any signed-message drift on either side (field
+// order, integer encoding, `\0` framing, domain prefix -- Delta #13 signs the message bytes
+// directly, no hash) or a renamed JSON key breaks this. Runs the whole flow once per provider via
+// SECTIONs: google_play exercises the composite "token|order_id" payment_id, app_store the plain tx
+// id. Each SECTION uses fresh keys + a freshly-seeded payment, so the runs are independent on the
+// shared ephemeral backend.
+TEST_CASE("Pro backend live full flow", "[pro_backend][pro_live]") {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    scope_exit curl_cleanup{[&]() { curl_global_cleanup(); }};
+    CURL* curl = curl_easy_init();
+    REQUIRE(curl);
+    scope_exit curl_free{[&]() { curl_easy_cleanup(curl); }};
+
+    const std::string& base_url = g_test_pro_backend_dev_server_url;
+    PostFn direct = make_direct_http_transport(curl, base_url);
+    std::array<uint8_t, 32> backend_pubkey = fetch_backend_pubkey(direct);
+    PostFn onion = make_onion_v4_transport(curl, base_url, backend_pubkey);
+
+    // Provider under test; the whole flow below re-runs once per SECTION.
+    std::string provider;
+    SECTION("google_play") {
+        provider = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY;
+    }
+    SECTION("app_store") {
+        provider = SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE;
+    }
+    INFO("provider=" << provider);
+
+    // Fresh account keys.
+    std::array<unsigned char, 32> master_pk{}, rotating_pk{};
+    std::array<unsigned char, 64> master_sk{}, rotating_sk{};
+    crypto_sign_ed25519_keypair(master_pk.data(), master_sk.data());
+    crypto_sign_ed25519_keypair(rotating_pk.data(), rotating_sk.data());
+    std::string master_hex = oxenc::to_hex(master_pk);
+
+    // Opaque per-provider payment_id: google is the composite "<token>|<order_id>" (backend splits
+    // on the first '|'); app_store is a bare transaction id.
+    std::string payment_id = provider == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY
+                                   ? master_hex.substr(0, 16) + "|GPA." + master_hex.substr(16, 12)
+                                   : "20000000" + master_hex.substr(0, 10);
+
+    // Seed the witnessed-unredeemed payment; the client's real add_pro_payment (below) redeems it.
+    run_seed_helper(
+            {"payment",
+             "--provider",
+             provider,
+             "--payment-id",
+             payment_id,
+             "--master-pubkey",
+             master_hex,
+             "--plan",
+             "1m"});
+
+    auto now = session::sysclock_now_s();
+
+    // 1) add_pro_payment -> signed proof.
+    ProRequest add_req = add_payment_request(
+            master_sk,
+            rotating_sk,
+            provider,
+            std::span<const uint8_t>{
+                    reinterpret_cast<const uint8_t*>(payment_id.data()), payment_id.size()});
+    AddProPaymentResponse add = parse_add_payment(send(onion, add_req));
+    INFO("add_pro_payment" << add.error.value_or(""));
+    REQUIRE(add.status == ResponseStatus::Ok);
+    CHECK(add.status == ResponseStatus::Ok);
+    CHECK(add.proof.verify_signature(backend_pubkey));
+    CHECK(std::memcmp(add.proof.rotating_pubkey.data(), rotating_pk.data(), 32) == 0);
+
+    // 1b) generate_pro_proof: pair a NEW rotating key to the same subscription -> a fresh proof.
+    std::array<unsigned char, 32> rotating2_pk{};
+    std::array<unsigned char, 64> rotating2_sk{};
+    crypto_sign_ed25519_keypair(rotating2_pk.data(), rotating2_sk.data());
+    ProRequest gen_req = pro_proof_request(master_sk, rotating2_sk, now);
+    GenerateProProofResponse gen = parse_pro_proof(send(onion, gen_req));
+    INFO("generate_pro_proof" << gen.error.value_or(""));
+    REQUIRE(gen.status == ResponseStatus::Ok);
+    CHECK(gen.status == ResponseStatus::Ok);
+    CHECK(gen.proof.verify_signature(backend_pubkey));
+    CHECK(std::memcmp(gen.proof.rotating_pubkey.data(), rotating2_pk.data(), 32) == 0);
+    // Same subscription epoch -> the fresh proof shares the add-payment proof's revocation_tag.
+    CHECK(gen.proof.revocation_tag == add.proof.revocation_tag);
+
+    // 2) get_pro_status (Delta #15): account ACTIVE, no refund yet, and the single latest payment
+    //    is our redeemed one.
+    ProStatusResponse status = parse_pro_status(send(onion, pro_status_request(master_sk, now)));
+    INFO("get_pro_status " << status.error.value_or(""));
+    REQUIRE(status.status == ResponseStatus::Ok);
+    CHECK(status.user_status == "active");
+    CHECK(status.refund_requested_at.time_since_epoch().count() == 0);  // no refund requested yet
+    REQUIRE(status.latest_payment.has_value());
+    CHECK(status.latest_payment->payment_id == payment_id);
+    CHECK(status.latest_payment->payment_provider == provider);
+    // plan is the parsed billing period (Delta #14): "1m" -> {count 1, month}.
+    CHECK(status.latest_payment->plan.count == 1);
+    CHECK(status.latest_payment->plan.unit == ProPlanUnit::month);
+    CHECK(status.latest_payment->status == "redeemed");
+
+    // 2b) get_payment_details (Delta #15): newest page (empty cursor) carries our payment. This
+    //     master has exactly one payment, so it fits in one page and next_cursor is empty.
+    PaymentDetailsResponse det =
+            parse_payment_details(send(onion, payment_details_request(master_sk, now, 10, "")));
+    INFO("get_payment_details " << det.error.value_or(""));
+    REQUIRE(det.status == ResponseStatus::Ok);
+    CHECK(det.payments_total >= 1);
+    CHECK(det.items.size() >= 1);
+    CHECK_FALSE(det.next_cursor.has_value());  // limit 10 >= 1 payment -> no further page
+    bool found = false;
+    for (const auto& item : det.items) {
+        if (item.payment_id == payment_id) {
+            found = true;
+            CHECK(item.payment_provider == provider);
+            CHECK(item.plan.count == 1);
+            CHECK(item.plan.unit == ProPlanUnit::month);
+            CHECK(item.status == "redeemed");
+        }
+    }
+    CHECK(found);
+
+    // 3) get_payment_details pagination + opaque-cursor round-trip: a limit-1 page returns one item
+    //    and (being a full page) a next_cursor; re-requesting with that cursor echoed back verbatim
+    //    must be accepted and return the next page. With a single payment on this master, page 2 is
+    //    empty and terminates (next_cursor cleared). This is the real test of the opaque keyset
+    //    cursor -- a tampered/synthesized cursor would be rejected, so a clean round-trip proves
+    //    the client relayed it faithfully.
+    PaymentDetailsResponse page1 =
+            parse_payment_details(send(onion, payment_details_request(master_sk, now, 1, "")));
+    REQUIRE(page1.status == ResponseStatus::Ok);
+    CHECK(page1.items.size() == 1);
+    if (det.payments_total == 1) {
+        REQUIRE(page1.next_cursor.has_value());  // a full page yields a cursor to try next
+        PaymentDetailsResponse page2 = parse_payment_details(
+                send(onion, payment_details_request(master_sk, now, 1, *page1.next_cursor)));
+        REQUIRE(page2.status ==
+                ResponseStatus::Ok);  // the opaque cursor was accepted (echo round-trip)
+        CHECK(page2.items.empty());   // no more payments
+        CHECK_FALSE(page2.next_cursor.has_value());  // end of data
     }
 
-    // Authorise new key
-    {
-        int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
-        session_pro_backend_request request_json =
-                session_pro_backend_generate_pro_proof_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        rotating_privkey.data,
-                        sizeof(rotating_privkey.data),
-                        now_unix_ts);
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
-
-        // Do CURL request
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/generate_pro_proof",
-                std::string_view(request_json.data.data, request_json.data.size));
-
-        // Parse response
-        session_pro_backend_pro_proof_response response =
-                session_pro_backend_pro_proof_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
-
-        INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error)
-            UNSCOPED_INFO("ERROR: " << response.header.error);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-
-        // Verify response
-        session_protocol_pro_proof proof = response.proof;
-        REQUIRE(session_protocol_pro_proof_verify_signature(
-                &proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
-        REQUIRE(std::memcmp(
-                        response.proof.rotating_pubkey.data,
-                        rotating_pubkey.data,
-                        sizeof(rotating_pubkey.data)) == 0);
+    // 4) set_payment_refund_requested. Apple-only at the HTTP layer: app_store -> updated +
+    // reflected
+    //    in get_pro_status; google_play -> rejected (Google refunds are handled out-of-band).
+    ProRequest refund_req = refund_request(
+            master_sk,
+            now,
+            now,
+            provider,
+            std::span<const uint8_t>{
+                    reinterpret_cast<const uint8_t*>(payment_id.data()), payment_id.size()});
+    SetPaymentRefundRequestedResponse refund = parse_refund(send(onion, refund_req));
+    if (provider == SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE) {
+        INFO("refund" << refund.error.value_or(""));
+        REQUIRE(refund.status == ResponseStatus::Ok);
+        CHECK(refund.updated);
+        // The soft "refund requested" marker is now reflected back in get_pro_status.
+        ProStatusResponse status2 =
+                parse_pro_status(send(onion, pro_status_request(master_sk, now)));
+        REQUIRE(status2.status == ResponseStatus::Ok);
+        CHECK(status2.refund_requested_at.time_since_epoch().count() != 0);
+    } else {
+        // The endpoint rejects non-App-Store providers.
+        CHECK_FALSE(refund.updated);
+        CHECK(refund.status != ResponseStatus::Ok);
     }
+}
 
-    // Get pro status (the hot path: account status + single latest payment)
-    {
-        session_pro_backend_request request_json = session_pro_backend_get_pro_status_request_build(
-                master_privkey.data,
-                sizeof(master_privkey.data),
-                session::epoch_seconds(session::sysclock_now_s()));
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
+// Revocation-list round-trip: seed + redeem a payment, seed a revocation for that generation, then
+// confirm get_pro_revocations surfaces it and its tag matches the issued proof. Kept independent of
+// the lifecycle flow so the revocation doesn't perturb those assertions.
+TEST_CASE("Pro backend live get_pro_revocations", "[pro_backend][pro_live]") {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    scope_exit curl_cleanup{[&]() { curl_global_cleanup(); }};
+    CURL* curl = curl_easy_init();
+    REQUIRE(curl);
+    scope_exit curl_free{[&]() { curl_easy_cleanup(curl); }};
 
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/get_pro_status",
-                std::string_view(request_json.data.data, request_json.data.size));
+    const std::string& base_url = g_test_pro_backend_dev_server_url;
+    PostFn direct = make_direct_http_transport(curl, base_url);
+    std::array<uint8_t, 32> backend_pubkey = fetch_backend_pubkey(direct);
+    PostFn onion = make_onion_v4_transport(curl, base_url, backend_pubkey);
 
-        // Parse response
-        session_pro_backend_get_pro_status_response response =
-                session_pro_backend_get_pro_status_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{
-                [&]() { session_pro_backend_get_pro_status_response_free(&response); }};
+    std::array<unsigned char, 32> master_pk{}, rotating_pk{};
+    std::array<unsigned char, 64> master_sk{}, rotating_sk{};
+    crypto_sign_ed25519_keypair(master_pk.data(), master_sk.data());
+    crypto_sign_ed25519_keypair(rotating_pk.data(), rotating_sk.data());
+    std::string master_hex = oxenc::to_hex(master_pk);
 
-        INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error)
-            UNSCOPED_INFO("ERROR: " << response.header.error);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(std::string_view(response.status) == "active");
-        REQUIRE(response.has_latest_payment);
-    }
+    // Seed + redeem an app_store payment so the master has an active generation to revoke.
+    std::string payment_id = "20000000" + master_hex.substr(0, 10);
+    run_seed_helper(
+            {"payment",
+             "--provider",
+             "app_store",
+             "--payment-id",
+             payment_id,
+             "--master-pubkey",
+             master_hex,
+             "--plan",
+             "1m"});
+    ProRequest add_req = add_payment_request(
+            master_sk,
+            rotating_sk,
+            SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE,
+            std::span<const uint8_t>{
+                    reinterpret_cast<const uint8_t*>(payment_id.data()), payment_id.size()});
+    AddProPaymentResponse add = parse_add_payment(send(onion, add_req));
+    REQUIRE(add.status == ResponseStatus::Ok);
+    CHECK(add.status == ResponseStatus::Ok);
 
-    // Get payment history (paginated) -- newest page
-    {
-        session_pro_backend_request request_json =
-                session_pro_backend_get_payment_details_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        session::epoch_seconds(session::sysclock_now_s()),
-                        100,
-                        "");
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
+    // Revoke that payment's generation (revocation is terminal now -- revoked_at set once, no
+    // per-entry expiry), then poll: the list must carry our proof's revocation_tag.
+    run_seed_helper({"revoke", "--provider", "app_store", "--payment-id", payment_id});
 
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/get_payment_details",
-                std::string_view(request_json.data.data, request_json.data.size));
-
-        // Parse response
-        session_pro_backend_get_payment_details_response response =
-                session_pro_backend_get_payment_details_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{
-                [&]() { session_pro_backend_get_payment_details_response_free(&response); }};
-
-        INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error)
-            UNSCOPED_INFO("ERROR: " << response.header.error);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.items_count > 0);
-        REQUIRE(response.payments_total > 0);
-    }
-
-    // Add _another_ payment, same details
-    std::string another_payment_id;
-    {
-        std::array<uint8_t, 8> fake_google_payment_token;
-        randombytes_buf(fake_google_payment_token.data(), fake_google_payment_token.size());
-        std::array<uint8_t, 8> fake_google_order_id;
-        randombytes_buf(fake_google_order_id.data(), fake_google_order_id.size());
-        another_payment_id = "DEV." + oxenc::to_hex(fake_google_payment_token) + "|DEV." +
-                             oxenc::to_hex(fake_google_order_id);
-
-        session_pro_backend_request request_json =
-                session_pro_backend_add_pro_payment_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        rotating_privkey.data,
-                        sizeof(rotating_privkey.data),
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                        reinterpret_cast<const uint8_t*>(another_payment_id.data()),
-                        another_payment_id.size());
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
-
-        // Do curl request
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/add_pro_payment",
-                std::string_view(request_json.data.data, request_json.data.size));
-
-        // Parse response
-        session_pro_backend_pro_proof_response response =
-                session_pro_backend_pro_proof_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{[&]() { session_pro_backend_pro_proof_response_free(&response); }};
-
-        // Verify response
-        session_protocol_pro_proof proof = response.proof;
-        REQUIRE(session_protocol_pro_proof_verify_signature(
-                &proof, DEV_BACKEND_PUBKEY.data(), DEV_BACKEND_PUBKEY.size()));
-        REQUIRE(std::memcmp(
-                        response.proof.rotating_pubkey.data,
-                        rotating_pubkey.data,
-                        sizeof(rotating_pubkey.data)) == 0);
-    }
-
-    // Get revocation list
-    {
-        session_pro_backend_request request_json =
-                session_pro_backend_get_pro_revocations_request_build(0);
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
-
-        // Do curl request
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/get_pro_revocations",
-                std::string_view(request_json.data.data, request_json.data.size));
-
-        // Parse response
-        session_pro_backend_get_pro_revocations_response response =
-                session_pro_backend_get_pro_revocations_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{
-                [&]() { session_pro_backend_get_pro_revocations_response_free(&response); }};
-
-        // Verify response
-        INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error)
-            UNSCOPED_INFO("ERROR: " << response.header.error);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.ticket == 0);
-        REQUIRE(response.items_count == 0);
-    }
-
-    // Set payment refund requested
-    {
-        int64_t now_unix_ts = session::epoch_seconds(session::sysclock_now_s());
-        session_pro_backend_request request_json =
-                session_pro_backend_set_payment_refund_requested_request_build(
-                        master_privkey.data,
-                        sizeof(master_privkey.data),
-                        /*ts*/ now_unix_ts,
-                        /*refund_requested_ts*/ now_unix_ts,
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY,
-                        reinterpret_cast<const uint8_t*>(another_payment_id.data()),
-                        another_payment_id.size());
-        scope_exit request_json_free{[&]() { session_pro_backend_request_free(&request_json); }};
-        REQUIRE(request_json.success);
-
-        // Do curl request
-        std::string response_json = curl_do_basic_blocking_post_request(
-                curl,
-                curl_headers,
-                g_test_pro_backend_dev_server_url + "/set_payment_refund_requested",
-                std::string_view(request_json.data.data, request_json.data.size));
-
-        // Parse response
-        session_pro_backend_set_payment_refund_requested_response response =
-                session_pro_backend_set_payment_refund_requested_response_parse(
-                        response_json.data(), response_json.size());
-        scope_exit response_free{[&]() {
-            session_pro_backend_set_payment_refund_requested_response_free(&response);
-        }};
-
-        // Verify response
-        INFO("ERROR: JSON response: " << response_json.c_str());
-        if (response.header.error)
-            UNSCOPED_INFO("ERROR: " << response.header.error);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
-        REQUIRE(response.updated);
-    }
+    ProRequest rev_req = revocations_request(0);
+    GetProRevocationsResponse rev = parse_revocations(send(onion, rev_req));
+    INFO("get_pro_revocations" << rev.error.value_or(""));
+    REQUIRE(rev.status == ResponseStatus::Ok);
+    CHECK(rev.retain_for.count() > 0);
+    CHECK_FALSE(rev.items.empty());
+    bool found = false;
+    for (const auto& it : rev.items)
+        if (it.revocation_tag == add.proof.revocation_tag)
+            found = true;
+    CHECK(found);
 }
 #endif


### PR DESCRIPTION
This extends PR #95 with integration tests that build the pro-backend and run a local copy to perform pro-backend <-> libsession endpoint testing.

(Not to merge before the other pro backend 0.2.0-related PRs are merged)