### PR TITLE
SnodePool: fix use-after-free when running post-refresh callbacks

### DIFF
--- a/src/network/snode_pool.cpp
+++ b/src/network/snode_pool.cpp
@@ -837,7 +837,9 @@ void SnodePool::_on_refresh_complete(
 }
 
 void SnodePool::_update_cache(std::string refresh_id, std::vector<service_node> nodes) {
-    _loop->call([this, refresh_id, &nodes] {
+    // Use 'call_get' to force this to be synchronous; a plain 'call' would queue when we aren't
+    // already on the loop thread, and the captured `nodes` reference would dangle
+    _loop->call_get([this, refresh_id, &nodes] {
         // Shuffle the nodes so we don't have a specific order
         std::ranges::shuffle(nodes, csrng);
         log::info(
@@ -864,20 +866,25 @@ void SnodePool::_update_cache(std::string refresh_id, std::vector<service_node> 
         });
 
         // Trigger any callbacks
+        //
+        // These must be moved out of the member before being run: a callback can re-enter the pool
+        // and register another post-refresh callback (`get_swarm` does exactly that if the cache is
+        // still empty), which would reallocate the vector we're iterating and leave us calling
+        // through a freed `std::function`. Anything registered while we're here accumulates in the
+        // now-empty member and runs after the next refresh instead of being silently discarded.
         if (!_after_snode_cache_refresh.empty()) {
-            log::debug(
-                    cat, "Executing {} post-refresh callbacks.", _after_snode_cache_refresh.size());
+            auto callbacks = std::move(_after_snode_cache_refresh);
+            _after_snode_cache_refresh.clear();  // A moved-from vector is valid but unspecified
 
-            for (const auto& cb : _after_snode_cache_refresh) {
+            log::debug(cat, "Executing {} post-refresh callbacks.", callbacks.size());
+
+            for (const auto& cb : callbacks) {
                 try {
                     cb();
                 } catch (const std::exception& e) {
                     log::error(cat, "Exception thrown in a post-refresh callback: {}", e.what());
                 }
             }
-
-            // Clear the callbacks
-            _after_snode_cache_refresh.clear();
         }
     });
 }

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -50,7 +50,7 @@ class TestSnodePool : public SnodePool {
     //
     // `shrink_to_fit` is a non-binding request, so return whether it actually took effect rather
     // than let the test quietly stop exercising the bug.
-    bool remove_debug_post_refresh_callback_spare_capacity() {
+    bool debug_remove_post_refresh_callback_spare_capacity() {
         return _loop->call_get([this] {
             _after_snode_cache_refresh.shrink_to_fit();
             return _after_snode_cache_refresh.capacity() == _after_snode_cache_refresh.size();
@@ -231,7 +231,7 @@ TEST_CASE("Network", "[network][update_cache]") {
     });
     snode_pool->debug_queue_post_refresh_callback([&] { callbacks_run.push_back(1); });
     snode_pool->debug_queue_post_refresh_callback([&] { callbacks_run.push_back(2); });
-    REQUIRE(snode_pool->remove_debug_post_refresh_callback_spare_capacity());
+    REQUIRE(snode_pool->debug_remove_post_refresh_callback_spare_capacity());
     snode_pool->update_cache({});
     CHECK(callbacks_run == std::vector<int>{0, 1, 2});
 

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -35,6 +35,24 @@ class TestSnodePool : public SnodePool {
             std::function<void()> on_refresh_complete = nullptr) override {
         // Do nothing (don't want to trigger a cache refresh)
     }
+
+    void queue_post_refresh_callback(std::function<void()> cb) {
+        _loop->call_get([this, cb = std::move(cb)]() mutable {
+            _after_snode_cache_refresh.push_back(std::move(cb));
+
+            // Drop any spare capacity so that a `push_back` during the post-refresh callback run is
+            // guaranteed to reallocate
+            _after_snode_cache_refresh.shrink_to_fit();
+        });
+    }
+
+    size_t pending_post_refresh_callbacks() {
+        return _loop->call_get([this] { return _after_snode_cache_refresh.size(); });
+    }
+
+    // Called from the test thread, so this also covers `_update_cache` being entered from off the
+    // loop thread
+    void update_cache(std::vector<service_node> nodes) { _update_cache("test", std::move(nodes)); }
 };
 }  // namespace session::network
 
@@ -160,4 +178,58 @@ TEST_CASE("Network", "[network][get_unused_nodes]") {
     for (const auto& node : unused_nodes)
         result_subnets.insert(node.ip.to_base(24));
     CHECK(result_subnets.size() == 4);
+}
+
+TEST_CASE("Network", "[network][update_cache]") {
+    session::network::config::SnodePool pool_config = {
+            std::nullopt,
+            std::nullopt,
+            std::chrono::minutes{5},
+            std::chrono::minutes{5},
+            false,  // enforce_subnet_diversity
+            network::opt::retry_delay{50ms, 200ms},
+            opt::netid::Target::testnet,
+            {},
+            0,
+            0,
+            3,  // cache_node_strike_threshold
+            false};
+    auto ed_pk = "4cb76fdc6d32278e3f83dbf608360ecc6b65727934b85d2fb86862ff98c46ab7"_hexbytes;
+    std::vector<service_node> snode_cache;
+
+    for (uint16_t i = 0; i < 5; ++i)
+        snode_cache.emplace_back(service_node{
+                ed25519_pubkey::from_bytes(ed_pk),
+                oxen::quic::ipv4{"192.168.0.{}"_format(i)},
+                static_cast<uint16_t>(20000 + i),
+                static_cast<uint16_t>(30000 + i),
+                {2, 11, 0},
+                0});
+
+    auto loop = std::make_shared<oxen::quic::Loop>();
+    auto disk_loop = std::make_shared<oxen::quic::Loop>();
+    auto snode_pool = std::make_shared<TestSnodePool>(pool_config, loop, disk_loop);
+
+    // Should tolerate a post-refresh callback registering another post-refresh callback (which is
+    // what a deferred `get_swarm` does when the refresh left the cache empty) rather than
+    // invalidating the vector it's iterating
+    std::vector<int> callbacks_run;
+    snode_pool->queue_post_refresh_callback([&] {
+        callbacks_run.push_back(0);
+        snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(3); });
+    });
+    snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(1); });
+    snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(2); });
+    snode_pool->update_cache({});
+    CHECK(callbacks_run == std::vector<int>{0, 1, 2});
+
+    // The callback registered during the run should be kept for the next refresh, not discarded
+    CHECK(snode_pool->pending_post_refresh_callbacks() == 1);
+    snode_pool->update_cache({});
+    CHECK(callbacks_run == std::vector<int>{0, 1, 2, 3});
+    CHECK(snode_pool->pending_post_refresh_callbacks() == 0);
+
+    // Should have stored the nodes by the time it returns
+    snode_pool->update_cache(snode_cache);
+    CHECK(snode_pool->size() == snode_cache.size());
 }

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -36,13 +36,24 @@ class TestSnodePool : public SnodePool {
         // Do nothing (don't want to trigger a cache refresh)
     }
 
