### PR TITLE
Allow an entitled account with no proof to acquire one

### DIFF
--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -230,11 +230,22 @@ void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> 
     else
         data["E"].erase();
 
-    // Confirming a live entitlement means any in-flight purchase resolved, and any long-stale
-    // refund request is moot -- opportunistically clear both (we're already writing E anyway).
+    // A live entitlement makes any long-stale refund request moot, and a live *proof* means an
+    // in-flight purchase resolved -- opportunistically clear both (we're already writing E anyway).
+    //
+    // The purchase marker is deliberately NOT cleared on a live E alone. Entitlement and credential
+    // are independent: an account can be entitled (E in the future, per the backend) while no device
+    // has ever minted a proof -- a server-side grant such as a promotional/complimentary
+    // subscription, or a store subscription recovered after an account hold, where no purchase flow
+    // runs on the device. That is exactly the state the acquire loop exists to resolve, so clearing
+    // the marker on E alone stops acquisition before it can start, on every status refresh.
+    //
+    // `set_pro_config` clears the marker when a proof lands; the check is repeated here because a
+    // proof can also arrive by config merge from another device rather than through that setter.
     if (access_expiry_ts && *access_expiry_ts > ts_now()) {
-        if (data["I"].exists())
-            data["I"].erase();
+        if (auto pro = get_pro_config(); pro && pro->proof.expiry_at > ts_now())
+            if (data["I"].exists())
+                data["I"].erase();
         if (auto* R = data["R"].integer(); R && std::chrono::sys_seconds{std::chrono::seconds{*R}} <
                                                         ts_now() - std::chrono::weeks{1})
             data["R"].erase();
@@ -281,12 +292,16 @@ void UserProfile::set_pro_prepaid(std::optional<std::chrono::sys_seconds> when) 
             changed = true;
         }
     } else {
-        // Only mark a purchase pending if the account isn't already entitled to Pro (a live proof
-        // or a still-future access expiry); otherwise there's nothing to poll for.
+        // Only mark a purchase pending if the account already holds a credential; otherwise there
+        // is nothing to poll for.
+        //
+        // A still-future access expiry deliberately does NOT count as "already pro" here.
+        // Entitlement and credential are independent, and "entitled with no proof" is the exact
+        // state the acquire loop exists to resolve -- a server-side grant (promotional or
+        // complimentary), or a store subscription recovered after an account hold, where no purchase
+        // flow ever runs on the device. Treating a live E as already-pro made the marker unsettable
+        // in precisely the case that needs it, leaving the account permanently unable to prove Pro.
         bool already_pro = get_pro_config().has_value();
-        if (!already_pro)
-            if (auto e = get_pro_access_expiry(); e && *e > ts_now())
-                already_pro = true;
         if (!already_pro) {
             data["I"] = epoch_seconds(*when);
             changed = true;

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -681,9 +681,8 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     profile.set_refund_requested(std::nullopt);
     CHECK_FALSE(profile.get_refund_requested().has_value());
 
-    // Pro-prepaid ("purchase in flight") marker: insert-only-if-not-pro, 1-week read gate, and
-    // auto-clear when entitlement lands. (No proof, access expiry in the past -> not currently
-    // pro.)
+    // Pro-prepaid ("purchase in flight") marker: insert-only-if-no-credential, 1-week read gate,
+    // and auto-clear when a proof lands. (No proof, access expiry in the past -> no credential.)
     CHECK_FALSE(profile.get_pro_prepaid().has_value());
 
     auto prepaid_at = now - 1h;
@@ -694,22 +693,38 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     profile.set_pro_prepaid(now - std::chrono::weeks{2});
     CHECK_FALSE(profile.get_pro_prepaid().has_value());
 
-    // Confirming a live access expiry clears the marker (entitlement arrived).
+    // A live access expiry alone does NOT clear the marker. Entitlement and credential are
+    // independent: the backend can report an account entitled while no device has ever minted a
+    // proof (a server-side grant, or a store subscription recovered without a purchase flow), and
+    // that is the state the acquire loop exists to resolve. Clearing on E alone stopped acquisition
+    // before it started, on every status refresh.
     profile.set_pro_prepaid(prepaid_at);
     REQUIRE(profile.get_pro_prepaid().has_value());
     profile.set_pro_access_expiry(now + 1h);
-    CHECK_FALSE(profile.get_pro_prepaid().has_value());
+    CHECK(profile.get_pro_prepaid() == prepaid_at);
 
-    // While pro (live access expiry), setting the marker is a no-op.
+    // For the same reason the marker can be SET while entitled but credential-less.
+    profile.set_pro_prepaid(std::nullopt);
+    REQUIRE_FALSE(profile.get_pro_prepaid().has_value());
     profile.set_pro_prepaid(prepaid_at);
-    CHECK_FALSE(profile.get_pro_prepaid().has_value());
+    CHECK(profile.get_pro_prepaid() == prepaid_at);
 
-    // A landed (still-valid) proof also clears it: back to not-pro, mark pending, store a proof.
+    // A landed (still-valid) proof DOES clear it -- that, not E, is what proves the purchase
+    // resolved: back to no entitlement, mark pending, store a proof.
     profile.set_pro_access_expiry(std::nullopt);
     profile.set_pro_prepaid(prepaid_at);
     REQUIRE(profile.get_pro_prepaid().has_value());
     pro_cpp.proof.expiry_at = now + 1h;
     profile.set_pro_config(pro_cpp);
+    CHECK_FALSE(profile.get_pro_prepaid().has_value());
+
+    // With a live proof stored, writing a live E clears the marker too (the merge case: a proof can
+    // arrive by config sync rather than through set_pro_config, so the check is repeated there).
+    profile.set_pro_access_expiry(now + 1h);
+    CHECK_FALSE(profile.get_pro_prepaid().has_value());
+
+    // And with a credential present, the marker stays unsettable -- there is nothing to poll for.
+    profile.set_pro_prepaid(prepaid_at);
     CHECK_FALSE(profile.get_pro_prepaid().has_value());
 
     // Explicit clear via nullopt.


### PR DESCRIPTION
An account can be entitled while no device has ever minted a proof, and the acquire loop was unreachable in that state: the prepaid marker could not be set while the access expiry was live, and writing a live access expiry cleared it. Neither is evidence that a purchase resolved -- only a live proof is.