### PR TITLE
user_profile: fetch a proof when entitled but holding none

### DIFF
--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -301,18 +301,24 @@ void UserProfile::set_pro_prepaid(std::optional<std::chrono::sys_seconds> when) 
 
 std::optional<std::chrono::sys_seconds> UserProfile::pro_renewal_target(
         std::chrono::sys_seconds now) const {
-    auto pro = get_pro_config();
-    if (!pro) {
-        // No credential on the account at all. Only fetch if a purchase is in flight (the prepaid
-        // marker); otherwise the account simply isn't Pro. An entitled account carries its proof in
-        // config `s` (synced from whichever device obtained it), so genuinely having no proof means
-        // there's none to renew. The prepaid marker ages out via its 1-week read gate, so a
-        // purchase that never lands self-terminates the acquire loop.
+    auto pro_config = get_pro_config();
+    if (!pro_config) {
+        // No proof credential to renew, but still (re)fetch if entitlement is signalled another
+        // way:
+        //  - a purchase in flight (the prepaid marker), or
+        //  - a still-future cached access expiry: we're entitled yet hold no proof to attach. `s`
+        //    (the credential) and `E` (the access horizon) are independent config keys, so `s` can
+        //    be dropped or merge-lost while `E` still carries a live horizon.
+        // Otherwise the account simply isn't Pro. Both signals self-terminate the acquire loop: the
+        // prepaid marker ages out via its 1-week read gate; a stale-but-future `E` resolves when a
+        // fetch returns not_subscribed and the client clears `E` (which does not self-age).
         if (get_pro_prepaid())
+            return now;
+        if (auto access = get_pro_access_expiry(); access && *access > now)
             return now;
         return std::nullopt;
     }
-    auto expiry = pro->proof.expiry_at;
+    auto expiry = pro_config->proof.expiry_at;
     if (expiry <= now)
         // Expired proof: always re-check with the backend. The subscription may have auto-renewed
         // (possibly without this device's knowledge -- our cached access expiry can't be trusted to


### PR DESCRIPTION
pro_renewal_target returned nullopt ("never (re)fetch") whenever there was no proof credential unless a prepaid purchase marker was set. But `s` (the credential) and `E` (the access expiry) are independent config keys, so an account can be genuinely entitled -- `E` still in the future -- while holding no proof (e.g. `s` was dropped or merge-lost). That state should fetch a proof, not sit idle forever. Return `now` when the access expiry is still in the future and there's no proof.

Also rename the local `pro` -> `pro_config`: it is the full ProConfig credential (rotating key + proof), not a boolean "are we pro", and the old name misled at least one reader into misdiagnosing this very path.

Relies on the client keeping `E` synced to the backend's reported horizon and clearing it on not_subscribed (E does not self-age); will be implemented separately in the clients.