-    void queue_post_refresh_callback(std::function<void()> cb) {
+    void debug_queue_post_refresh_callback(std::function<void()> cb) {
         _loop->call_get([this, cb = std::move(cb)]() mutable {
             _after_snode_cache_refresh.push_back(std::move(cb));
+        });
+    }
 
-            // Drop any spare capacity so that a `push_back` during the post-refresh callback run is
-            // guaranteed to reallocate
+    // Removes the spare capacity from the pending-callback vector, so that a callback registering
+    // another callback while they're being run is *guaranteed* to reallocate the vector.  Without
+    // this the re-registration lands in spare capacity, nothing reallocates, and iterating the
+    // vector by reference stays accidentally valid - which is exactly why the real crash only
+    // showed up on some launches.
+    //
+    // `shrink_to_fit` is a non-binding request, so return whether it actually took effect rather
+    // than let the test quietly stop exercising the bug.
+    bool remove_debug_post_refresh_callback_spare_capacity() {
+        return _loop->call_get([this] {
             _after_snode_cache_refresh.shrink_to_fit();
+            return _after_snode_cache_refresh.capacity() == _after_snode_cache_refresh.size();
         });
     }
 
@@ -214,12 +225,13 @@ TEST_CASE("Network", "[network][update_cache]") {
     // what a deferred `get_swarm` does when the refresh left the cache empty) rather than
     // invalidating the vector it's iterating
     std::vector<int> callbacks_run;
-    snode_pool->queue_post_refresh_callback([&] {
+    snode_pool->debug_queue_post_refresh_callback([&] {
         callbacks_run.push_back(0);
-        snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(3); });
+        snode_pool->debug_queue_post_refresh_callback([&] { callbacks_run.push_back(3); });
     });
-    snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(1); });
-    snode_pool->queue_post_refresh_callback([&] { callbacks_run.push_back(2); });
+    snode_pool->debug_queue_post_refresh_callback([&] { callbacks_run.push_back(1); });
+    snode_pool->debug_queue_post_refresh_callback([&] { callbacks_run.push_back(2); });
+    REQUIRE(snode_pool->remove_debug_post_refresh_callback_spare_capacity());
     snode_pool->update_cache({});
     CHECK(callbacks_run == std::vector<int>{0, 1, 2});
 

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -44,15 +44,17 @@ class TestSnodePool : public SnodePool {
 
     // Removes the spare capacity from the pending-callback vector, so that a callback registering
     // another callback while they're being run is *guaranteed* to reallocate the vector.  Without
-    // this the re-registration lands in spare capacity, nothing reallocates, and iterating the
+    // this the re-registration can land in spare capacity, nothing reallocates, and iterating the
     // vector by reference stays accidentally valid - which is exactly why the real crash only
     // showed up on some launches.
     //
-    // `shrink_to_fit` is a non-binding request, so return whether it actually took effect rather
-    // than let the test quietly stop exercising the bug.
+    // The copy allocates exactly `size()` entries and the move-assign then takes over that buffer;
+    // `shrink_to_fit` would only be a hint that the stdlib is allowed to ignore.  The return value
+    // confirms it took effect rather than letting the test quietly stop exercising the bug.
     bool debug_remove_post_refresh_callback_spare_capacity() {
         return _loop->call_get([this] {
-            _after_snode_cache_refresh.shrink_to_fit();
+            auto exact_sized_copy = _after_snode_cache_refresh;
+            _after_snode_cache_refresh = std::move(exact_sized_copy);
             return _after_snode_cache_refresh.capacity() == _after_snode_cache_refresh.size();
         });
     }


### PR DESCRIPTION
Fixes a segfault on the quic loop thread ~1s after launch (Session iOS 2.15.4, 3 crashes in 20 minutes of Appium runs against devnet).

- Run the post-refresh callbacks from a moved-out copy of `_after_snode_cache_refresh`. A deferred `get_swarm` re-registers itself mid-loop, reallocating the vector being iterated. The old trailing `clear()` also discarded those re-registrations, so a waiting `get_swarm` could hang instead.
- Make `_update_cache` synchronous via `call_get`, so its `&nodes` capture can't dangle. Both callers are already on the loop thread, so no behaviour change.