### PR TITLE
Clamp revocation list retry/cleanup values

### DIFF
--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -554,6 +554,13 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
     result.retry_in = std::chrono::seconds(json_require<int64_t>(result_obj, "retry_in", errs));
     result.retain_for = std::chrono::seconds(json_require<int64_t>(result_obj, "retain_for", errs));
 
+    // Clamp values against non-sensical/catastrophic values: retry_in of very small would result in
+    // excess retries, and an overly long retry (e.g. 10 years) would make the client not properly
+    // refresh at all.  The retain_for clamp is deliberately larger because that is only a hint as
+    // to when the record can be cleaned up.
+    result.retry_in = std::clamp<std::chrono::seconds>(result.retry_in, 60s, 48h);
+    result.retain_for = std::clamp<std::chrono::seconds>(result.retain_for, 24h, 365 * 24h);
+
     auto array = json_require<nlohmann::json::array_t>(result_obj, "items", errs);
     result.items.reserve(array.size());
     for (size_t index = 0; index < array.size(); index++) {

--- a/tests/pro_backend/seed_payment.py
+++ b/tests/pro_backend/seed_payment.py
@@ -67,10 +67,20 @@ def _payment_tx(provider, payment_id):
 
 
 def _obfuscated_id(provider, vk):
+    # The witnessed `platform_obfuscated_account_id` must equal what the backend recomputes from the
+    # request-signed master key at redeem time (backend.py add_pro_payment binding), per provider.
     if provider == "google_play":
-        return backend.google_obfuscated_account_id_from_master_pkey(vk)
+        # Google: the client sets setObfuscatedAccountId to the master pubkey verbatim, so the
+        # attested id IS the raw 32-byte master pubkey; the redeem binds by byte-equality.
+        return bytes(vk)
     if provider == "app_store":
-        return backend.apple_obfuscated_account_id_from_master_pkey(vk)
+        # Apple: appAccountToken = UUID(first 16 bytes of the master pubkey); the redeem binds by
+        # equality against the same recomputed UUID (stored lowercased on receipt). Import the Apple
+        # provider lazily -- its module pulls the Apple SDK -- so seeding a non-Apple payment doesn't
+        # need it.
+        from providers import app_store
+
+        return app_store.uuid_from_master_pk(bytes(vk)).lower()
     return b""
 
 


### PR DESCRIPTION
Makes sure both have a reasonably sane value; mainly defensive.

(Also includes a fix for the session-pro-backend CI test due to recent backend changes)