### PR TITLE
Re-resolve the right swarm after a 421

### DIFF
--- a/include/session/network/service_node.hpp
+++ b/include/session/network/service_node.hpp
@@ -53,7 +53,6 @@ struct service_node {
 
     std::span<const unsigned char> view_remote_key() const { return remote_pubkey; }
     std::string host() const { return ip.to_string(); }
-    session::network::x25519_pubkey swarm_pubkey() const;
 
     std::string to_string() const;
     std::string to_https_string() const;

--- a/include/session/network/session_network_types.h
+++ b/include/session/network/session_network_types.h
@@ -63,6 +63,16 @@ typedef struct {
 
     const char* request_id;  // Optional id for the request to trace through logs, null terminated
 
+    // The account whose swarm this request addresses, as 64 hex chars of its X25519 pubkey — the
+    // same value passed to session_network_get_swarm() to choose the destination node.  Null for a
+    // request aimed at a node rather than about an account (a cache refresh, a clock resync) or at
+    // a server, which no swarm membership applies to.
+    //
+    // Set it whenever there is one: a storage server rejects a request whose pubkey is outside its
+    // swarm with a 421, and recovering means re-resolving this account's swarm.  Left null, such a
+    // request fails on the first 421 instead of being redirected.
+    const char* swarm_pubkey_hex;
+
 } session_request_params;
 
 typedef struct {

--- a/include/session/network/session_network_types.hpp
+++ b/include/session/network/session_network_types.hpp
@@ -166,6 +166,16 @@ struct Request {
     /// Any extra request details which may modify the structure of the request.
     RequestDetails details;
 
+    /// The account whose swarm this request addresses, when it addresses one: the X25519 pubkey of
+    /// a session ID, group ID, etc.  Set it for anything sent to a swarm member *about* that
+    /// account, and leave it unset for a request merely aimed at a node (a snode cache refresh, a
+    /// clock resync), which no swarm membership applies to.
+    ///
+    /// Required to recover from a 421: the storage server rejects a request whose pubkey is not in
+    /// its swarm, and recovering means re-resolving the swarm of *this account*, which cannot be
+    /// derived from the node we happened to ask.
+    std::optional<session::network::x25519_pubkey> swarm_pubkey;
+
     /// The time the request was created, this is used primarily for determining whether the
     /// `overall_timeout` has been exceeded.
     std::chrono::steady_clock::time_point creation_time = std::chrono::steady_clock::now();

--- a/src/network/service_node.cpp
+++ b/src/network/service_node.cpp
@@ -11,10 +11,6 @@ using namespace oxen::log::literals;
 
 namespace session::network {
 
-session::network::x25519_pubkey service_node::swarm_pubkey() const {
-    return session::network::compute_x25519_pubkey(remote_pubkey);
-}
-
 std::string service_node::to_string() const {
     return remote_pubkey.hex();
 }

--- a/src/network/session_network.cpp
+++ b/src/network/session_network.cpp
@@ -808,6 +808,22 @@ void Network::_handle_421_retry(
                 {content_type_plain_text},
                 "Received 421 from a non-service-node destination");
 
+    // A 421 says the account we asked about is not in this node's swarm, so recovering means
+    // re-resolving *that account's* swarm.  Nothing about the node we asked can tell us which
+    // account that was, so a request that did not record one cannot be redirected.
+    if (!original_request.swarm_pubkey) {
+        log::warning(
+                cat,
+                "Request {} received 421 but carries no swarm pubkey to re-resolve.",
+                original_request.request_id);
+        return final_callback(
+                false,
+                false,
+                ERROR_MISDIRECTED_REQUEST,
+                {content_type_plain_text},
+                "421 Misdirected Request for a request with no swarm");
+    }
+
     // If we got a 421 it means our snode cache is outdated (because the swarm the destination node
     // belongs to doesn't match our cache anymore)
     log::info(
@@ -824,7 +840,7 @@ void Network::_handle_421_retry(
              req_to_retry = std::move(original_request),
              cb = std::move(final_callback),
              failed_node = failed_node_copy] {
-                auto swarm_pubkey = failed_node.swarm_pubkey();
+                auto swarm_pubkey = *req_to_retry.swarm_pubkey;
 
                 _snode_pool->get_swarm(
                         swarm_pubkey,
@@ -1751,6 +1767,10 @@ LIBSESSION_C_API void session_network_send_request(
                          : std::nullopt),
                 std::nullopt,
                 request_id};
+
+        if (params->swarm_pubkey_hex)
+            request.swarm_pubkey = x25519_pubkey::from_hex({params->swarm_pubkey_hex, 64});
+
         auto cpp_callback = [c_cb = callback, c_ctx = ctx](
                                     bool success,
                                     bool timeout,


### PR DESCRIPTION
_handle_421_retry re-resolved the swarm using service_node::swarm_pubkey(), which returns compute_x25519_pubkey(remote_pubkey) -- the failing *node's own* X25519 key, not the account the request was about. So a misdirected request was retried against a swarm chosen by hashing the pubkey of the node that had just rejected it: an unrelated swarm, giving another 421 and then the retry limit. Recovering needs the swarm of the *account*, which may have moved.

Request now records the account whose swarm it addresses, and the retry re-resolves that. A request with no swarm recorded -- a snode cache refresh, a clock resync, anything aimed at a node rather than about an account -- is not redirected at all, rather than being sent somewhere arbitrary. session_request_params gains a swarm_pubkey_hex field (appended, so a caller that doesn't set it behaves as before).

service_node::swarm_pubkey() is removed rather than corrected: it had a single caller and the name invited exactly this mistake (it reads as "the swarm this node is in" while computing the node's own key). compute_x25519_pubkey() stays.

Adapted from pfs commit e5a93a87. On this branch the account-addressed sends originate above libsession and arrive through the C session_network_send_request (hence the swarm_pubkey_hex param); the only internal swarm sends -- the clock resync and snode-pool refreshes -- are node-directed and correctly leave swarm_pubkey unset.