### PR TITLE
Use fixed-size spans for XEd25519 inputs

### DIFF
--- a/include/session/xed25519.hpp
+++ b/include/session/xed25519.hpp
@@ -10,16 +10,15 @@ namespace session::xed25519 {
 
 /// XEd25519-signs a message given the curve25519 privkey and message.
 std::array<unsigned char, 64> sign(
-        std::span<const unsigned char> curve25519_privkey /* 32 bytes */,
-        std::span<const unsigned char> msg);
+        std::span<const unsigned char, 32> curve25519_privkey, std::span<const unsigned char> msg);
 
 /// "Softer" version that takes and returns strings of regular chars
 std::string sign(std::string_view curve25519_privkey /* 32 bytes */, std::string_view msg);
 
 /// Verifies a curve25519 message allegedly signed by the given curve25519 pubkey
 [[nodiscard]] bool verify(
-        std::span<const unsigned char> signature /* 64 bytes */,
-        std::span<const unsigned char> curve25519_pubkey /* 32 bytes */,
+        std::span<const unsigned char, 64> signature,
+        std::span<const unsigned char, 32> curve25519_pubkey,
         std::span<const unsigned char> msg);
 
 /// "Softer" version that takes strings of regular chars
@@ -32,7 +31,7 @@ std::string sign(std::string_view curve25519_privkey /* 32 bytes */, std::string
 /// however, that there are *two* possible Ed25519 pubkeys that could result in a given curve25519
 /// pubkey: this always returns the positive value.  You can get the other possibility (the
 /// negative) by setting the sign bit, i.e. `returned_pubkey[31] |= 0x80`.
-std::array<unsigned char, 32> pubkey(std::span<const unsigned char> curve25519_pubkey);
+std::array<unsigned char, 32> pubkey(std::span<const unsigned char, 32> curve25519_pubkey);
 
 /// "Softer" version that takes/returns strings of regular chars
 std::string pubkey(std::string_view curve25519_pubkey);

--- a/src/blinding.cpp
+++ b/src/blinding.cpp
@@ -67,7 +67,7 @@ namespace {
         auto k = blind15_factor(server_pk);
         if (session_id.size() == 33)
             session_id = session_id.subspan(1);
-        auto ed_pk = xed25519::pubkey(session_id);
+        auto ed_pk = xed25519::pubkey(session_id.first<32>());
         if (0 != crypto_scalarmult_ed25519_noclamp(out + 1, k.data(), ed_pk.data()))
             throw std::runtime_error{"Cannot blind: invalid session_id (not on main subgroup)"};
         out[0] = 0x15;
@@ -80,7 +80,7 @@ namespace {
         auto k = blind25_factor(session_id, server_pk);
         if (session_id.size() == 33)
             session_id = session_id.subspan(1);
-        auto ed_pk = xed25519::pubkey(session_id);
+        auto ed_pk = xed25519::pubkey(session_id.first<32>());
         if (0 != crypto_scalarmult_ed25519_noclamp(out + 1, k.data(), ed_pk.data()))
             throw std::runtime_error{"Cannot blind: invalid session_id (not on main subgroup)"};
         out[0] = 0x25;

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -596,7 +596,7 @@ std::vector<unsigned char> Keys::swarm_make_subaccount(
     auto k = subaccount_blind_factor(X);
 
     // T = |S|
-    auto T = xed25519::pubkey(std::span<const unsigned char>{X.data(), X.size()});
+    auto T = xed25519::pubkey(X);
 
     // kT is the user's Ed25519 blinded pubkey:
     std::array<unsigned char, 32> kT;
@@ -633,7 +633,7 @@ std::vector<unsigned char> Keys::swarm_subaccount_token(
     auto k = subaccount_blind_factor(X);
 
     // T = |S|
-    auto T = xed25519::pubkey(std::span<const unsigned char>{X.data(), X.size()});
+    auto T = xed25519::pubkey(X);
 
     std::vector<unsigned char> out;
     out.resize(4 + 32);

--- a/src/xed25519.cpp
+++ b/src/xed25519.cpp
@@ -80,9 +80,7 @@ namespace {
 }  // namespace
 
 bytes<64> sign(
-        std::span<const unsigned char> curve25519_privkey, std::span<const unsigned char> msg) {
-
-    assert(curve25519_privkey.size() == 32);
+        std::span<const unsigned char, 32> curve25519_privkey, std::span<const unsigned char> msg) {
 
     bytes<32> A;
     // Convert the x25519 privkey to an ed25519 pubkey:
@@ -117,26 +115,36 @@ bytes<64> sign(
 }
 
 std::string sign(std::string_view curve25519_privkey, std::string_view msg) {
-    auto sig = sign(to_span(curve25519_privkey), to_span(msg));
+    auto privkey = to_span(curve25519_privkey);
+    if (privkey.size() != 32)
+        throw std::invalid_argument{"Invalid curve25519_privkey: expected 32 bytes"};
+
+    auto sig = sign(privkey.first<32>(), to_span(msg));
     return std::string{reinterpret_cast<const char*>(sig.data()), sig.size()};
 }
 
 bool verify(
-        std::span<const unsigned char> signature,
-        std::span<const unsigned char> curve25519_pubkey,
+        std::span<const unsigned char, 64> signature,
+        std::span<const unsigned char, 32> curve25519_pubkey,
         std::span<const unsigned char> msg) {
-    assert(signature.size() == crypto_sign_ed25519_BYTES);
-    assert(curve25519_pubkey.size() == 32);
     auto ed_pubkey = pubkey(curve25519_pubkey);
     return 0 == crypto_sign_ed25519_verify_detached(
                         signature.data(), msg.data(), msg.size(), ed_pubkey.data());
 }
 
 bool verify(std::string_view signature, std::string_view curve25519_pubkey, std::string_view msg) {
-    return verify(to_span(signature), to_span(curve25519_pubkey), to_span(msg));
+    auto sig = to_span(signature);
+    if (sig.size() != crypto_sign_ed25519_BYTES)
+        throw std::invalid_argument{"Invalid signature: expected 64 bytes"};
+
+    auto pubkey = to_span(curve25519_pubkey);
+    if (pubkey.size() != 32)
+        throw std::invalid_argument{"Invalid curve25519_pubkey: expected 32 bytes"};
+
+    return verify(sig.first<64>(), pubkey.first<32>(), to_span(msg));
 }
 
-std::array<unsigned char, 32> pubkey(std::span<const unsigned char> curve25519_pubkey) {
+std::array<unsigned char, 32> pubkey(std::span<const unsigned char, 32> curve25519_pubkey) {
     fe25519 u, y;
     crypto_internal_fe25519_frombytes(u, curve25519_pubkey.data());
     fe25519_montx_to_edy(y, u);
@@ -148,7 +156,11 @@ std::array<unsigned char, 32> pubkey(std::span<const unsigned char> curve25519_p
 }
 
 std::string pubkey(std::string_view curve25519_pubkey) {
-    auto ed_pk = pubkey(to_span(curve25519_pubkey));
+    auto x_pk = to_span(curve25519_pubkey);
+    if (x_pk.size() != 32)
+        throw std::invalid_argument{"Invalid curve25519_pubkey: expected 32 bytes"};
+
+    auto ed_pk = pubkey(x_pk.first<32>());
     return std::string{reinterpret_cast<const char*>(ed_pk.data()), ed_pk.size()};
 }
 
@@ -163,7 +175,8 @@ LIBSESSION_C_API bool session_xed25519_sign(
         size_t msg_len) {
     assert(signature != NULL);
     try {
-        auto sig = session::xed25519::sign({curve25519_privkey, 32}, {msg, msg_len});
+        auto sig = session::xed25519::sign(
+                std::span<const unsigned char, 32>{curve25519_privkey, 32}, {msg, msg_len});
         std::memcpy(signature, sig.data(), sig.size());
         return true;
     } catch (...) {
@@ -176,14 +189,18 @@ LIBSESSION_C_API bool session_xed25519_verify(
         const unsigned char* pubkey,
         const unsigned char* msg,
         size_t msg_len) {
-    return session::xed25519::verify({signature, 64}, {pubkey, 32}, {msg, msg_len});
+    return session::xed25519::verify(
+            std::span<const unsigned char, 64>{signature, 64},
+            std::span<const unsigned char, 32>{pubkey, 32},
+            {msg, msg_len});
 }
 
 LIBSESSION_C_API bool session_xed25519_pubkey(
         unsigned char* ed25519_pubkey, const unsigned char* curve25519_pubkey) {
     assert(ed25519_pubkey != NULL);
     try {
-        auto edpk = session::xed25519::pubkey({curve25519_pubkey, 32});
+        auto edpk = session::xed25519::pubkey(
+                std::span<const unsigned char, 32>{curve25519_pubkey, 32});
         std::memcpy(ed25519_pubkey, edpk.data(), edpk.size());
         return true;
     } catch (...) {

--- a/tests/test_xed25519.cpp
+++ b/tests/test_xed25519.cpp
@@ -3,6 +3,7 @@
 #include <sodium/crypto_sign_ed25519.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
 
 #include "session/util.hpp"
 #include "session/xed25519.h"
@@ -57,11 +58,11 @@ TEST_CASE("XEd25519 pubkey conversion", "[xed25519][pubkey]") {
     REQUIRE(rc == 0);
     REQUIRE(view_hex(xpk2) == view_hex(xpub2));
 
-    auto xed1 = session::xed25519::pubkey(session::to_span(xpub1));
+    auto xed1 = session::xed25519::pubkey(xpub1);
     REQUIRE(view_hex(xed1) == oxenc::to_hex(pub1));
 
     // This one fails because the original Ed pubkey is negative
-    auto xed2 = session::xed25519::pubkey(session::to_span(xpub2));
+    auto xed2 = session::xed25519::pubkey(xpub2);
     REQUIRE(view_hex(xed2) != oxenc::to_hex(pub2));
     // After making the xed negative we should be okay:
     xed2[31] |= 0x80;
@@ -83,12 +84,12 @@ TEST_CASE("XEd25519 signing", "[xed25519][sign]") {
 
     const auto msg = session::to_span("hello world");
 
-    auto xed_sig1 = session::xed25519::sign(session::to_span(xsk1), msg);
+    auto xed_sig1 = session::xed25519::sign(xsk1, msg);
 
     rc = crypto_sign_ed25519_verify_detached(xed_sig1.data(), msg.data(), msg.size(), pub1.data());
     REQUIRE(rc == 0);
 
-    auto xed_sig2 = session::xed25519::sign(session::to_span(xsk2), msg);
+    auto xed_sig2 = session::xed25519::sign(xsk2, msg);
 
     // This one will fail, because Xed signing always uses the positive but our actual pub2 is the
     // negative:
@@ -112,24 +113,48 @@ TEST_CASE("XEd25519 verification", "[xed25519][verify]") {
 
     const auto msg = session::to_span("hello world");
 
-    auto xed_sig1 = session::xed25519::sign(session::to_span(xsk1), msg);
-    auto xed_sig2 = session::xed25519::sign(session::to_span(xsk2), msg);
+    auto xed_sig1 = session::xed25519::sign(xsk1, msg);
+    auto xed_sig2 = session::xed25519::sign(xsk2, msg);
 
-    REQUIRE(session::xed25519::verify(session::to_span(xed_sig1), session::to_span(xpub1), msg));
-    REQUIRE(session::xed25519::verify(session::to_span(xed_sig2), session::to_span(xpub2), msg));
+    REQUIRE(session::xed25519::verify(xed_sig1, xpub1, msg));
+    REQUIRE(session::xed25519::verify(xed_sig2, xpub2, msg));
 
     // Unlike regular Ed25519, XEd25519 uses randomness in the signature, so signing the same value
     // a second should give us a different signature:
-    auto xed_sig1b = session::xed25519::sign(session::to_span(xsk1), msg);
+    auto xed_sig1b = session::xed25519::sign(xsk1, msg);
     REQUIRE(view_hex(xed_sig1b) != view_hex(xed_sig1));
 }
 
+TEST_CASE("XEd25519 string overloads reject invalid input sizes", "[xed25519]") {
+    std::string short_key(31, '\0');
+    std::string key(32, '\0');
+    std::string long_key(33, '\0');
+    std::string short_signature(63, '\0');
+    std::string signature(64, '\0');
+    std::string long_signature(65, '\0');
+
+    CHECK_THROWS_AS(session::xed25519::sign(short_key, "hello world"), std::invalid_argument);
+    CHECK_THROWS_AS(session::xed25519::sign(long_key, "hello world"), std::invalid_argument);
+
+    CHECK_THROWS_AS(
+            session::xed25519::verify(short_signature, key, "hello world"), std::invalid_argument);
+    CHECK_THROWS_AS(
+            session::xed25519::verify(long_signature, key, "hello world"), std::invalid_argument);
+    CHECK_THROWS_AS(
+            session::xed25519::verify(signature, short_key, "hello world"), std::invalid_argument);
+    CHECK_THROWS_AS(
+            session::xed25519::verify(signature, long_key, "hello world"), std::invalid_argument);
+
+    CHECK_THROWS_AS(session::xed25519::pubkey(short_key), std::invalid_argument);
+    CHECK_THROWS_AS(session::xed25519::pubkey(long_key), std::invalid_argument);
+}
+
 TEST_CASE("XEd25519 pubkey conversion (C wrapper)", "[xed25519][pubkey][c]") {
-    auto xed1 = session::xed25519::pubkey(session::to_span(xpub1));
+    auto xed1 = session::xed25519::pubkey(xpub1);
     REQUIRE(view_hex(xed1) == oxenc::to_hex(pub1));
 
     // This one fails because the original Ed pubkey is negative
-    auto xed2 = session::xed25519::pubkey(session::to_span(xpub2));
+    auto xed2 = session::xed25519::pubkey(xpub2);
     REQUIRE(view_hex(xed2) != oxenc::to_hex(pub2));
     // After making the xed negative we should be okay:
     xed2[31] |= 0x80;


### PR DESCRIPTION
## summary

the binary C++ XEd25519 API now uses fixed-size spans for keys and signatures, making invalid input sizes a compile-time error

the dynamic string overloads validate sizes before converting to those fixed spans, and the affected blinding and group-key call sites now pass explicitly sized views or fixed arrays

## tests

- `./utils/format.sh verify`
- release build with `cmake --build build-clean --target testAll --parallel 2`
- `./build-clean/tests/testAll "[xed25519]"`
- `./build-clean/tests/testAll "*blinded*"`
- `./build-clean/tests/testAll "Group Keys*"`
- `./build-clean/tests/testAll`
