### PR TITLE
multi_encrypt: match padding entries to ciphertext size

### DIFF
--- a/src/multi_encrypt.cpp
+++ b/src/multi_encrypt.cpp
@@ -163,11 +163,11 @@ std::vector<unsigned char> encrypt_for_multiple_simple(
                     msg_count++;
                 });
 
-        if (int pad_size = pad > 1 && !messages.empty() ? messages.front().size() : 0) {
-            std::vector<unsigned char> junk;
-            junk.resize(pad_size);
+        if (pad > 1 && !messages.empty()) {
+            const auto pad_size = messages.front().size() + encrypt_multiple_message_overhead;
+            std::vector<unsigned char> junk(pad_size);
             for (; msg_count % pad != 0; msg_count++) {
-                randombytes_buf(junk.data(), pad_size);
+                randombytes_buf(junk.data(), junk.size());
                 enc_list.append(to_string(junk));
             }
         }

--- a/tests/test_multi_encrypt.cpp
+++ b/tests/test_multi_encrypt.cpp
@@ -1,4 +1,5 @@
 #include <fmt/core.h>
+#include <oxenc/bt_serialize.h>
 #include <sodium/crypto_aead_xchacha20poly1305.h>
 #include <sodium/crypto_sign_ed25519.h>
 
@@ -246,6 +247,61 @@ TEST_CASE("Multi-recipient encryption, simpler interface", "[encrypt][multi][sim
                                session::to_span(x_keys[0].first),
                                session::to_span(x_keys[0].second),
                                "test suite"));
+
+    auto padded = session::encrypt_for_multiple_simple(
+            msgs[0],
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            session::to_span(x_keys[0].first),
+            session::to_span(x_keys[0].second),
+            "test suite",
+            nonce,
+            4);
+
+    oxenc::bt_dict_consumer padded_dict{padded};
+    auto padded_list = padded_dict.require<oxenc::bt_list_consumer>("e");
+    std::vector<size_t> padded_sizes;
+    while (!padded_list.is_finished())
+        padded_sizes.push_back(padded_list.consume<std::span<const unsigned char>>().size());
+
+    CHECK(padded_sizes ==
+          std::vector<size_t>(4, msgs[0].size() + crypto_aead_xchacha20poly1305_ietf_ABYTES));
+
+    auto padded_message = session::decrypt_for_multiple_simple(
+            padded,
+            session::to_span(x_keys[3].first),
+            session::to_span(x_keys[3].second),
+            session::to_span(x_keys[0].second),
+            "test suite");
+    REQUIRE(padded_message);
+    CHECK(session::to_string(*padded_message) == msgs[0]);
+
+    auto empty_padded = session::encrypt_for_multiple_simple(
+            std::string_view{},
+            session::to_view_vector(
+                    std::next(recipients.begin()), std::next(recipients.begin(), 2)),
+            session::to_span(x_keys[0].first),
+            session::to_span(x_keys[0].second),
+            "test suite",
+            nonce,
+            4);
+
+    oxenc::bt_dict_consumer empty_padded_dict{empty_padded};
+    auto empty_padded_list = empty_padded_dict.require<oxenc::bt_list_consumer>("e");
+    std::vector<size_t> empty_padded_sizes;
+    while (!empty_padded_list.is_finished())
+        empty_padded_sizes.push_back(
+                empty_padded_list.consume<std::span<const unsigned char>>().size());
+
+    CHECK(empty_padded_sizes == std::vector<size_t>(4, crypto_aead_xchacha20poly1305_ietf_ABYTES));
+
+    auto empty_message = session::decrypt_for_multiple_simple(
+            empty_padded,
+            session::to_span(x_keys[1].first),
+            session::to_span(x_keys[1].second),
+            session::to_span(x_keys[0].second),
+            "test suite");
+    REQUIRE(empty_message);
+    CHECK(empty_message->empty());
 
     auto m1 = session::decrypt_for_multiple_simple(
             encrypted,


### PR DESCRIPTION
## summary

when `pad` is enabled, `encrypt_for_multiple_simple()` currently sizes junk entries from the plaintext. real XChaCha20-Poly1305 ciphertexts include a 16-byte tag, so padding entries stay distinguishable by length

this uses the encrypted size for padding entries, matching the existing C and C++ API docs. it also keeps padding enabled for empty messages, whose ciphertexts are still 16 bytes

## tests

- `./build-pr/tests/testAll "[simple]"`
- `./build-pr/tests/testAll`
- `clang-format-19 --dry-run --Werror src/multi_encrypt.cpp tests/test_multi_encrypt.cpp`