### PR TITLE
user_profile: add the pro grace period, and distinguish an unset auto-renewing flag

### DIFF
--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -429,9 +429,9 @@ LIBSESSION_EXPORT void user_profile_set_pro_auto_renewing(config_object* conf, i
 ///
 /// Returns the account's grace period in seconds (`get_pro_status.grace_period_duration`), or 0 if
 /// none is stored. Backend-derived and synced alongside the access expiry, so any linked device can
-/// derive the paid-through instant as `access_expiry - grace_period`: the backend folds the grace
-/// period into the stored expiry for auto-renewing subscriptions, so the access expiry is the end
-/// of coverage rather than the date the renewal is due.
+/// compute when coverage actually ends: `access_expiry + grace_period`. The access expiry is the
+/// payment-due date -- the instant the term was paid through -- and `[E, E + G)` is the window
+/// where the payment is overdue but service continues.
 ///
 /// There is deliberately no companion presence check: the backend sends 0 whenever the
 /// subscription is not auto-renewing, so "unset" and "zero" describe the same account and both give

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -435,7 +435,7 @@ LIBSESSION_EXPORT void user_profile_set_pro_auto_renewing(config_object* conf, i
 ///
 /// There is deliberately no companion presence check: the backend sends 0 whenever the
 /// subscription is not auto-renewing, so "unset" and "zero" describe the same account and both give
-/// `expiry - 0 == expiry`.
+/// `expiry + 0 == expiry`.
 ///
 /// Inputs:
 /// - `conf` -- [in] Pointer to the config object

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -399,6 +399,32 @@ LIBSESSION_EXPORT int64_t user_profile_get_pro_access_expiry(const config_object
 LIBSESSION_EXPORT void user_profile_set_pro_access_expiry(
         config_object* conf, int64_t access_expiry_ts);
 
+/// API: user_profile/user_profile_get_pro_auto_renewing
+///
+/// Returns whether the account's current Session Pro subscription is auto-renewing. Backend-derived
+/// (the `auto_renewing` field on /get_pro_status); set alongside the access expiry.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to the config object
+///
+/// Outputs:
+/// - `int` -- 1 if the subscription is known to be auto-renewing, otherwise 0 (terminal, unknown,
+///   or not Pro).
+LIBSESSION_EXPORT int user_profile_get_pro_auto_renewing(const config_object* conf);
+
+/// API: user_profile/user_profile_set_pro_auto_renewing
+///
+/// Records whether the current Session Pro subscription is auto-renewing: nonzero stores the flag,
+/// 0 clears it (which is also how it is cleared when the subscription lapses).
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to the config object
+/// - `auto_renewing` -- [in] nonzero if auto-renewing, 0 to clear
+///
+/// Outputs:
+/// - `void`
+LIBSESSION_EXPORT void user_profile_set_pro_auto_renewing(config_object* conf, int auto_renewing);
+
 /// API: user_profile/user_profile_get_refund_requested
 ///
 /// Retrieves the timestamp at which the user requested a refund of their current Session Pro

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -425,6 +425,39 @@ LIBSESSION_EXPORT int user_profile_get_pro_auto_renewing(const config_object* co
 /// - `void`
 LIBSESSION_EXPORT void user_profile_set_pro_auto_renewing(config_object* conf, int auto_renewing);
 
+/// API: user_profile/user_profile_get_pro_grace_period
+///
+/// Returns the account's grace period in seconds (`get_pro_status.grace_period_duration`), or 0 if
+/// none is stored. Backend-derived and synced alongside the access expiry, so any linked device can
+/// derive the paid-through instant as `access_expiry - grace_period`: the backend folds the grace
+/// period into the stored expiry for auto-renewing subscriptions, so the access expiry is the end
+/// of coverage rather than the date the renewal is due.
+///
+/// There is deliberately no companion presence check: the backend sends 0 whenever the
+/// subscription is not auto-renewing, so "unset" and "zero" describe the same account and both give
+/// `expiry - 0 == expiry`.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to the config object
+///
+/// Outputs:
+/// - `int64_t` -- the grace period in seconds, or 0 if unset.
+LIBSESSION_EXPORT int64_t user_profile_get_pro_grace_period(const config_object* conf);
+
+/// API: user_profile/user_profile_set_pro_grace_period
+///
+/// Sets the account's grace period, in seconds. Set alongside `user_profile_set_pro_access_expiry`
+/// from each `get_pro_status` response; 0 (or negative) clears it.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to the config object
+/// - `grace_seconds` -- [in] the grace period in seconds, or 0 to clear
+///
+/// Outputs:
+/// - `void`
+LIBSESSION_EXPORT void user_profile_set_pro_grace_period(
+        config_object* conf, int64_t grace_seconds);
+
 /// API: user_profile/user_profile_get_refund_requested
 ///
 /// Retrieves the timestamp at which the user requested a refund of their current Session Pro

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -382,7 +382,7 @@ class UserProfile : public ConfigBase {
     ///
     /// Note this deliberately returns a plain duration rather than an optional: the backend sends
     /// zero when the subscription is not auto-renewing, so "no grace stored" and "a grace of zero"
-    /// describe the same account and both give `E - 0 == E`.  There is no state a caller could act
+    /// describe the same account and both give `E + 0 == E`.  There is no state a caller could act
     /// on differently, so there is nothing for a presence check to disambiguate.
     ///
     /// Inputs: None

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -40,6 +40,10 @@ using namespace std::literals;
 ///     flight"), so all the account's devices poll the backend to pull the entitlement through.
 ///     Inserted only when not already pro; cleared automatically when entitlement lands; values
 ///     more than a week in the past are ignored on read.
+/// A - set to 1 when the current Session Pro subscription is auto-renewing; omitted when it is
+///     terminal (will not renew), unknown, or the account isn't Pro. Backend-derived
+///     (get_pro_status.auto_renewing) and synced across devices; the client sets it alongside `E`
+///     and clears it (sets false) when the subscription lapses.
 /// P - user profile url after re-uploading (should take precedence over `p` when `T > t`).
 /// Q - user profile decryption key (binary) after re-uploading (should take precedence over `q`
 ///     when `T > t`).
@@ -338,6 +342,28 @@ class UserProfile : public ConfigBase {
     /// - `access_expiry_ts` -- The timestamp (unix epoch seconds) that the users Session Pro access
     /// will expire, or nullopt to remove the value.
     void set_pro_access_expiry(std::optional<sys_seconds> access_expiry_ts);
+
+    /// API: user_profile/UserProfile::get_pro_auto_renewing
+    ///
+    /// Returns whether the account's current Session Pro subscription is auto-renewing (true) or
+    /// terminal/unknown (false). Backend-derived (the `auto_renewing` field on /get_pro_status);
+    /// the client sets it alongside `set_pro_access_expiry`. Only a `true` value is stored, so an
+    /// account that isn't Pro, or whose renewal status has not been learned, reads as false.
+    ///
+    /// Inputs: None
+    ///
+    /// Outputs:
+    /// - `bool` -- true iff the subscription is known to be auto-renewing.
+    bool get_pro_auto_renewing() const;
+
+    /// API: user_profile/UserProfile::set_pro_auto_renewing
+    ///
+    /// Records whether the current Session Pro subscription is auto-renewing. `true` stores the
+    /// flag; `false` erases it -- which is also how it is cleared when the subscription lapses.
+    ///
+    /// Inputs:
+    /// - `auto_renewing` -- true if the subscription auto-renews; false to clear the flag.
+    void set_pro_auto_renewing(bool auto_renewing);
 
     /// API: user_profile/UserProfile::get_refund_requested
     ///

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -44,10 +44,12 @@ using namespace std::literals;
 ///     terminal (will not renew), unknown, or the account isn't Pro. Backend-derived
 ///     (get_pro_status.auto_renewing) and synced across devices; the client sets it alongside `E`
 ///     and clears it (sets false) when the subscription lapses.
-/// G - the account's grace period, in seconds (get_pro_status.grace_period_duration), synced so any
-///     device can derive the paid-through instant as `E - G`. Backend-derived and set alongside
-///     `E`. Omitted when zero, which is also what the backend sends when the subscription is not
-///     auto-renewing -- so an absent `G` and a zero `G` mean the same thing and `E - G == E`.
+/// G - how much longer the account keeps being served past `E`, in seconds
+///     (get_pro_status.grace_period_duration): the store's dunning window plus the backend's own
+///     renewal-latency allowance. Coverage ends at `E + G`; `[E, E + G)` is the window where the
+///     payment is overdue but service continues. Backend-derived and set alongside `E`. Omitted
+///     when zero, which is also what the backend sends when the subscription is not auto-renewing
+///     -- so an absent `G` and a zero `G` mean the same thing and coverage ends at `E`.
 /// P - user profile url after re-uploading (should take precedence over `p` when `T > t`).
 /// Q - user profile decryption key (binary) after re-uploading (should take precedence over `q`
 ///     when `T > t`).
@@ -371,11 +373,12 @@ class UserProfile : public ConfigBase {
 
     /// API: user_profile/UserProfile::get_pro_grace_period
     ///
-    /// Returns the account's grace period (`get_pro_status.grace_period_duration`), or zero if none
-    /// is stored.  Backend-derived and synced alongside `E`, so any linked device can derive the
-    /// paid-through instant as `get_pro_access_expiry() - get_pro_grace_period()`: the backend
-    /// folds the grace period into the stored expiry for auto-renewing subscriptions, so `E` is the
-    /// end of coverage rather than the date the renewal is due.
+    /// Returns how much longer the account keeps being served past `E`
+    /// (`get_pro_status.grace_period_duration`), or zero if none is stored.  Backend-derived and
+    /// synced alongside `E`, so any linked device can compute when coverage actually ends:
+    /// `get_pro_access_expiry() + get_pro_grace_period()`.  `E` itself is the payment-due date --
+    /// the instant the term was paid through -- and `[E, E + G)` is the window where the payment is
+    /// overdue but service continues.
     ///
     /// Note this deliberately returns a plain duration rather than an optional: the backend sends
     /// zero when the subscription is not auto-renewing, so "no grace stored" and "a grace of zero"

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -44,6 +44,10 @@ using namespace std::literals;
 ///     terminal (will not renew), unknown, or the account isn't Pro. Backend-derived
 ///     (get_pro_status.auto_renewing) and synced across devices; the client sets it alongside `E`
 ///     and clears it (sets false) when the subscription lapses.
+/// G - the account's grace period, in seconds (get_pro_status.grace_period_duration), synced so any
+///     device can derive the paid-through instant as `E - G`. Backend-derived and set alongside
+///     `E`. Omitted when zero, which is also what the backend sends when the subscription is not
+///     auto-renewing -- so an absent `G` and a zero `G` mean the same thing and `E - G == E`.
 /// P - user profile url after re-uploading (should take precedence over `p` when `T > t`).
 /// Q - user profile decryption key (binary) after re-uploading (should take precedence over `q`
 ///     when `T > t`).
@@ -364,6 +368,34 @@ class UserProfile : public ConfigBase {
     /// Inputs:
     /// - `auto_renewing` -- true if the subscription auto-renews; false to clear the flag.
     void set_pro_auto_renewing(bool auto_renewing);
+
+    /// API: user_profile/UserProfile::get_pro_grace_period
+    ///
+    /// Returns the account's grace period (`get_pro_status.grace_period_duration`), or zero if none
+    /// is stored.  Backend-derived and synced alongside `E`, so any linked device can derive the
+    /// paid-through instant as `get_pro_access_expiry() - get_pro_grace_period()`: the backend
+    /// folds the grace period into the stored expiry for auto-renewing subscriptions, so `E` is the
+    /// end of coverage rather than the date the renewal is due.
+    ///
+    /// Note this deliberately returns a plain duration rather than an optional: the backend sends
+    /// zero when the subscription is not auto-renewing, so "no grace stored" and "a grace of zero"
+    /// describe the same account and both give `E - 0 == E`.  There is no state a caller could act
+    /// on differently, so there is nothing for a presence check to disambiguate.
+    ///
+    /// Inputs: None
+    ///
+    /// Outputs:
+    /// - `std::chrono::seconds` -- the grace period, or `0s` if unset.
+    std::chrono::seconds get_pro_grace_period() const;
+
+    /// API: user_profile/UserProfile::set_pro_grace_period
+    ///
+    /// Records the account's grace period, in seconds.  Set alongside `set_pro_access_expiry` from
+    /// each `get_pro_status` response; a zero (or negative) value erases the key.
+    ///
+    /// Inputs:
+    /// - `grace` -- the grace period; zero or negative clears it.
+    void set_pro_grace_period(std::chrono::seconds grace);
 
     /// API: user_profile/UserProfile::get_refund_requested
     ///

--- a/include/session/parse_error.hpp
+++ b/include/session/parse_error.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <fmt/core.h>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace session {
+
+/// Thrown by the parse_* helpers when serialized input (a backend JSON reply, onion-request
+/// metadata, a service node description, ...) cannot be understood: malformed JSON, a missing or
+/// wrong-typed field, an unrecognized envelope status, or bad hex. This is distinct from a
+/// well-formed backend *failure* (an envelope carrying a "fail"/"error" status + error_code), which
+/// is not a parse error: it is returned normally with the status/error fields populated.
+struct parse_error : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+/// A parse failure attributable to a specific field, whose name is carried in `key` (rather than
+/// being recoverable only by scraping `what()`).
+struct parse_error_key : parse_error {
+    std::string key;
+    parse_error_key(std::string_view key, std::string_view msg) :
+            parse_error{std::string{msg}}, key{key} {}
+};
+
+/// A required field was absent.
+struct parse_error_missing : parse_error_key {
+    explicit parse_error_missing(std::string_view key) :
+            parse_error_key{key, fmt::format("Key '{}' is missing", key)} {}
+};
+
+/// A field was present but held the wrong type; `expected` names the type that was wanted and
+/// `found` is a short rendering of the value that was there instead.
+struct parse_error_type : parse_error_key {
+    parse_error_type(std::string_view key, std::string_view expected, std::string_view found) :
+            parse_error_key{
+                    key, fmt::format("Key value ({}, {}) was not {}", key, found, expected)} {}
+};
+
+}  // namespace session

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -217,7 +217,13 @@ typedef struct session_pro_backend_pro_payment_item {
     /// Provider purchase time, fractional UNIX seconds. Millisecond-precise: the value passes
     /// through a millisecond-resolution representation, so sub-millisecond digits are not retained.
     double purchased_ts;
+    /// When THIS payment's term was paid through.
     int64_t expiry_ts;
+    /// The dunning window this one payment's provider declared -- raw store data. NOT the same
+    /// quantity as the account-level `grace_period_duration` on the status response, which adds the
+    /// backend's renewal-latency allowance and is gated on the account renewing. This one is not
+    /// gated, so a cancelled subscription can still carry a stale non-zero value. For "when does
+    /// entitlement end", use the account-level field.
     int64_t grace_period_duration;
     int64_t platform_refund_expiry_ts;
     /// Provider revocation instant, fractional UNIX seconds (millisecond-precise; 0 if not revoked)
@@ -234,7 +240,17 @@ typedef struct session_pro_backend_get_pro_status_response {
     /// NUL-terminated; points into the response's `internal_`.
     const char* status;
     bool auto_renewing;
+    /// The account's PAYMENT-DUE date: when the current term was paid through. Does NOT include the
+    /// grace period -- entitlement runs to `expiry_ts + grace_period_duration`, and `status` is
+    /// judged against that sum. Do not subtract the grace from this.
     int64_t expiry_ts;
+    /// How much longer (seconds) entitlement continues PAST `expiry_ts`: the provider's dunning
+    /// window plus the backend's renewal-latency allowance. Add it to `expiry_ts` to get the
+    /// instant entitlement ends; `[expiry_ts, expiry_ts + this)` is overdue-but-still-served. 0
+    /// when `auto_renewing` is false, so the sum stays correct there without a special case.
+    ///
+    /// ACCOUNT-level. `latest_payment.grace_period_duration` shares the name and is a different
+    /// quantity -- see there.
     int64_t grace_period_duration;
     /// True if the account has at least one payment, in which case `latest_payment` is populated
     /// with the most recent one; false means the account has no payments and `latest_payment` is

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -144,17 +144,15 @@ typedef struct session_pro_backend_pro_proof_response {
     /// coverage ends at `account_expiry_ts + account_grace_period_duration`. 0 when the
     /// subscription is not auto-renewing.
     ///
-    /// ⚠️ MEANINGFUL ONLY WHEN `header.status` IS OK. Filled only on the success path, so every
-    /// non-OK outcome -- protocol error, `stale_request`, transport failure, where the account is
-    /// untouched -- yields a plain 0 that is indistinguishable from "no grace". Nothing in the
-    /// struct signals which you have. Read it inside the success branch or not at all.
+    /// Carried with `account_auto_renewing` on a successful proof and on a `subscription_expired`
+    /// failure -- refresh all three together (see `account_expiry_ts`), never the expiry alone. 0
+    /// when the backend omits it (grace not applicable), so a refresh clears any stale cached grace
+    /// rather than preserving it; likewise a truthful 0 on `not_subscribed` / `revoked` / errors.
     int64_t account_grace_period_duration;
-    /// Whether the subscription behind `account_expiry_ts` renews itself.
-    ///
-    /// ⚠️ MEANINGFUL ONLY WHEN `header.status` IS OK, and this one is the more dangerous of the two:
-    /// every non-OK outcome yields a plain false, and the config key it feeds is presence-only,
-    /// where writing false ERASES. Reading it after a failed request destroys a renewing flag
-    /// learned from `get_pro_status`, on a response that said nothing about the account.
+    /// Whether the subscription behind `account_expiry_ts` renews itself. Travels with
+    /// `account_grace_period_duration`: carried on a successful proof and a `subscription_expired`
+    /// failure, false when the backend omits it. Refresh it with the expiry and grace; a false
+    /// clears the presence-only config flag rather than preserving a stale one.
     bool account_auto_renewing;
 } session_pro_backend_pro_proof_response;
 

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -140,6 +140,22 @@ typedef struct session_pro_backend_pro_proof_response {
     /// proof-validity window). Populated on a successful proof and on a `subscription_expired`
     /// failure (a now-past value); 0 on `not_subscribed` / `revoked` / protocol errors.
     int64_t account_expiry_ts;
+    /// The grace period (seconds) folded into `account_expiry_ts`, so the paid-through instant is
+    /// `account_expiry_ts - account_grace_period_duration`. 0 when the subscription is not
+    /// auto-renewing.
+    ///
+    /// ⚠️ MEANINGFUL ONLY WHEN `header.status` IS OK. Filled only on the success path, so every
+    /// non-OK outcome -- protocol error, `stale_request`, transport failure, where the account is
+    /// untouched -- yields a plain 0 that is indistinguishable from "no grace". Nothing in the
+    /// struct signals which you have. Read it inside the success branch or not at all.
+    int64_t account_grace_period_duration;
+    /// Whether the subscription behind `account_expiry_ts` renews itself.
+    ///
+    /// ⚠️ MEANINGFUL ONLY WHEN `header.status` IS OK, and this one is the more dangerous of the two:
+    /// every non-OK outcome yields a plain false, and the config key it feeds is presence-only,
+    /// where writing false ERASES. Reading it after a failed request destroys a renewing flag
+    /// learned from `get_pro_status`, on a response that said nothing about the account.
+    bool account_auto_renewing;
 } session_pro_backend_pro_proof_response;
 
 /// API: session_pro_backend/pro_proof_response_free

--- a/include/session/pro_backend.h
+++ b/include/session/pro_backend.h
@@ -133,16 +133,16 @@ typedef struct session_pro_backend_response_header {
 typedef struct session_pro_backend_pro_proof_response {
     session_pro_backend_response_header header;
     session_protocol_pro_proof proof;
-    /// The account's true, grace-inclusive subscription entitlement end (unix seconds), or 0 if
-    /// this response carries no horizon. Advisory and unsigned (pro-wire-protocol.md §2.2): use for
-    /// display / refreshing the cached access expiry only -- NOT an entitlement authority and NOT
-    /// part of the proof signature. Distinct from `proof.expiry_ts` (the clamped <=30d
+    /// The end of the paid term (unix seconds) -- coverage runs to this plus the grace below -- or
+    /// 0 if this response carries no horizon. Advisory and unsigned (pro-wire-protocol.md §2.2):
+    /// use for display / refreshing the cached access expiry only -- NOT an entitlement authority
+    /// and NOT part of the proof signature. Distinct from `proof.expiry_ts` (the clamped <=30d
     /// proof-validity window). Populated on a successful proof and on a `subscription_expired`
     /// failure (a now-past value); 0 on `not_subscribed` / `revoked` / protocol errors.
     int64_t account_expiry_ts;
-    /// The grace period (seconds) folded into `account_expiry_ts`, so the paid-through instant is
-    /// `account_expiry_ts - account_grace_period_duration`. 0 when the subscription is not
-    /// auto-renewing.
+    /// How much longer (seconds) the account keeps being served past `account_expiry_ts`, so
+    /// coverage ends at `account_expiry_ts + account_grace_period_duration`. 0 when the
+    /// subscription is not auto-renewing.
     ///
     /// ⚠️ MEANINGFUL ONLY WHEN `header.status` IS OK. Filled only on the success path, so every
     /// non-OK outcome -- protocol error, `stale_request`, transport failure, where the account is

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -199,31 +199,21 @@ struct GenerateProProofResponse : ResponseBase {
     /// auto-renewing, mirroring `get_pro_status`, because neither span applies to a term that is
     /// simply ending.
     ///
-    /// Required on a successful proof, like `account_expiry`: a response missing it can't be paired
-    /// with the expiry it qualifies, and a client that persisted the two out of step would compute
-    /// the wrong coverage end.
-    ///
-    /// ⚠️ **Meaningful ONLY when the response succeeded.** This is default-initialised and is filled
-    /// only on the success path, so on *every* non-OK outcome -- including a protocol error, a
-    /// `stale_request`, or a transport failure, where the account is untouched -- it reads as a
-    /// plain `0`, indistinguishable from a backend that really said "no grace". Nothing in the type
-    /// signals which you have. Read it inside the success branch or not at all; a caller that
-    /// persists this after a failed request erases a grace it had learned from `get_pro_status`.
+    /// Carried, alongside `account_auto_renewing`, on both a successful proof and a
+    /// `subscription_expired` failure -- refresh all three of these together (see `account_expiry`)
+    /// and never the expiry alone. `0` when the backend omits it, which it does whenever grace does
+    /// not apply: a missing value means "not applicable" and should overwrite (clear) any stale
+    /// cached grace, never be taken as "leave the old value". Consequently it is a truthful `0` on
+    /// the account-less outcomes too (`not_subscribed`, `revoked`, protocol/transport errors).
     std::chrono::seconds account_grace_period{0};
 
     /// Whether the subscription behind `account_expiry` renews itself -- the same value
     /// `get_pro_status` reports as `auto_renewing`. Advisory and UNSIGNED, like the two above.
     ///
-    /// Required on a successful proof for the same reason as the grace period: clients persist it
-    /// into config beside the expiry, and a stale flag next to a fresh expiry reads as a terminal
-    /// subscription that is in fact renewing.
-    ///
-    /// ⚠️ **Meaningful ONLY when the response succeeded**, and this one is the more dangerous of the
-    /// two. Default-initialised and filled only on the success path, so every non-OK outcome yields
-    /// a plain `false` -- and the config key it feeds is presence-only, where writing `false`
-    /// **erases**. A caller that reads it after a protocol error or a `stale_request` therefore
-    /// destroys a renewing flag learned from `get_pro_status`, on a request that told it nothing
-    /// about the account at all. Read it inside the success branch or not at all.
+    /// Travels with `account_grace_period` (see there): carried on a successful proof and on a
+    /// `subscription_expired` failure, `false` whenever the backend omits it. Refresh it together
+    /// with the expiry and grace; a missing value means "not renewing" and should clear the
+    /// presence-only config flag, not preserve a stale one.
     bool account_auto_renewing{false};
 };
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -189,24 +189,26 @@ struct ProRequest {
 struct GenerateProProofResponse : ResponseBase {
     ProProof proof;
 
-    /// The account's true, grace-inclusive subscription entitlement end -- the same value
-    /// `get_pro_status` reports as its `expiry_ts` (pro-wire-protocol.md §2.2). Advisory and
-    /// UNSIGNED: not part of the proof's signed message and never fed into signature verification;
-    /// it rides on the response so a proof fetch also refreshes the client's cached access expiry.
-    /// Distinct from `proof.expiry_at` (the clamped, rolling <=30d proof-validity window). Present
-    /// (and required) on a successful proof, and on a `subscription_expired` failure (a now-past
-    /// value carried top-level on the envelope); nullopt on other outcomes (`not_subscribed`,
-    /// `revoked`, protocol errors).
+    /// The end of the paid term -- the same value `get_pro_status` reports as its `expiry_ts`
+    /// (pro-wire-protocol.md §2.2), carrying neither the store's grace nor the backend's
+    /// renewal-latency allowance; coverage runs to `account_expiry + account_grace_period`.
+    /// Advisory and UNSIGNED: not part of the proof's signed message and never fed into signature
+    /// verification; it rides on the response so a proof fetch also refreshes the client's cached
+    /// access expiry. Distinct from `proof.expiry_at` (the clamped, rolling <=30d proof-validity
+    /// window). Present (and required) on a successful proof, and on a `subscription_expired`
+    /// failure (a now-past value carried top-level on the envelope); nullopt on other outcomes
+    /// (`not_subscribed`, `revoked`, protocol errors).
     std::optional<std::chrono::sys_seconds> account_expiry;
 
-    /// The grace period folded into `account_expiry` above, so a client can recover the
-    /// paid-through instant as `account_expiry - account_grace_period`. Zero whenever the
-    /// subscription is not auto-renewing, mirroring `get_pro_status`, because the backend only
-    /// folds grace in for auto-renewing payments.
+    /// How much longer the account keeps being served past `account_expiry` above -- the store's
+    /// dunning window plus the backend's renewal-latency allowance -- so coverage ends at
+    /// `account_expiry + account_grace_period`. Zero whenever the subscription is not
+    /// auto-renewing, mirroring `get_pro_status`, because neither span applies to a term that is
+    /// simply ending.
     ///
     /// Required on a successful proof, like `account_expiry`: a response missing it can't be paired
     /// with the expiry it qualifies, and a client that persisted the two out of step would compute
-    /// the wrong paid-through instant.
+    /// the wrong coverage end.
     ///
     /// ⚠️ **Meaningful ONLY when the response succeeded.** This is default-initialised and is filled
     /// only on the success path, so on *every* non-OK outcome -- including a protocol error, a

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -371,10 +371,13 @@ struct ProPaymentItem {
     /// Unix timestamp of when the payment was expiry. 0 if not activated
     sys_seconds expiry_at;
 
-    /// Duration of the grace period, e.g. when the payment provider will start to attempt to renew
-    /// the Session Pro subscription. During the period between
-    /// [expiry_at, expiry_at + grace_period_duration] the user continues to have
-    /// entitlement to Session Pro. This value is only applicable if `auto_renewing` is `true`.
+    /// The dunning window this ONE payment's provider declared -- raw store data, and NOT the same
+    /// quantity as `ProStatusResponse::grace_period_duration`, which is account-level and adds the
+    /// backend's renewal-latency allowance. This one is also not gated on `auto_renewing`, so a
+    /// cancelled subscription can still carry a stale non-zero value here.
+    ///
+    /// Use the account-level field for "when does entitlement end"; this is for showing what a
+    /// given payment was granted. Only meaningful when this payment's `auto_renewing` is true.
     std::chrono::seconds grace_period_duration;
 
     /// Unix deadline timestamp of when the user is able to refund the subscription via the payment
@@ -403,36 +406,30 @@ struct ProStatusResponse : ResponseBase {
     /// Flag to indicate if the user will automatically renew their subscription.
     bool auto_renewing;
 
-    /// Deadline UNIX timestamp that a user is entitled to Session Pro Proofs. The user is allowed
-    /// to request a Session Pro Proof from the Pro Backend up until this timestamp. Thereafter
-    /// the user is no longer entitled to Session Pro. This deadline includes the grace period if
-    /// applicable.
+    /// The account's PAYMENT-DUE date: the instant the current term was paid through. This does
+    /// NOT include the grace period -- entitlement continues to `expiry_at +
+    /// grace_period_duration`, and the backend judges `user_status` against that sum rather than
+    /// against this value.
     ///
-    /// The grace period is enabled when `auto_renewing` is `true` and is the extra period after a
-    /// user's subscription has elapsed that the payment provider allocates to continue entitlement
-    /// to Session Pro whilst attempting to execute the billing of a Session Pro subscription.
-    ///
-    /// This allows a user to maintain entitlement to Session Pro across billing cycles by giving
-    /// some leeway as to the time required for the payment provider to successfully bill the user.
-    /// This expiry timestamp is hence calculated as:
-    ///
-    ///   expiry_at = subscription_expiry + grace_period_duration
-    ///
-    /// E.g. The subscription expiry timestamp can be calculated by subtracting
-    /// `grace_period_duration` to determine if the user is currently in a grace period. Some
-    /// platforms do not support a grace period so this value can be 0.
-    ///
-    /// Finally, a reminder that the grace period is not activated or included in this deadline
-    /// timestamp if they have configured subscription `auto_renewing` to be off.
+    /// So `expiry_at` alone answers "when is the next payment due", and `[expiry_at,
+    /// expiry_at + grace_period_duration)` is the window where the payment is overdue but service
+    /// continues. Do not subtract the grace from this -- that was the shape before the backend
+    /// stopped folding grace into the stored expiry, and it now yields an instant that means
+    /// nothing.
     ///
     /// This timestamp may be in the past if the user no longer has active payments. Overtime the
     /// Pro Backend may prune user history and so after long lapses of activity, a user's
     /// subscription history may be deleted.
     sys_seconds expiry_at;
 
-    /// Duration that a user is entitled to for their grace period. This value is to be ignored if
-    /// `auto_renewing` is false. It can be used to calculate the subscription expiry timestamp by
-    /// subtracting it from `expiry_at`.
+    /// How much longer entitlement continues PAST `expiry_at`: the payment provider's dunning
+    /// window (the leeway it allows itself to retry a failed renewal) plus the backend's own
+    /// renewal-latency allowance, which covers the gap between a term ending and the backend
+    /// learning whether it renewed.
+    ///
+    /// Add it to `expiry_at` to get the instant entitlement actually ends. 0 when `auto_renewing`
+    /// is false, because neither span applies to a term that is simply ending -- so the sum is
+    /// still correct there without a special case.
     std::chrono::seconds grace_period_duration;
 };
 

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -198,6 +198,38 @@ struct GenerateProProofResponse : ResponseBase {
     /// value carried top-level on the envelope); nullopt on other outcomes (`not_subscribed`,
     /// `revoked`, protocol errors).
     std::optional<std::chrono::sys_seconds> account_expiry;
+
+    /// The grace period folded into `account_expiry` above, so a client can recover the
+    /// paid-through instant as `account_expiry - account_grace_period`. Zero whenever the
+    /// subscription is not auto-renewing, mirroring `get_pro_status`, because the backend only
+    /// folds grace in for auto-renewing payments.
+    ///
+    /// Required on a successful proof, like `account_expiry`: a response missing it can't be paired
+    /// with the expiry it qualifies, and a client that persisted the two out of step would compute
+    /// the wrong paid-through instant.
+    ///
+    /// ⚠️ **Meaningful ONLY when the response succeeded.** This is default-initialised and is filled
+    /// only on the success path, so on *every* non-OK outcome -- including a protocol error, a
+    /// `stale_request`, or a transport failure, where the account is untouched -- it reads as a
+    /// plain `0`, indistinguishable from a backend that really said "no grace". Nothing in the type
+    /// signals which you have. Read it inside the success branch or not at all; a caller that
+    /// persists this after a failed request erases a grace it had learned from `get_pro_status`.
+    std::chrono::seconds account_grace_period{0};
+
+    /// Whether the subscription behind `account_expiry` renews itself -- the same value
+    /// `get_pro_status` reports as `auto_renewing`. Advisory and UNSIGNED, like the two above.
+    ///
+    /// Required on a successful proof for the same reason as the grace period: clients persist it
+    /// into config beside the expiry, and a stale flag next to a fresh expiry reads as a terminal
+    /// subscription that is in fact renewing.
+    ///
+    /// ⚠️ **Meaningful ONLY when the response succeeded**, and this one is the more dangerous of the
+    /// two. Default-initialised and filled only on the success path, so every non-OK outcome yields
+    /// a plain `false` -- and the config key it feeds is presence-only, where writing `false`
+    /// **erases**. A caller that reads it after a protocol error or a `stale_request` therefore
+    /// destroys a renewing flag learned from `get_pro_status`, on a request that told it nothing
+    /// about the account at all. Read it inside the success branch or not at all.
+    bool account_auto_renewing{false};
 };
 
 /// Parse the reply to a generate-proof request. On success `proof` holds the issued proof; a

--- a/include/session/pro_backend.hpp
+++ b/include/session/pro_backend.hpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <optional>
+#include <session/parse_error.hpp>
 #include <session/session_protocol.hpp>
 #include <session/types.hpp>
 #include <span>
@@ -61,14 +62,6 @@
 namespace session::pro_backend {
 
 using namespace oxenc::literals;
-
-/// Thrown by the parse_* functions when the backend's reply cannot be understood: malformed JSON, a
-/// missing or wrong-typed field, an unrecognized envelope status, or bad hex. This is distinct from
-/// a well-formed backend *failure* (envelope status "fail"/"error" carrying an error_code), which
-/// is not an error to the parser -- it is returned normally with `status`/`error_code` populated.
-struct parse_error : std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
 
 /// The Session Pro Backend's Ed25519 public key: verify that a proof was issued by the backend by
 /// checking its signature against this key (see ProProof::verify_signature). This is the current

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -229,7 +229,7 @@ void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> 
         data["E"] = epoch_seconds(*access_expiry_ts);
     else {
         data["E"].erase();
-        // `G` is only meaningful as `E - G`, so it must never outlive the `E` it was paired with:
+        // `G` is only meaningful as `E + G`, so it must never outlive the `E` it was paired with:
         // a stranded `G` would silently pair with whatever the *next* `E` write happens to be, and
         // that next write is usually a proof outcome, which carries no grace of its own to correct
         // it with.  Enforced here rather than left to callers because clearing `E` is the common

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -241,6 +241,17 @@ void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> 
     }
 }
 
+bool UserProfile::get_pro_auto_renewing() const {
+    return data["A"].integer_or(0) != 0;
+}
+
+void UserProfile::set_pro_auto_renewing(bool auto_renewing) {
+    // Presence-only: store 1 when auto-renewing, erase otherwise (absent == terminal/unknown). No
+    // t/T bump -- this is backend-derived pro state (like E/I/R), not a user-initiated profile
+    // edit.
+    set_nonzero_int(data["A"], auto_renewing);
+}
+
 std::optional<std::chrono::sys_seconds> UserProfile::get_refund_requested() const {
     if (auto* R = data["R"].integer()) {
         std::chrono::sys_seconds when{std::chrono::seconds{*R}};
@@ -539,6 +550,14 @@ LIBSESSION_C_API void user_profile_set_pro_access_expiry(
         unbox<UserProfile>(conf)->set_pro_access_expiry(std::nullopt);
     else
         unbox<UserProfile>(conf)->set_pro_access_expiry(as_sys_seconds(access_expiry_ts));
+}
+
+LIBSESSION_C_API int user_profile_get_pro_auto_renewing(const config_object* conf) {
+    return unbox<UserProfile>(conf)->get_pro_auto_renewing() ? 1 : 0;
+}
+
+LIBSESSION_C_API void user_profile_set_pro_auto_renewing(config_object* conf, int auto_renewing) {
+    unbox<UserProfile>(conf)->set_pro_auto_renewing(auto_renewing != 0);
 }
 
 LIBSESSION_C_API int64_t user_profile_get_refund_requested(const config_object* conf) {

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -236,6 +236,17 @@ void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> 
         // case (the proof-outcome clears), and a rule spread across every call site is one a new
         // call site inherits wrongly.
         data["G"].erase();
+        // `A` describes the subscription `E` denotes, so the same argument applies: a renewing flag
+        // with no expiry beside it describes a subscription that is not there.  Every caller that
+        // clears `E` is handling an account with no entitlement -- a proof cleared, a proof
+        // revoked, or a non-positive `expiry_ts` -- and none of those is auto-renewing, so there is
+        // no state in which the flag should survive its expiry.
+        //
+        // Without this the three keys are only coherent because every *consumer* happens to test
+        // `E` before reading `A`.  That is true today on all three clients and it is not a property
+        // anything enforces; making the write side maintain the invariant is what stops the next
+        // consumer inheriting the obligation without knowing it has one.
+        data["A"].erase();
     }
 
     // Confirming a live entitlement means any in-flight purchase resolved, and any long-stale

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -277,7 +277,7 @@ std::chrono::seconds UserProfile::get_pro_grace_period() const {
 
 void UserProfile::set_pro_grace_period(std::chrono::seconds grace) {
     // Omitted when zero: the backend sends 0 whenever the subscription isn't auto-renewing, and
-    // `E - 0 == E`, so an absent key and a stored zero describe the same account.  Set alongside
+    // `E + 0 == E`, so an absent key and a stored zero describe the same account.  Set alongside
     // `E`; no t/T bump -- backend-derived pro state, like E/I/R/A.
     set_nonzero_int(data["G"], grace.count() > 0 ? grace.count() : 0);
 }

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -227,8 +227,16 @@ std::optional<std::chrono::sys_seconds> UserProfile::get_pro_access_expiry() con
 void UserProfile::set_pro_access_expiry(std::optional<std::chrono::sys_seconds> access_expiry_ts) {
     if (access_expiry_ts)
         data["E"] = epoch_seconds(*access_expiry_ts);
-    else
+    else {
         data["E"].erase();
+        // `G` is only meaningful as `E - G`, so it must never outlive the `E` it was paired with:
+        // a stranded `G` would silently pair with whatever the *next* `E` write happens to be, and
+        // that next write is usually a proof outcome, which carries no grace of its own to correct
+        // it with.  Enforced here rather than left to callers because clearing `E` is the common
+        // case (the proof-outcome clears), and a rule spread across every call site is one a new
+        // call site inherits wrongly.
+        data["G"].erase();
+    }
 
     // Confirming a live entitlement means any in-flight purchase resolved, and any long-stale
     // refund request is moot -- opportunistically clear both (we're already writing E anyway).
@@ -250,6 +258,17 @@ void UserProfile::set_pro_auto_renewing(bool auto_renewing) {
     // t/T bump -- this is backend-derived pro state (like E/I/R), not a user-initiated profile
     // edit.
     set_nonzero_int(data["A"], auto_renewing);
+}
+
+std::chrono::seconds UserProfile::get_pro_grace_period() const {
+    return std::chrono::seconds{data["G"].integer_or(0)};
+}
+
+void UserProfile::set_pro_grace_period(std::chrono::seconds grace) {
+    // Omitted when zero: the backend sends 0 whenever the subscription isn't auto-renewing, and
+    // `E - 0 == E`, so an absent key and a stored zero describe the same account.  Set alongside
+    // `E`; no t/T bump -- backend-derived pro state, like E/I/R/A.
+    set_nonzero_int(data["G"], grace.count() > 0 ? grace.count() : 0);
 }
 
 std::optional<std::chrono::sys_seconds> UserProfile::get_refund_requested() const {
@@ -558,6 +577,15 @@ LIBSESSION_C_API int user_profile_get_pro_auto_renewing(const config_object* con
 
 LIBSESSION_C_API void user_profile_set_pro_auto_renewing(config_object* conf, int auto_renewing) {
     unbox<UserProfile>(conf)->set_pro_auto_renewing(auto_renewing != 0);
+}
+
+LIBSESSION_C_API int64_t user_profile_get_pro_grace_period(const config_object* conf) {
+    return unbox<UserProfile>(conf)->get_pro_grace_period().count();
+}
+
+LIBSESSION_C_API void user_profile_set_pro_grace_period(
+        config_object* conf, int64_t grace_seconds) {
+    unbox<UserProfile>(conf)->set_pro_grace_period(std::chrono::seconds{grace_seconds});
 }
 
 LIBSESSION_C_API int64_t user_profile_get_refund_requested(const config_object* conf) {

--- a/src/json_parser.hpp
+++ b/src/json_parser.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <fmt/core.h>
+
+#include <chrono>
+#include <concepts>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <session/parse_error.hpp>
+#include <session/types.hpp>
+#include <string_view>
+
+namespace session::detail {
+
+// A T that is carried on the wire as an integer count of seconds: either a duration (seconds) or a
+// system-clock time point at second granularity (sys_seconds). json_require<T>/json_maybe<T> read
+// the integer and wrap it, so a call site never repeats `sys_seconds{seconds{get<int64_t>()}}`.
+template <typename T>
+concept wire_seconds =
+        std::same_as<T, std::chrono::seconds> || std::same_as<T, std::chrono::sys_seconds>;
+
+// Whether the JSON value `v` holds a T, paired with a human name for the type (used in the error
+// message on a mismatch). Single source of truth so json_require and json_maybe cannot drift on
+// what counts as a valid T.
+template <typename T>
+std::pair<bool, std::string_view> json_is(const nlohmann::json& v) {
+    if constexpr (wire_seconds<T>)
+        // Integer seconds on the wire; reject a fractional value rather than truncating it.
+        return {v.is_number_integer(), "an integer"};
+    else if constexpr (std::floating_point<T>)
+        // An integer is a valid float, so accept any number: is_number_float() would reject it.
+        return {v.is_number(), "a number"};
+    else if constexpr (std::same_as<T, bool>)
+        return {v.is_boolean(), "a boolean"};
+    else if constexpr (std::integral<T>)
+        // is_number_integer() (not is_number()) so a fractional value is rejected, not truncated.
+        return {v.is_number_integer(), "an integer"};
+    else if constexpr (is_one_of<T, std::string, std::string_view>)
+        return {v.is_string(), "a string"};
+    else if constexpr (std::same_as<T, nlohmann::json::array_t>)
+        return {v.is_array(), "an array"};
+    else {
+        static_assert(std::same_as<T, nlohmann::json::object_t>);
+        return {v.is_object(), "an object"};
+    }
+}
+
+// Extracts an already-type-validated value as T, applying the seconds-wrapping for wire_seconds.
+template <typename T>
+T json_extract(const nlohmann::json& v) {
+    if constexpr (wire_seconds<T>)
+        return T{std::chrono::seconds{v.template get<int64_t>()}};
+    else {
+        T result = {};
+        v.get_to(result);
+        return result;
+    }
+}
+
+// Parse `input` as JSON, throwing parse_error (not a nlohmann exception) if it is not valid JSON.
+inline nlohmann::json json_parse(std::string_view input) {
+    try {
+        return nlohmann::json::parse(input);
+    } catch (const std::exception& e) {
+        throw parse_error{fmt::format("Invalid JSON received, parse failed: {}", e.what())};
+    }
+}
+
+// Reads a required field: throws parse_error_missing if absent, parse_error_type if the wrong type.
+template <typename T>
+T json_require(const nlohmann::json& j, std::string_view key) {
+    auto it = j.find(key);
+    if (it == j.end())
+        throw parse_error_missing{key};
+    if (auto [ok, type] = json_is<T>(*it); !ok)
+        throw parse_error_type{key, type, it->dump(1)};
+    return json_extract<T>(*it);
+}
+
+// Reads an optional field: a missing key or a wrong-typed value both yield nullopt (rather than
+// throwing) -- for advisory fields a caller should read leniently and skip when absent.
+template <typename T>
+std::optional<T> json_maybe(const nlohmann::json& j, std::string_view key) {
+    auto it = j.find(key);
+    if (it == j.end() || !json_is<T>(*it).first)
+        return std::nullopt;
+    return json_extract<T>(*it);
+}
+
+}  // namespace session::detail

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -267,13 +267,15 @@ namespace {
         result.account_expiry =
                 json_require<std::chrono::sys_seconds>(result_obj, "account_expiry_ts");
 
-        // The two values that qualify `account_expiry_ts`, required for the same reason it is: a
-        // client persists all three into config together, and a fresh expiry beside a stale grace
-        // or a stale renewing flag is worse than no refresh at all -- it computes a wrong
-        // coverage end, and reads a renewing subscription as terminal.
-        result.account_grace_period =
-                json_require<std::chrono::seconds>(result_obj, "account_grace_period_duration");
-        result.account_auto_renewing = json_require<bool>(result_obj, "account_auto_renewing");
+        // The two values that qualify `account_expiry_ts`. Absent -> keep the {0}/{false} default:
+        // the backend sends `0`/`false` whenever grace/renewal don't apply and omits them on a
+        // backend that predates them, so a missing field means "not applicable", never "keep the
+        // stale value". A present value must still be well-formed (a wrong type throws).
+        if (result_obj.contains("account_grace_period_duration"))
+            result.account_grace_period =
+                    json_require<std::chrono::seconds>(result_obj, "account_grace_period_duration");
+        if (result_obj.contains("account_auto_renewing"))
+            result.account_auto_renewing = json_require<bool>(result_obj, "account_auto_renewing");
     }
 }  // namespace
 
@@ -282,13 +284,23 @@ GenerateProProofResponse parse_pro_proof(std::string_view json) {
     auto result_obj = read_envelope(json, result);
     if (!result) {
         // On a subscription_expired failure the account's (now-past) true expiry rides top-level on
-        // the envelope (pro-wire-protocol.md §2.2 / §5.1) so the client can refresh its cached
-        // horizon / access expiry without a separate get_pro_status. Advisory -- read leniently
-        // (the envelope already parsed, so this re-parse can't throw).
+        // the envelope, alongside the same grace/renewal qualifiers as the success path
+        // (pro-wire-protocol.md §2.2 / §5.1), so the client can refresh all three without a
+        // separate get_pro_status. They must travel together: coverage ends at `account_expiry +
+        // grace`, and an expiry has typically NOT changed on this failure (it is a
+        // lapse/cancellation) while the grace and flag have -- refreshing only the expiry would
+        // leave a stale grace claiming coverage the backend has stopped honouring. Read leniently,
+        // absent -> {0}/{false} as on the success path (the envelope already parsed, so json_parse
+        // here can't throw).
         if (result.error_code == "subscription_expired") {
             auto j = json_parse(json);
             if (auto expiry = json_maybe<std::chrono::sys_seconds>(j, "account_expiry_ts"))
                 result.account_expiry = *expiry;
+            if (j.contains("account_grace_period_duration"))
+                result.account_grace_period =
+                        json_require<std::chrono::seconds>(j, "account_grace_period_duration");
+            if (j.contains("account_auto_renewing"))
+                result.account_auto_renewing = json_require<bool>(j, "account_auto_renewing");
         }
         return result;
     }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -15,59 +15,12 @@
 #include <session/types.hpp>
 #include <session/util.hpp>
 
+#include "json_parser.hpp"
 #include "pro_message.hpp"
 
 namespace {
 
-using session::pro_backend::parse_error;
-
-nlohmann::json json_parse(std::string_view json) {
-    try {
-        return nlohmann::json::parse(json);
-    } catch (const std::exception& e) {
-        throw parse_error{fmt::format("Invalid JSON received, parse failed: {}", e.what())};
-    }
-}
-
-template <typename T>
-T json_require(const nlohmann::json& j, std::string_view key) {
-    auto it = j.find(key);
-    if (it == j.end())
-        throw parse_error{fmt::format("Key '{}' is missing", key)};
-
-    bool success = false;
-    std::string_view type;
-    if constexpr (std::floating_point<T>) {
-        // An integer is a valid float value, so accept any JSON number: is_number_float() alone
-        // would wrongly reject an integer-valued number.
-        type = "a number";
-        success = it->is_number();
-    } else if constexpr (std::same_as<T, bool>) {
-        type = "a boolean";
-        success = it->is_boolean();
-    } else if constexpr (std::integral<T>) {
-        // is_number_integer() (not is_number()) so a fractional wire value is rejected rather than
-        // silently truncated by get_to. True for both signed and unsigned integer storage.
-        type = "an integer";
-        success = it->is_number_integer();
-    } else if constexpr (session::is_one_of<T, std::string, std::string_view>) {
-        type = "a string";
-        success = it->is_string();
-    } else if constexpr (std::same_as<T, nlohmann::json::array_t>) {
-        type = "an array";
-        success = it->is_array();
-    } else {
-        static_assert(std::same_as<T, nlohmann::json::object_t>);
-        type = "an object";
-        success = it->is_object();
-    }
-    if (!success)
-        throw parse_error{fmt::format("Key value ({}, {}) was not {}", key, it->dump(1), type)};
-
-    T result = {};
-    it->get_to<T>(result);
-    return result;
-}
+using namespace session::detail;
 
 // Fractional UNIX seconds (double) -> millisecond-precision system time, preserving the provider's
 // sub-second precision (rounded to the nearest millisecond).
@@ -89,15 +42,18 @@ void json_require_hex(const nlohmann::json& j, std::string_view key, std::span<u
 
     size_t hex_avail = dest.size() * 2;
     if (hex.size() != hex_avail)
-        throw parse_error{fmt::format(
-                "Hex -> bytes failed ({}, {}). {} hex chars capacity (requires {})",
+        throw session::parse_error_key{
                 key,
-                hex,
-                hex_avail,
-                hex.size())};
+                fmt::format(
+                        "Hex -> bytes failed ({}, {}). {} hex chars capacity (requires {})",
+                        key,
+                        hex,
+                        hex_avail,
+                        hex.size())};
 
     if (!oxenc::is_hex(hex))
-        throw parse_error{fmt::format("Key value string was not hex: '{}': '{}'", key, hex)};
+        throw session::parse_error_key{
+                key, fmt::format("Key value string was not hex: '{}': '{}'", key, hex)};
     oxenc::from_hex(hex.begin(), hex.end(), dest.begin());
 }
 };  // namespace
@@ -300,8 +256,7 @@ namespace {
     // proof) from the already-extracted `result` object.
     void fill_proof(const nlohmann::json::object_t& result_obj, GenerateProProofResponse& result) {
         result.proof.version = json_require<uint8_t>(result_obj, "version");
-        auto expiry_ts = json_require<int64_t>(result_obj, "expiry_ts");
-        result.proof.expiry_at = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
+        result.proof.expiry_at = json_require<std::chrono::sys_seconds>(result_obj, "expiry_ts");
         json_require_hex(result_obj, "revocation_tag", result.proof.revocation_tag);
         json_require_hex(result_obj, "rotating_pkey", result.proof.rotating_pubkey);
         json_require_hex(result_obj, "sig", result.proof.sig);
@@ -309,15 +264,15 @@ namespace {
         // Advisory and unsigned (pro-wire-protocol.md §2.2) -- never fed into signature
         // verification -- but required: a proof response without it can't refresh the cached access
         // expiry, which breaks renewal, so treat a missing value as a malformed response.
-        auto account_expiry_ts = json_require<int64_t>(result_obj, "account_expiry_ts");
-        result.account_expiry = std::chrono::sys_seconds(std::chrono::seconds(account_expiry_ts));
+        result.account_expiry =
+                json_require<std::chrono::sys_seconds>(result_obj, "account_expiry_ts");
 
         // The two values that qualify `account_expiry_ts`, required for the same reason it is: a
         // client persists all three into config together, and a fresh expiry beside a stale grace
         // or a stale renewing flag is worse than no refresh at all -- it computes a wrong
         // coverage end, and reads a renewing subscription as terminal.
-        result.account_grace_period = std::chrono::seconds(
-                json_require<int64_t>(result_obj, "account_grace_period_duration"));
+        result.account_grace_period =
+                json_require<std::chrono::seconds>(result_obj, "account_grace_period_duration");
         result.account_auto_renewing = json_require<bool>(result_obj, "account_auto_renewing");
     }
 }  // namespace
@@ -332,9 +287,8 @@ GenerateProProofResponse parse_pro_proof(std::string_view json) {
         // (the envelope already parsed, so this re-parse can't throw).
         if (result.error_code == "subscription_expired") {
             auto j = json_parse(json);
-            if (auto it = j.find("account_expiry_ts"); it != j.end() && it->is_number_integer())
-                result.account_expiry =
-                        std::chrono::sys_seconds(std::chrono::seconds(it->get<int64_t>()));
+            if (auto expiry = json_maybe<std::chrono::sys_seconds>(j, "account_expiry_ts"))
+                result.account_expiry = *expiry;
         }
         return result;
     }
@@ -420,8 +374,8 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
 
     // Parse payload
     result.ticket = json_require<int64_t>(result_obj, "ticket");
-    result.retry_in = std::chrono::seconds(json_require<int64_t>(result_obj, "retry_in"));
-    result.retain_for = std::chrono::seconds(json_require<int64_t>(result_obj, "retain_for"));
+    result.retry_in = json_require<std::chrono::seconds>(result_obj, "retry_in");
+    result.retain_for = json_require<std::chrono::seconds>(result_obj, "retain_for");
 
     // Clamp values against non-sensical/catastrophic values: retry_in of very small would result in
     // excess retries, and an overly long retry (e.g. 10 years) would make the client not properly
@@ -440,7 +394,7 @@ GetProRevocationsResponse parse_revocations(std::string_view json) {
 
         auto obj = it.get<nlohmann::json::object_t>();
         ProRevocationItem item = {};
-        item.effective_at = as_sys_seconds(json_require<int64_t>(obj, "effective_ts"));
+        item.effective_at = json_require<std::chrono::sys_seconds>(obj, "effective_ts");
         json_require_hex(obj, "revocation_tag", item.revocation_tag);
         result.items.emplace_back(std::move(item));
     }
@@ -538,9 +492,11 @@ namespace {
         // carrying sub-second precision (kept as millisecond-precision sys_ms). All other
         // timestamps are whole-second integers.
         auto purchased_ts = json_require<double>(obj, "purchased_ts");
-        auto expiry_ts = json_require<int64_t>(obj, "expiry_ts");
-        auto grace_period_duration = json_require<int64_t>(obj, "grace_period_duration");
-        auto platform_refund_expiry_ts = json_require<int64_t>(obj, "platform_refund_expiry_ts");
+        auto expiry_at = json_require<std::chrono::sys_seconds>(obj, "expiry_ts");
+        auto grace_period_duration =
+                json_require<std::chrono::seconds>(obj, "grace_period_duration");
+        auto platform_refund_expiry_at =
+                json_require<std::chrono::sys_seconds>(obj, "platform_refund_expiry_ts");
         auto revoked_ts = json_require<double>(obj, "revoked_ts");
 
         ProPaymentItem item = {};
@@ -550,10 +506,9 @@ namespace {
         item.payment_id = std::move(payment_id);
         item.auto_renewing = auto_renewing;
         item.purchased_at = sys_ms_from_seconds(purchased_ts);
-        item.expiry_at = std::chrono::sys_seconds(std::chrono::seconds(expiry_ts));
-        item.grace_period_duration = std::chrono::seconds(grace_period_duration);
-        item.platform_refund_expiry_at =
-                std::chrono::sys_seconds(std::chrono::seconds(platform_refund_expiry_ts));
+        item.expiry_at = expiry_at;
+        item.grace_period_duration = grace_period_duration;
+        item.platform_refund_expiry_at = platform_refund_expiry_at;
         item.revoked_at = sys_ms_from_seconds(revoked_ts);
         return item;
     }
@@ -592,21 +547,19 @@ ProStatusResponse parse_pro_status(std::string_view json) {
     // parse. (Wire key `user_status`, disambiguated from the envelope `status` -- spec §5.2.)
     result.user_status = json_require<std::string>(result_obj, "user_status");
     result.auto_renewing = json_require<bool>(result_obj, "auto_renewing");
-    result.expiry_at = std::chrono::sys_seconds(
-            std::chrono::seconds(json_require<int64_t>(result_obj, "expiry_ts")));
+    result.expiry_at = json_require<std::chrono::sys_seconds>(result_obj, "expiry_ts");
     result.grace_period_duration =
-            std::chrono::seconds(json_require<int64_t>(result_obj, "grace_period_duration"));
+            json_require<std::chrono::seconds>(result_obj, "grace_period_duration");
 
     // `latest_payment` is a single payment item, or null when the account has no payments.
     if (auto it = result_obj.find("latest_payment"); it == result_obj.end())
-        throw parse_error{"Key 'latest_payment' is missing"};
+        throw parse_error_missing{"latest_payment"};
     else if (it->second.is_null()) {
         // No payments: latest_payment stays std::nullopt.
     } else if (it->second.is_object())
         result.latest_payment = parse_payment_item(it->second.get<nlohmann::json::object_t>());
     else
-        throw parse_error{fmt::format(
-                "Key value (latest_payment, {}) was not an object or null", it->second.dump(1))};
+        throw parse_error_type{"latest_payment", "an object or null", it->second.dump(1)};
 
     return result;
 }
@@ -631,14 +584,13 @@ PaymentDetailsResponse parse_payment_details(std::string_view json) {
 
     // `next_cursor` is the opaque keyset cursor (§5.3), or null at end-of-data.
     if (auto it = result_obj.find("next_cursor"); it == result_obj.end())
-        throw parse_error{"Key 'next_cursor' is missing"};
+        throw parse_error_missing{"next_cursor"};
     else if (it->second.is_null()) {
         // End of data: next_cursor stays std::nullopt.
     } else if (it->second.is_string())
         result.next_cursor = it->second.get<std::string>();
     else
-        throw parse_error{fmt::format(
-                "Key value (next_cursor, {}) was not a string or null", it->second.dump(1))};
+        throw parse_error_type{"next_cursor", "a string or null", it->second.dump(1)};
 
     return result;
 }

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -311,6 +311,14 @@ namespace {
         // expiry, which breaks renewal, so treat a missing value as a malformed response.
         auto account_expiry_ts = json_require<int64_t>(result_obj, "account_expiry_ts");
         result.account_expiry = std::chrono::sys_seconds(std::chrono::seconds(account_expiry_ts));
+
+        // The two values that qualify `account_expiry_ts`, required for the same reason it is: a
+        // client persists all three into config together, and a fresh expiry beside a stale grace
+        // or a stale renewing flag is worse than no refresh at all -- it computes a wrong
+        // paid-through instant, and reads a renewing subscription as terminal.
+        result.account_grace_period = std::chrono::seconds(
+                json_require<int64_t>(result_obj, "account_grace_period_duration"));
+        result.account_auto_renewing = json_require<bool>(result_obj, "account_auto_renewing");
     }
 }  // namespace
 
@@ -860,6 +868,8 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
         std::memcpy(result.proof.sig.data, p.sig.data(), p.sig.size());
         result.account_expiry_ts =
                 owned->account_expiry ? session::epoch_seconds(*owned->account_expiry) : 0;
+        result.account_grace_period_duration = owned->account_grace_period.count();
+        result.account_auto_renewing = owned->account_auto_renewing;
         // All C fields aliased into *owned; hand ownership to the response (freed by *_free).
         result.header.internal_ = owned.release();
     } catch (const std::exception& e) {

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -315,7 +315,7 @@ namespace {
         // The two values that qualify `account_expiry_ts`, required for the same reason it is: a
         // client persists all three into config together, and a fresh expiry beside a stale grace
         // or a stale renewing flag is worse than no refresh at all -- it computes a wrong
-        // paid-through instant, and reads a renewing subscription as terminal.
+        // coverage end, and reads a renewing subscription as terminal.
         result.account_grace_period = std::chrono::seconds(
                 json_require<int64_t>(result_obj, "account_grace_period_duration"));
         result.account_auto_renewing = json_require<bool>(result_obj, "account_auto_renewing");

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -682,21 +682,21 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     profile.set_pro_auto_renewing(false);
     CHECK_FALSE(profile.get_pro_auto_renewing());
 
-    // Grace period: synced so any device can derive the paid-through instant as `E - G`. The
-    // backend folds grace INTO the stored expiry for auto-renewing subscriptions, so `E` is the end
-    // of coverage rather than the renewal-due date -- deriving that is the whole reason this key
-    // exists.
+    // Grace period: synced so any device can compute when coverage actually ends, at `E + G`. `E`
+    // is the payment-due date -- the instant the term was paid through -- and `G` is how much
+    // longer the backend keeps serving past it (the store's dunning window plus its renewal-latency
+    // allowance). Carrying `G` is the whole reason this key exists: `E` alone cannot answer it.
     CHECK(profile.get_pro_grace_period() == 0s);
     UserProfileTester::set_profile_updated(profile, std::chrono::sys_seconds{456s});
     profile.set_pro_grace_period(1h);
     CHECK(profile.get_pro_grace_period() == 1h);
     // Backend-derived, like E/I/R/A: no profile-updated bump.
     CHECK(profile.get_profile_updated().time_since_epoch().count() == 456);
-    // The property the key exists for: coverage end minus grace is the paid-through instant.
+    // The property the key exists for: expiry plus grace is the instant coverage ends.
     profile.set_pro_access_expiry(std::chrono::sys_seconds{5000s});
-    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
-          std::chrono::sys_seconds{5000s} - 1h);
-    // Zero clears; unset and zero are indistinguishable *and* equivalent (`E - 0 == E`).
+    CHECK(*profile.get_pro_access_expiry() + profile.get_pro_grace_period() ==
+          std::chrono::sys_seconds{5000s} + 1h);
+    // Zero clears; unset and zero are indistinguishable *and* equivalent (coverage ends at `E`).
     profile.set_pro_grace_period(0s);
     CHECK(profile.get_pro_grace_period() == 0s);
     CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
@@ -714,7 +714,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     CHECK(profile.get_pro_grace_period() == 0s);
     CHECK_FALSE(profile.get_pro_access_expiry().has_value());
 
-    // Clearing `E` also clears `G`: the pair is only meaningful as `E - G`, so a `G` that outlived
+    // Clearing `E` also clears `G`: the pair is only meaningful as `E + G`, so a `G` that outlived
     // its `E` would silently pair with the NEXT `E` write -- and that write is typically a proof
     // outcome, which carries no grace to correct it with. Enforced in the setter, not at call
     // sites.

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -699,7 +699,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     // Zero clears; unset and zero are indistinguishable *and* equivalent (coverage ends at `E`).
     profile.set_pro_grace_period(0s);
     CHECK(profile.get_pro_grace_period() == 0s);
-    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
+    CHECK(*profile.get_pro_access_expiry() + profile.get_pro_grace_period() ==
           std::chrono::sys_seconds{5000s});
 
     // Clearing `E` clears the renewing flag with it, for the same reason it clears `G`: `A`
@@ -725,7 +725,7 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     CHECK(profile.get_pro_grace_period() == 0s);
     // ...and a later `E` write therefore cannot inherit the stale grace.
     profile.set_pro_access_expiry(std::chrono::sys_seconds{9000s});
-    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
+    CHECK(*profile.get_pro_access_expiry() + profile.get_pro_grace_period() ==
           std::chrono::sys_seconds{9000s});
 
     // Refund-requested flag (synced via config, not the Pro backend)

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -702,6 +702,18 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
           std::chrono::sys_seconds{5000s});
 
+    // Clearing `E` clears the renewing flag with it, for the same reason it clears `G`: `A`
+    // describes the subscription `E` denotes, and a renewing flag with no expiry beside it
+    // describes a subscription that is not there. Pinned because the alternative -- every consumer
+    // testing `E` before reading `A` -- is a convention nothing enforces.
+    profile.set_pro_auto_renewing(true);
+    profile.set_pro_access_expiry(std::chrono::sys_seconds{9000s});
+    CHECK(profile.get_pro_auto_renewing());
+    profile.set_pro_access_expiry(std::nullopt);
+    CHECK_FALSE(profile.get_pro_auto_renewing());
+    CHECK(profile.get_pro_grace_period() == 0s);
+    CHECK_FALSE(profile.get_pro_access_expiry().has_value());
+
     // Clearing `E` also clears `G`: the pair is only meaningful as `E - G`, so a `G` that outlived
     // its `E` would silently pair with the NEXT `E` write -- and that write is typically a proof
     // outcome, which carries no grace to correct it with. Enforced in the setter, not at call

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -342,6 +342,18 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     CHECK(user_profile_get_pro_auto_renewing(conf2) == 1);
     user_profile_set_pro_auto_renewing(conf2, 0);
     CHECK(user_profile_get_pro_auto_renewing(conf2) == 0);
+
+    CHECK(user_profile_get_pro_grace_period(conf2) == 0);
+    user_profile_set_pro_grace_period(conf2, 3600);
+    CHECK(user_profile_get_pro_grace_period(conf2) == 3600);
+    // Zero erases and reads back as 0 -- unset and zero are the same account state here, which is
+    // why there is deliberately no presence check to go with it.
+    user_profile_set_pro_grace_period(conf2, 0);
+    CHECK(user_profile_get_pro_grace_period(conf2) == 0);
+    // Negative clears rather than storing a negative duration.
+    user_profile_set_pro_grace_period(conf2, -5);
+    CHECK(user_profile_get_pro_grace_period(conf2) == 0);
+
     UserProfileTester::set_profile_updated(conf2, std::chrono::sys_seconds{124s});
 
     // Both have changes, so push need a push
@@ -669,6 +681,40 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     CHECK(profile.get_profile_updated().time_since_epoch().count() == 456);
     profile.set_pro_auto_renewing(false);
     CHECK_FALSE(profile.get_pro_auto_renewing());
+
+    // Grace period: synced so any device can derive the paid-through instant as `E - G`. The
+    // backend folds grace INTO the stored expiry for auto-renewing subscriptions, so `E` is the end
+    // of coverage rather than the renewal-due date -- deriving that is the whole reason this key
+    // exists.
+    CHECK(profile.get_pro_grace_period() == 0s);
+    UserProfileTester::set_profile_updated(profile, std::chrono::sys_seconds{456s});
+    profile.set_pro_grace_period(1h);
+    CHECK(profile.get_pro_grace_period() == 1h);
+    // Backend-derived, like E/I/R/A: no profile-updated bump.
+    CHECK(profile.get_profile_updated().time_since_epoch().count() == 456);
+    // The property the key exists for: coverage end minus grace is the paid-through instant.
+    profile.set_pro_access_expiry(std::chrono::sys_seconds{5000s});
+    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
+          std::chrono::sys_seconds{5000s} - 1h);
+    // Zero clears; unset and zero are indistinguishable *and* equivalent (`E - 0 == E`).
+    profile.set_pro_grace_period(0s);
+    CHECK(profile.get_pro_grace_period() == 0s);
+    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
+          std::chrono::sys_seconds{5000s});
+
+    // Clearing `E` also clears `G`: the pair is only meaningful as `E - G`, so a `G` that outlived
+    // its `E` would silently pair with the NEXT `E` write -- and that write is typically a proof
+    // outcome, which carries no grace to correct it with. Enforced in the setter, not at call
+    // sites.
+    profile.set_pro_grace_period(1h);
+    CHECK(profile.get_pro_grace_period() == 1h);
+    profile.set_pro_access_expiry(std::nullopt);
+    CHECK_FALSE(profile.get_pro_access_expiry().has_value());
+    CHECK(profile.get_pro_grace_period() == 0s);
+    // ...and a later `E` write therefore cannot inherit the stale grace.
+    profile.set_pro_access_expiry(std::chrono::sys_seconds{9000s});
+    CHECK(*profile.get_pro_access_expiry() - profile.get_pro_grace_period() ==
+          std::chrono::sys_seconds{9000s});
 
     // Refund-requested flag (synced via config, not the Pro backend)
     CHECK_FALSE(profile.get_refund_requested().has_value());

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -336,6 +336,12 @@ TEST_CASE("user profile C API", "[config][user_profile][c]") {
     CHECK(user_profile_get_blinded_msgreqs(conf2) == -1);
     user_profile_set_blinded_msgreqs(conf2, 1);
     CHECK(user_profile_get_blinded_msgreqs(conf2) == 1);
+
+    CHECK(user_profile_get_pro_auto_renewing(conf2) == 0);
+    user_profile_set_pro_auto_renewing(conf2, 1);
+    CHECK(user_profile_get_pro_auto_renewing(conf2) == 1);
+    user_profile_set_pro_auto_renewing(conf2, 0);
+    CHECK(user_profile_get_pro_auto_renewing(conf2) == 0);
     UserProfileTester::set_profile_updated(conf2, std::chrono::sys_seconds{124s});
 
     // Both have changes, so push need a push
@@ -653,6 +659,16 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     auto access_expiry = std::chrono::sys_seconds{std::chrono::seconds{500}};
     profile.set_pro_access_expiry(access_expiry);
     CHECK(profile.get_pro_access_expiry() == access_expiry);
+
+    // Pro auto-renewing flag: presence-only, defaults to false, and (backend-derived state, not a
+    // user edit) does not stamp the profile-updated timestamp.
+    CHECK_FALSE(profile.get_pro_auto_renewing());
+    UserProfileTester::set_profile_updated(profile, std::chrono::sys_seconds{456s});
+    profile.set_pro_auto_renewing(true);
+    CHECK(profile.get_pro_auto_renewing());
+    CHECK(profile.get_profile_updated().time_since_epoch().count() == 456);
+    profile.set_pro_auto_renewing(false);
+    CHECK_FALSE(profile.get_pro_auto_renewing());
 
     // Refund-requested flag (synced via config, not the Pro backend)
     CHECK_FALSE(profile.get_refund_requested().has_value());

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -211,7 +211,7 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 // Required on success: a proof response missing it is treated as malformed.
                 nlohmann::json j_no_ae = j;
                 j_no_ae["result"].erase("account_expiry_ts");
-                REQUIRE_THROWS_AS(parse_pro_proof(j_no_ae.dump()), parse_error);
+                REQUIRE_THROWS_AS(parse_pro_proof(j_no_ae.dump()), session::parse_error_missing);
 
                 // The two fields that QUALIFY account_expiry_ts: both surface through the C and
                 // C++ parses, and `E + G` is the instant coverage ends.
@@ -229,14 +229,15 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 for (const auto* key : {"account_grace_period_duration", "account_auto_renewing"}) {
                     nlohmann::json j_missing = j;
                     j_missing["result"].erase(key);
-                    REQUIRE_THROWS_AS(parse_pro_proof(j_missing.dump()), parse_error);
+                    REQUIRE_THROWS_AS(
+                            parse_pro_proof(j_missing.dump()), session::parse_error_missing);
                 }
 
                 // A wrong type is malformed for the same reason: a silently defaulted flag would be
                 // written to config as an explicit false, and there a false ERASES the key.
                 nlohmann::json j_bad = j;
                 j_bad["result"]["account_auto_renewing"] = 1;  // int, not bool
-                REQUIRE_THROWS_AS(parse_pro_proof(j_bad.dump()), parse_error);
+                REQUIRE_THROWS_AS(parse_pro_proof(j_bad.dump()), session::parse_error_type);
 
                 // The non-auto-renewing account: a genuine zero grace, and `E - 0 == E`.
                 nlohmann::json j_false = j;

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -214,12 +214,12 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE_THROWS_AS(parse_pro_proof(j_no_ae.dump()), parse_error);
 
                 // The two fields that QUALIFY account_expiry_ts: both surface through the C and
-                // C++ parses, and `E - G` recovers the paid-through instant.
+                // C++ parses, and `E + G` is the instant coverage ends.
                 REQUIRE(result_cpp.account_grace_period.count() == 14 * 24 * 3600);
                 REQUIRE(result_cpp.account_auto_renewing);
-                REQUIRE((*result_cpp.account_expiry - result_cpp.account_grace_period)
+                REQUIRE((*result_cpp.account_expiry + result_cpp.account_grace_period)
                                 .time_since_epoch()
-                                .count() == unix_ts + 90 * 24 * 3600 - 14 * 24 * 3600);
+                                .count() == unix_ts + 90 * 24 * 3600 + 14 * 24 * 3600);
                 REQUIRE(result.account_grace_period_duration == 14 * 24 * 3600);
                 REQUIRE(result.account_auto_renewing);
 

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -148,7 +148,9 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     {"revocation_tag", oxenc::to_hex(fake_revocation_tag)},
                     {"rotating_pkey", oxenc::to_hex(rotating_pubkey.data)},
                     {"sig", oxenc::to_hex(master_privkey.data)},
-                    {"account_expiry_ts", unix_ts + 90 * 24 * 3600}};
+                    {"account_expiry_ts", unix_ts + 90 * 24 * 3600},
+                    {"account_grace_period_duration", 14 * 24 * 3600},
+                    {"account_auto_renewing", true}};
             std::string json = j.dump();
 
             // Valid JSON
@@ -211,6 +213,39 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 j_no_ae["result"].erase("account_expiry_ts");
                 REQUIRE_THROWS_AS(parse_pro_proof(j_no_ae.dump()), parse_error);
 
+                // The two fields that QUALIFY account_expiry_ts: both surface through the C and
+                // C++ parses, and `E - G` recovers the paid-through instant.
+                REQUIRE(result_cpp.account_grace_period.count() == 14 * 24 * 3600);
+                REQUIRE(result_cpp.account_auto_renewing);
+                REQUIRE((*result_cpp.account_expiry - result_cpp.account_grace_period)
+                                .time_since_epoch()
+                                .count() == unix_ts + 90 * 24 * 3600 - 14 * 24 * 3600);
+                REQUIRE(result.account_grace_period_duration == 14 * 24 * 3600);
+                REQUIRE(result.account_auto_renewing);
+
+                // Required on success, exactly like account_expiry_ts: a proof that cannot be
+                // paired with the values qualifying its expiry is malformed, rather than handing
+                // the client a fresh expiry beside a defaulted grace/flag it would then persist.
+                for (const auto* key : {"account_grace_period_duration", "account_auto_renewing"}) {
+                    nlohmann::json j_missing = j;
+                    j_missing["result"].erase(key);
+                    REQUIRE_THROWS_AS(parse_pro_proof(j_missing.dump()), parse_error);
+                }
+
+                // A wrong type is malformed for the same reason: a silently defaulted flag would be
+                // written to config as an explicit false, and there a false ERASES the key.
+                nlohmann::json j_bad = j;
+                j_bad["result"]["account_auto_renewing"] = 1;  // int, not bool
+                REQUIRE_THROWS_AS(parse_pro_proof(j_bad.dump()), parse_error);
+
+                // The non-auto-renewing account: a genuine zero grace, and `E - 0 == E`.
+                nlohmann::json j_false = j;
+                j_false["result"]["account_grace_period_duration"] = 0;
+                j_false["result"]["account_auto_renewing"] = false;
+                auto f_cpp = parse_pro_proof(j_false.dump());
+                REQUIRE_FALSE(f_cpp.account_auto_renewing);
+                REQUIRE(f_cpp.account_grace_period.count() == 0);
+
                 // It also rides a subscription_expired failure (top-level, now-past value) so the
                 // client can refresh its cached horizon without a separate status call.
                 nlohmann::json j_exp;
@@ -222,6 +257,24 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(exp.error_code == "subscription_expired");
                 REQUIRE(exp.account_expiry.has_value());
                 REQUIRE(exp.account_expiry->time_since_epoch().count() == unix_ts - 24 * 3600);
+
+                // 🔴 The failure path leaves BOTH qualifying fields at their struct defaults, and
+                // nothing in the type says so. `not_subscribed` here, but the same holds for a
+                // protocol error or a `stale_request` -- outcomes that say nothing about the
+                // account. A caller that reads them outside the success branch gets a plain
+                // 0/false, and writing that false to the presence-only config key ERASES a flag
+                // learned from get_pro_status. Pinned so the hazard is executable, not just
+                // documented: the protection here is SCOPE, not the type.
+                {
+                    nlohmann::json j_fail;
+                    j_fail["status"] = "fail";
+                    j_fail["error_code"] = "not_subscribed";
+                    j_fail["error"] = "no";
+                    auto fail = parse_pro_proof(j_fail.dump());
+                    REQUIRE_FALSE(static_cast<bool>(fail));
+                    REQUIRE(fail.account_grace_period.count() == 0);  // default, NOT "no grace"
+                    REQUIRE_FALSE(fail.account_auto_renewing);        // default, NOT "not renewing"
+                }
 
                 // Other failures (e.g. not_subscribed) carry no horizon.
                 nlohmann::json j_ns;

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -223,23 +223,35 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE(result.account_grace_period_duration == 14 * 24 * 3600);
                 REQUIRE(result.account_auto_renewing);
 
-                // Required on success, exactly like account_expiry_ts: a proof that cannot be
-                // paired with the values qualifying its expiry is malformed, rather than handing
-                // the client a fresh expiry beside a defaulted grace/flag it would then persist.
-                for (const auto* key : {"account_grace_period_duration", "account_auto_renewing"}) {
-                    nlohmann::json j_missing = j;
-                    j_missing["result"].erase(key);
-                    REQUIRE_THROWS_AS(
-                            parse_pro_proof(j_missing.dump()), session::parse_error_missing);
+                // Absent -> not applicable, defaulting to 0/false: never a throw, and never
+                // preserving a stale value. The backend omits these when grace/renewal don't apply,
+                // and a client refreshes all three together, so absence clears the cached
+                // grace/flag rather than keeping it. A present value is parsed; the other,
+                // still-present one is untouched.
+                {
+                    nlohmann::json j_no_grace = j;
+                    j_no_grace["result"].erase("account_grace_period_duration");
+                    auto m = parse_pro_proof(j_no_grace.dump());
+                    REQUIRE(static_cast<bool>(m));
+                    REQUIRE(m.account_grace_period.count() == 0);
+                    REQUIRE(m.account_auto_renewing);
+
+                    nlohmann::json j_no_renew = j;
+                    j_no_renew["result"].erase("account_auto_renewing");
+                    m = parse_pro_proof(j_no_renew.dump());
+                    REQUIRE(static_cast<bool>(m));
+                    REQUIRE_FALSE(m.account_auto_renewing);
+                    REQUIRE(m.account_grace_period.count() == 14 * 24 * 3600);
                 }
 
-                // A wrong type is malformed for the same reason: a silently defaulted flag would be
-                // written to config as an explicit false, and there a false ERASES the key.
+                // A *present* value must still be well-formed: a wrong-typed field is a backend
+                // bug, not "not applicable", so it is a hard parse error rather than a silent
+                // default.
                 nlohmann::json j_bad = j;
                 j_bad["result"]["account_auto_renewing"] = 1;  // int, not bool
                 REQUIRE_THROWS_AS(parse_pro_proof(j_bad.dump()), session::parse_error_type);
 
-                // The non-auto-renewing account: a genuine zero grace, and `E - 0 == E`.
+                // The non-auto-renewing account: a genuine zero grace, and `E + 0 == E`.
                 nlohmann::json j_false = j;
                 j_false["result"]["account_grace_period_duration"] = 0;
                 j_false["result"]["account_auto_renewing"] = false;
@@ -247,25 +259,30 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 REQUIRE_FALSE(f_cpp.account_auto_renewing);
                 REQUIRE(f_cpp.account_grace_period.count() == 0);
 
-                // It also rides a subscription_expired failure (top-level, now-past value) so the
-                // client can refresh its cached horizon without a separate status call.
+                // It also rides a subscription_expired failure, carrying the same three account
+                // fields so the client refreshes all of them without a separate status call. A
+                // lapse can still be auto-renewing: the store keeps retrying the renewal past the
+                // grace window, so subscription_expired does NOT imply grace 0 / not-renewing --
+                // the parser must surface whatever the backend sent, never assume defaults.
                 nlohmann::json j_exp;
                 j_exp["status"] = "fail";
                 j_exp["error_code"] = "subscription_expired";
                 j_exp["error"] = "expired";
                 j_exp["account_expiry_ts"] = unix_ts - 24 * 3600;
+                j_exp["account_grace_period_duration"] = 14 * 24 * 3600;
+                j_exp["account_auto_renewing"] = true;
                 auto exp = parse_pro_proof(j_exp.dump());
                 REQUIRE(exp.error_code == "subscription_expired");
                 REQUIRE(exp.account_expiry.has_value());
                 REQUIRE(exp.account_expiry->time_since_epoch().count() == unix_ts - 24 * 3600);
+                REQUIRE(exp.account_grace_period.count() == 14 * 24 * 3600);
+                REQUIRE(exp.account_auto_renewing);
 
-                // 🔴 The failure path leaves BOTH qualifying fields at their struct defaults, and
-                // nothing in the type says so. `not_subscribed` here, but the same holds for a
-                // protocol error or a `stale_request` -- outcomes that say nothing about the
-                // account. A caller that reads them outside the success branch gets a plain
-                // 0/false, and writing that false to the presence-only config key ERASES a flag
-                // learned from get_pro_status. Pinned so the hazard is executable, not just
-                // documented: the protection here is SCOPE, not the type.
+                // An account-less failure (not_subscribed here; likewise revoked,
+                // protocol/transport errors) carries none of the three, so grace/renewal read as
+                // their truthful "not applicable" defaults of 0 / false -- always definite and safe
+                // to read, so a client refreshing config from them clears a stale grace/flag rather
+                // than being told to preserve one.
                 {
                     nlohmann::json j_fail;
                     j_fail["status"] = "fail";
@@ -273,8 +290,8 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                     j_fail["error"] = "no";
                     auto fail = parse_pro_proof(j_fail.dump());
                     REQUIRE_FALSE(static_cast<bool>(fail));
-                    REQUIRE(fail.account_grace_period.count() == 0);  // default, NOT "no grace"
-                    REQUIRE_FALSE(fail.account_auto_renewing);        // default, NOT "not renewing"
+                    REQUIRE(fail.account_grace_period.count() == 0);
+                    REQUIRE_FALSE(fail.account_auto_renewing);
                 }
 
                 // Other failures (e.g. not_subscribed) carry no horizon.


### PR DESCRIPTION
# user_profile: add the pro grace period (config key `G`)

> ⚠️ **This PR is opened against `dev`, so its diff includes #121.** The first of the seven commits shown,
> `8e5634b8` *"user_profile: add pro auto-renewing status (config key `A`)"*, is **jagerman's, from
> [#121](https://github.com/session-foundation/libsession-util/pull/121)** — not mine, and not under review
> here. **Only the six below it are.** If #121 merges first this PR's diff shrinks to exactly those six.

**Built on:** `jagerman/pro-auto-renewing-config` @ `8e5634b8` — the head of **#121**, *not* the
`-pfs` variant (identical commit subject, different sha, sits on the PFS track).
**Branch:** `feature/pro-auto-renewing-tristate` · **Commits:** `269f8b88`, `f197a0bd`, `b066ba27`,
`1e8b521f`, `54e246b2`, `de208ff1` · 8 files, +332 −41 *(derived from
`git diff --shortstat 8e5634b8..HEAD`, not computed)*

> **Three code commits.** `269f8b88` adds the `G` config key (`user_profile`). `f197a0bd` makes
> `parse_pro_proof` read `account_grace_period_duration` and `account_auto_renewing` off the proof
> response (`pro_backend`). `b066ba27` clears `A` alongside `E` and `G` (§7) — without it the backend
> fields those describe are unreachable by any client, which is how they shipped and sat unnoticed for
> three days. See §6.
>
> **Three documentation commits, and they matter more than their size suggests.** `1e8b521f` and
> `54e246b2` correct the expiry/grace model throughout the headers; `de208ff1` fixes a sign typo left in
> the corrected prose. The original wording said the backend *folds grace into the stored expiry*, so a
> reader should derive the paid-through instant as **`E − G`**. **That is backwards.** `E` is the
> payment-due date, `G` is how much longer service continues, and coverage ends at **`E + G`** — the
> model the backend has used since it changed on 2026-08-03, seven days before the `G` key landed here
> carrying the pre-flip wording.
>
> This was found by an independent reviewer reading the **pushed** branch, and it is the single
> highest-value change in the PR: three client teams had already implemented against the old wording and
> corrected themselves. Anyone reading the header next — a glue layer, a fourth client, or someone
> "fixing" a client to match core — would have put coverage a full grace period early.

> The branch name predates a revision that removed the auto-renewing accessors (see *What this PR no
> longer contains*). Kept as-is because it already has an open draft PR against it.

Completes the config side of #121 against the Pro status-refresh spec, which asks for **both**
`auto_renewing` **and** `grace` to be synced alongside `E`. #121 ships `auto_renewing`; this adds
the grace period.

---

## The key

```cpp
std::chrono::seconds UserProfile::get_pro_grace_period() const;
void                 UserProfile::set_pro_grace_period(std::chrono::seconds);

int64_t user_profile_get_pro_grace_period(const config_object*);   // seconds, 0 if unset
void    user_profile_set_pro_grace_period(config_object*, int64_t);
```

**Why it is needed rather than merely nice.** `E` is the account's **payment-due date** — the instant
the term was paid through — and entitlement continues past it for the store's dunning window plus the
backend's renewal-latency allowance. `get_pro_status` reports that span as `grace_period_duration`, and
judges `user_status` against `expiry_at + grace_period_duration` (`server.py:327`, `backend.py:512`).

So **coverage ends at `E + G`, and `E` alone cannot answer when.** With `G` synced, any device computes
it. Without it, a config-only consumer — notably each client's `user_expiry` wake, which must fire at
coverage end — has no way to reach that instant.

**No companion presence check, deliberately.** The backend sends `0` whenever the subscription is not
auto-renewing, so "unset" and "zero" describe the same account and both give `E − 0 == E`. There is
no state a caller could act on differently, so there is nothing for a presence check to disambiguate.

**Clearing `E` clears `G`.** A grace that outlived its expiry would pair with whatever wrote `E` next.
`set_pro_access_expiry` already clears `I` and `R` as side effects, so this follows the existing shape
rather than introducing one.

## Testing

`All tests passed (25755864 assertions in 128 test cases)`, and specifically:

- The assertion **count moved** on the addition (…856 → …864), which is this repo's own guard against
  a stale `testAll` binary reporting a previous build's result.
- `user_profile_{get,set}_pro_grace_period` verified **in the built artefact** (`libsession-config.a`)
  alongside the shipping control symbol `user_profile_get_pro_access_expiry`, not inferred from a
  green compile.
- **Rebuilt and re-run after `clang-format`** — a green run taken before the format pass would have
  been a stale-binary claim.
- `CLANG_FORMAT_DESIRED_VERSION=19 ./utils/format.sh`; the diff touches nothing unrelated.

Tests pin that a zero or negative grace erases rather than storing, and that clearing `E` prevents a
later `E` write from inheriting a stale grace.

## Known limitation

**`E + G` is only coherent if `E` and `G` are written from the same response.** The
`generate_pro_proof` response carries `account_expiry_ts`, so a proof outcome writes `E`. A companion
backend change adds `account_grace_period_duration` (and `account_auto_renewing`) to that response —
`Session-Pro-Backend`, `feature/proof-response-carries-grace`. **Without it, `G` is a strict
improvement over having nothing but is not reliable across a proof-then-grace-transition sequence.**
The clear-pairing above is insurance; the backend field is the fix.

## Why there is no presence check on `A`

A predicate telling an unset `auto_renewing` flag from a stored `false` cannot work under the
presence-only encoding: `set_nonzero_int` erases on false, so `A` is present **if and only if** its
value is 1, and any such predicate returns the same bit as the plain getter in every reachable state.
Making the distinction real would mean storing `0` rather than erasing — a change to this key's
encoding and to a convention used across the config types (`+` priority, `y` legacy_blinding,
`e` pro_expiry).

The client-side need is met instead by the proof response carrying `auto_renewing`, so every writer of
`E` writes `A` too.

## Relationship to the client work

Three client PRs (Android/Desktop/iOS Pro status-refresh unification) list this as a **conditional**
dependency: all three read `get_pro_auto_renewing()` and `get_pro_access_expiry()`, which this PR
leaves unchanged, so all three compile and behave correctly without it. It becomes a hard dependency
once a client needs the coverage-end instant — the `user_expiry` wake and the grace indicator both do.

Per-platform glue cost: Android a JNI pair, Desktop ~6 lines in its `pro-auto-renewing-glue` branch
(already open and already exposing `G`), iOS **free** — its module map is generated by globbing the
header tree, so a new `LIBSESSION_EXPORT` is visible to Swift immediately.

---

## 6. Second commit — `f197a0bd`: parse the two fields off the proof response

**4 files, +72.** `pro_backend`, not `user_profile` — a separate subsystem, reviewable separately.

`generate_pro_proof` returns `account_expiry_ts` so a proof fetch can refresh the client's cached access
expiry. The backend also sends the two values that **qualify** it — `account_grace_period_duration` and
`account_auto_renewing` — and `parse_pro_proof` read neither, so no client could reach them.

That mattered because clients persist the account expiry into synced config from this response as well as
from `get_pro_status`. Without the companions, a proof fetch wrote a fresh expiry beside a stale grace and
a stale renewing flag. The flag is the sharp end: config stores it **presence-only**, so an account whose
expiry has only ever been written by a proof reads back as terminal while it renews.

```cpp
std::chrono::seconds account_grace_period{0};
bool                 account_auto_renewing{false};
```

**Both required on a successful proof, exactly like `account_expiry_ts`.** A response that cannot be
paired with the values qualifying its expiry is treated as malformed, rather than handing the caller a
fresh expiry beside a defaulted grace and flag it would then persist — and a defaulted `false` is not
inert, because writing `false` to the config key **erases** it. Zero/false on the failure outcomes that
carry no proof, which is also the truthful value for `subscription_expired` / `not_subscribed` /
`revoked`.

> *Required rather than optional-with-a-default deliberately: no backend predates these fields, so
> there is no "the backend did not say" case to represent, and required parsing is both simpler and
> safer than an optional a caller could collapse to `false` — which would erase the config key rather
> than leave it alone.*

Tests cover the pair round-tripping through the C and C++ parses with `E + G` giving the coverage end,
each field missing being a parse error, a wrong-typed flag being a parse error, and the
non-auto-renewing account's genuine zero.

`All tests passed (25755877 assertions in 128 test cases)`, rebuilt and re-run after `clang-format`. The
assertion count is checked to have moved on each addition — this repo's own guard against a stale `testAll`
binary reporting a previous build's result.

---

## 7. Third commit — `b066ba27`: clear the renewing flag with the expiry it describes

**2 files, +23.** `user_profile`. **Deliberately separate, because it changes the lifecycle of `A`, which
is #121's key rather than mine** — take or drop it independently of the `G` work.

`set_pro_access_expiry(nullopt)` already cleared `G`: a grace is only meaningful as `E + G`, so it must not
outlive its expiry. `A` has the same relationship and was not being cleared, so a revoked or lapsed
subscription kept a renewing flag describing a subscription that is not there.

Every caller that clears `E` is handling an account with no entitlement — a proof cleared, a proof revoked,
or a non-positive `expiry_ts` — and none of those is auto-renewing.

**The reason it is worth doing rather than documenting:** without it the three keys are coherent only
because every *consumer* happens to test `E` before reading `A`. That was true on all three clients and
**nothing enforced it** — each had arrived there independently, and a new consumer would inherit the
obligation without knowing it had one. 
