### PR TITLE
(PFS) Rename payment provider rangeproof -> stf

### DIFF
--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -19,7 +19,7 @@ extern "C" {
 /// primary; C references).
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY;
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE;
-LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF;
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF;
 
 /// Endpoint path (relative to the backend base URL) that each request type is POSTed to. libsession
 /// owns the body<->route pairing, so reference these rather than hardcoding the path client-side.
@@ -53,7 +53,7 @@ LIBSESSION_EXPORT extern const unsigned char* const SESSION_PRO_BACKEND_PUBKEY_X
 /// code from a known provider that simply has no URLs.
 typedef struct session_pro_backend_provider_urls {
     /// True if `provider_code` is a recognised provider; false if it is unknown (or e.g.
-    /// rangeproof), in which case every URL field below is NULL. A recognised provider may still
+    /// STF), in which case every URL field below is NULL. A recognised provider may still
     /// leave any or all URL fields NULL.
     bool found;
     const char* refund_platform_url;      /// Native store refund flow
@@ -76,7 +76,7 @@ session_pro_backend_get_provider_urls(const char* provider_code) NON_NULL_ARG(1)
 ///
 /// Returns the user-visible purchasable platforms as an array of `*count` provider-code C strings
 /// (a subset of the SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* values). Order is not significant;
-/// clients pick their own. Hidden mechanisms (e.g. rangeproof) are excluded. The returned array and
+/// clients pick their own. Hidden mechanisms (e.g. STF) are excluded. The returned array and
 /// its strings are static storage owned by libsession — do not free.
 LIBSESSION_EXPORT const char* const* session_pro_backend_visible_platforms(size_t* count);
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -87,7 +87,8 @@ constexpr std::string_view URL = "https://pro.session.codes";
 /// valid on the wire and passes through as an opaque string.
 constexpr std::string_view PAYMENT_PROVIDER_GOOGLE_PLAY = "google_play";
 constexpr std::string_view PAYMENT_PROVIDER_APP_STORE = "app_store";
-constexpr std::string_view PAYMENT_PROVIDER_RANGEPROOF = "rangeproof";
+// STF = the Session Technology Foundation's out-of-band grant (not a purchasable store).
+constexpr std::string_view PAYMENT_PROVIDER_STF = "stf";
 
 /// Domain used with ed25519::derive_subkey to derive the Session Pro signing keypair from the
 /// account's root Ed25519 seed.
@@ -142,12 +143,12 @@ struct ProviderURLs {
 /// Look up the support/management URLs for a provider code (see
 /// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*). Returns a pointer to a static per-provider
 /// constant, or nullptr for a provider with no applicable URLs at all (an unknown code, or e.g.
-/// rangeproof); within a returned set each field is present or std::nullopt per that provider.
+/// STF); within a returned set each field is present or std::nullopt per that provider.
 const ProviderURLs* provider_urls(std::string_view provider_code);
 
 /// The user-visible purchasable platforms, as provider-code slugs (a subset of the
 /// SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_* values — currently "google_play" and "app_store").
-/// Order is not significant; clients pick their own. Hidden mechanisms (e.g. rangeproof) are
+/// Order is not significant; clients pick their own. Hidden mechanisms (e.g. STF) are
 /// excluded — they surface only for users who already hold them — so this is the set that drives a
 /// "purchase via …" store list.
 std::span<const std::string_view> visible_platforms();

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -168,8 +168,8 @@ LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_
         PAYMENT_PROVIDER_GOOGLE_PLAY.data();
 LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE =
         PAYMENT_PROVIDER_APP_STORE.data();
-LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF =
-        PAYMENT_PROVIDER_RANGEPROOF.data();
+LIBSESSION_EXPORT extern const char* const SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF =
+        PAYMENT_PROVIDER_STF.data();
 }
 
 using namespace std::literals;
@@ -200,7 +200,7 @@ const ProviderURLs* provider_urls(std::string_view provider_code) {
         return &google_play_urls;
     if (provider_code == PAYMENT_PROVIDER_APP_STORE)
         return &app_store_urls;
-    // rangeproof and unknown providers have no applicable URLs
+    // STF and unknown providers have no applicable URLs
     return nullptr;
 }
 

--- a/tests/pro_backend/run-dev-backend.sh
+++ b/tests/pro_backend/run-dev-backend.sh
@@ -73,7 +73,7 @@ createdb -h "$WORK" -p "$PORT" -U "$USER" pro_backend
 
 export SESH_PRO_BACKEND_DB_URL="postgresql:///pro_backend?host=$WORK&port=$PORT&user=$USER"
 export SESH_PRO_BACKEND_KEY_PATH="$KEYFILE"
-# Stub all payment-provider egress so a real add_pro_payment redeems (google/app_store/rangeproof)
+# Stub all payment-provider egress so a real add_pro_payment redeems (google/app_store/stf)
 # without contacting Google/Apple. Landed backend-side (base.PROVIDER_DRY_RUN). No platform creds and
 # no with_platform_* needed: the provider comes from the seeded row, not from platform config.
 export SESH_PRO_BACKEND_PROVIDER_DRY_RUN=1

--- a/tests/pro_backend/seed_payment.py
+++ b/tests/pro_backend/seed_payment.py
@@ -13,7 +13,7 @@ Run with the backend clone's venv python. Requires env:
   PRO_BACKEND_DIR           path to the backend clone (for importing base/backend/db)
 
 Usage:
-  seed_payment.py payment --provider {google_play,app_store,rangeproof} --payment-id ID
+  seed_payment.py payment --provider {google_play,app_store,stf} --payment-id ID
                           --master-pubkey HEX64 [--plan 1m|3m|1y] [--expiry-days N]
   seed_payment.py revoke  --provider {google_play,app_store} --payment-id ID
 """
@@ -58,9 +58,9 @@ def _payment_tx(provider, payment_id):
         tx.apple_tx_id = payment_id
         tx.apple_original_tx_id = payment_id
         tx.apple_web_line_order_tx_id = ""
-    elif provider == "rangeproof":
-        tx.provider = base.PaymentProvider.Rangeproof
-        tx.rangeproof_order_id = payment_id
+    elif provider == "stf":
+        tx.provider = base.PaymentProvider.SessionFoundation
+        tx.stf_order_id = payment_id
     else:
         sys.exit(f"seed: unknown provider {provider}")
     return tx
@@ -144,7 +144,7 @@ def main():
 
     p = sub.add_parser("payment", help="seed a witnessed-unredeemed payment")
     p.add_argument("--provider", required=True,
-                   choices=["google_play", "app_store", "rangeproof"])
+                   choices=["google_play", "app_store", "stf"])
     p.add_argument("--payment-id", required=True)
     p.add_argument("--master-pubkey", required=True, help="64 hex chars")
     p.add_argument("--plan", default="1m")

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -465,8 +465,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             // End-of-data: null next_cursor, and payment_id is opaque so a different provider's
             // value passes through unchanged.
             j["result"]["items"][0]["payment_provider"] =
-                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF;
-            j["result"]["items"][0]["payment_id"] = "rangeproof-opaque-id";
+                    SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF;
+            j["result"]["items"][0]["payment_id"] = "stf-opaque-id";
             j["result"]["next_cursor"] = nullptr;
             json = j.dump();
             auto result_end = session_pro_backend_get_payment_details_response_parse(
@@ -479,8 +479,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     INFO(result_end.header.error);
                 REQUIRE(result_end.header.status == SESSION_PRO_BACKEND_RESPONSE_STATUS_OK);
                 REQUIRE(std::string_view(result_end.items[0].payment_provider) ==
-                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF);
-                REQUIRE(std::string_view(result_end.items[0].payment_id) == "rangeproof-opaque-id");
+                        SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF);
+                REQUIRE(std::string_view(result_end.items[0].payment_id) == "stf-opaque-id");
                 REQUIRE(result_end.next_cursor == nullptr);  // end-of-data
             }
 
@@ -547,9 +547,7 @@ TEST_CASE("Pro Backend X25519 pubkey matches the converted Ed25519 pubkey", "[pr
             0);
 }
 
-TEST_CASE(
-        "Pro Backend visible_platforms lists purchasable stores, excludes rangeproof",
-        "[pro_backend]") {
+TEST_CASE("Pro Backend visible_platforms lists purchasable stores, excludes stf", "[pro_backend]") {
     auto platforms = visible_platforms();
     auto has = [](std::span<const std::string_view> v, std::string_view s) {
         for (auto x : v)
@@ -560,7 +558,7 @@ TEST_CASE(
     REQUIRE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY));
     REQUIRE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE));
     // Hidden mechanisms are handled but never listed.
-    REQUIRE_FALSE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_RANGEPROOF));
+    REQUIRE_FALSE(has(platforms, SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF));
     REQUIRE(platforms.size() == 2);
 
     // The C export returns the same slugs, in the same order (it is derived from the C++ list).


### PR DESCRIPTION
The backend renamed the out-of-band grant provider from "rangeproof" to "stf", reflecting that such issuances come from the Session Technology Foundation, not the inactive Rangeproof dev house. Follow the wire/slug value ("stf") and the C/C++ constant names to match.