### PR TITLE
Validate blinded IDs before matching

### DIFF
--- a/src/blinding.cpp
+++ b/src/blinding.cpp
@@ -534,7 +534,10 @@ bool session_id_matches_blinded_id(
                 "session_id_matches_blinded_id: session_id must be hex (66 digits)"};
     if (session_id[0] != '0' || session_id[1] != '5')
         throw std::invalid_argument{"session_id_matches_blinded_id: session_id must start with 05"};
-    if (blinded_id[1] != '5' && (blinded_id[0] != '1' || blinded_id[0] != '2'))
+    if (blinded_id.size() != 66 || !oxenc::is_hex(blinded_id))
+        throw std::invalid_argument{
+                "session_id_matches_blinded_id: blinded_id must be hex (66 digits)"};
+    if ((blinded_id[0] != '1' && blinded_id[0] != '2') || blinded_id[1] != '5')
         throw std::invalid_argument{
                 "session_id_matches_blinded_id: blinded_id must start with 15 or 25"};
     if (server_pk.size() != 64 || !oxenc::is_hex(server_pk))

--- a/src/blinding.cpp
+++ b/src/blinding.cpp
@@ -532,12 +532,12 @@ bool session_id_matches_blinded_id(
     if (session_id.size() != 66 || !oxenc::is_hex(session_id))
         throw std::invalid_argument{
                 "session_id_matches_blinded_id: session_id must be hex (66 digits)"};
-    if (session_id[0] != '0' || session_id[1] != '5')
+    if (!session_id.starts_with("05"sv))
         throw std::invalid_argument{"session_id_matches_blinded_id: session_id must start with 05"};
     if (blinded_id.size() != 66 || !oxenc::is_hex(blinded_id))
         throw std::invalid_argument{
                 "session_id_matches_blinded_id: blinded_id must be hex (66 digits)"};
-    if ((blinded_id[0] != '1' && blinded_id[0] != '2') || blinded_id[1] != '5')
+    if (!(blinded_id.starts_with("15"sv) || blinded_id.starts_with("25"sv)))
         throw std::invalid_argument{
                 "session_id_matches_blinded_id: blinded_id must start with 15 or 25"};
     if (server_pk.size() != 64 || !oxenc::is_hex(server_pk))

--- a/tests/test_blinding.cpp
+++ b/tests/test_blinding.cpp
@@ -350,9 +350,25 @@ TEST_CASE("Communities session id blinded id matching", "[blinding][matching]") 
     CHECK(session_id_matches_blinded_id(session_id1, b25_6, server_pks[5]));
 
     auto invalid_session_id = "9"s + session_id1.substr(1);
-    auto invalid_blinded_id = "9"s + b15_1.substr(1);
+    auto invalid_blinded_prefix = "9"s + b15_1.substr(1);
+    auto invalid_blinded_hex = b15_1;
+    invalid_blinded_hex.back() = 'g';
     auto invalid_server_pk = server_pks[0].substr(0, 60);
-    CHECK_THROWS(session_id_matches_blinded_id(invalid_session_id, b15_1, server_pks[0]));
-    CHECK_THROWS(session_id_matches_blinded_id(session_id1, invalid_blinded_id, server_pks[0]));
-    CHECK_THROWS(session_id_matches_blinded_id(session_id1, invalid_blinded_id, invalid_server_pk));
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(invalid_session_id, b15_1, server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, invalid_blinded_prefix, server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, ""sv, server_pks[0]), std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, b15_1.substr(0, 65), server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, invalid_blinded_hex, server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, b15_1, invalid_server_pk),
+            std::invalid_argument);
 }

--- a/tests/test_blinding.cpp
+++ b/tests/test_blinding.cpp
@@ -371,4 +371,28 @@ TEST_CASE("Communities session id blinded id matching", "[blinding][matching]") 
     CHECK_THROWS_AS(
             session_id_matches_blinded_id(session_id1, b15_1, invalid_server_pk),
             std::invalid_argument);
+
+    auto invalid_b25_prefix = "9"s + b25_1.substr(1);
+    auto invalid_b25_hex = b25_1;
+    invalid_b25_hex.back() = 'g';
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, invalid_b25_prefix, server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, b25_1.substr(0, 65), server_pks[0]),
+            std::invalid_argument);
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, invalid_b25_hex, server_pks[0]),
+            std::invalid_argument);
+
+    // Regression: a standard (05-prefixed) session id has '5' at index 1, which the old prefix
+    // check erroneously accepted; it must now be rejected as a blinded id:
+    CHECK_THROWS_AS(
+            session_id_matches_blinded_id(session_id1, session_id1, server_pks[0]),
+            std::invalid_argument);
+
+    // A well-formed blinded id that simply doesn't match must return false, not throw (covers both
+    // the 15 and 25 branches actually running the comparison rather than being rejected up front):
+    CHECK_FALSE(session_id_matches_blinded_id(session_id1, b25_2, server_pks[0]));
+    CHECK_FALSE(session_id_matches_blinded_id(session_id1, b15_2, server_pks[0]));
 }


### PR DESCRIPTION
## summary

`session_id_matches_blinded_id()` validated the session id and server key, but read the blinded id prefix before checking its length and never checked that the full value was hexadecimal

this validates the blinded id before indexing it and fixes the `15`/`25` prefix predicate

## tests

- `./utils/ci/drone-format-verify.sh`
- release build with `WARNINGS_AS_ERRORS=ON`
- `Build/tests/testAll "Communities session id blinded id matching" --colour-mode none`
- `Build/tests/testLogging --colour-mode none`
- `Build/tests/testAll --colour-mode none`