### PR TITLE
SnodePool: don't let an undersized refresh wipe a good cache

### DIFF
--- a/src/network/snode_pool.cpp
+++ b/src/network/snode_pool.cpp
@@ -714,14 +714,20 @@ void SnodePool::_on_refresh_complete(
                  use_direct_fetcher,
                  total_requests] {
         // Throw away everything we received and start the requests again after a backoff
-        auto discard_and_retry = [this,
+        auto discard_and_retry = [weak_self = weak_from_this(),
                                   refresh_id,
                                   refreshing_from_seed_nodes,
                                   use_direct_fetcher,
                                   total_requests](std::string_view reason) {
-            _snode_refresh_results.clear();
-            _snode_cache_refresh_failure_count++;
-            auto delay = _config.retry_delay.exponential(_snode_cache_refresh_failure_count);
+            auto self = weak_self.lock();
+
+            if (!self)
+                return;
+
+            self->_snode_refresh_results.clear();
+            self->_snode_cache_refresh_failure_count++;
+            auto delay =
+                    self->_config.retry_delay.exponential(self->_snode_cache_refresh_failure_count);
 
             log::error(
                     cat,
@@ -729,9 +735,9 @@ void SnodePool::_on_refresh_complete(
                     refresh_id,
                     delay.count(),
                     reason);
-            _loop->call_later(
+            self->_loop->call_later(
                     delay,
-                    [weak_self = weak_from_this(),
+                    [weak_self,
                      refresh_id,
                      refreshing_from_seed_nodes,
                      use_direct_fetcher,

--- a/src/network/snode_pool.cpp
+++ b/src/network/snode_pool.cpp
@@ -713,6 +713,40 @@ void SnodePool::_on_refresh_complete(
                  refreshing_from_seed_nodes,
                  use_direct_fetcher,
                  total_requests] {
+        // Throw away everything we received and start the requests again after a backoff
+        auto discard_and_retry = [this,
+                                  refresh_id,
+                                  refreshing_from_seed_nodes,
+                                  use_direct_fetcher,
+                                  total_requests](std::string_view reason) {
+            _snode_refresh_results.clear();
+            _snode_cache_refresh_failure_count++;
+            auto delay = _config.retry_delay.exponential(_snode_cache_refresh_failure_count);
+
+            log::error(
+                    cat,
+                    "[Request {}] Discarding responses and retrying after {}ms due to {}.",
+                    refresh_id,
+                    delay.count(),
+                    reason);
+            _loop->call_later(
+                    delay,
+                    [weak_self = weak_from_this(),
+                     refresh_id,
+                     refreshing_from_seed_nodes,
+                     use_direct_fetcher,
+                     total_requests] {
+                        if (auto self = weak_self.lock())
+                            for (uint8_t i = 0; i < total_requests; ++i)
+                                self->_launch_next_refresh_request(
+                                        refresh_id,
+                                        i,
+                                        refreshing_from_seed_nodes,
+                                        use_direct_fetcher,
+                                        total_requests);
+                    });
+        };
+
         // Sort the vectors (so make it easier to find the intersection)
         std::vector<std::vector<service_node>> processed_nodes;
         processed_nodes.reserve(raw_results.size());
@@ -744,34 +778,7 @@ void SnodePool::_on_refresh_complete(
                 std::ranges::stable_sort(nodes);
                 processed_nodes.emplace_back(std::move(nodes));
             } catch (const std::exception& e) {
-                _snode_refresh_results.clear();
-                _snode_cache_refresh_failure_count++;
-                auto delay = _config.retry_delay.exponential(_snode_cache_refresh_failure_count);
-
-                log::error(
-                        cat,
-                        "[Request {}] Discarding responses and retrying after {}ms due to invalid "
-                        "response #{}: {}.",
-                        refresh_id,
-                        delay.count(),
-                        (i + 1),
-                        e.what());
-                _loop->call_later(
-                        delay,
-                        [weak_self = weak_from_this(),
-                         refresh_id,
-                         refreshing_from_seed_nodes,
-                         use_direct_fetcher,
-                         total_requests] {
-                            if (auto self = weak_self.lock())
-                                for (uint8_t i = 0; i < total_requests; ++i)
-                                    self->_launch_next_refresh_request(
-                                            refresh_id,
-                                            i,
-                                            refreshing_from_seed_nodes,
-                                            use_direct_fetcher,
-                                            total_requests);
-                        });
+                discard_and_retry("invalid response #{}: {}"_format((i + 1), e.what()));
                 return;
             }
         }
@@ -829,6 +836,17 @@ void SnodePool::_on_refresh_complete(
                         heap.push(Cursor{cur.vec, next_index});
                 }
             }
+        }
+
+        // Only replace the cache if the refresh actually came back with a usable pool.  A refresh
+        // can legitimately succeed and still produce too few nodes (most easily when the multi-
+        // request intersection finds little in common), and overwriting a good cache with that
+        // leaves us with nothing to route through until the next refresh completes.  Treat it as a
+        // failed refresh and retry instead, keeping whatever cache we already have.
+        if (nodes.empty() || nodes.size() < _config.cache_min_size) {
+            discard_and_retry("a refreshed cache of only {} nodes (need {})"_format(
+                    nodes.size(), _config.cache_min_size));
+            return;
         }
 
         // Update the cache with the combined nodes

--- a/tests/pro_backend/seed_payment.py
+++ b/tests/pro_backend/seed_payment.py
@@ -84,6 +84,20 @@ def _obfuscated_id(provider, vk):
     return b""
 
 
+def _round_up_to_utc_midnight(value):
+    """Ceil to the next UTC midnight; a value already exactly at midnight stays put.
+
+    Deliberately inlined rather than called from the backend. This was `base.round_datetime_to_next_day`
+    until the backend moved it into its own test scaffolding, on the grounds that day-rounding is not
+    something the backend does -- proof expiry lands on a per-account grid and every other instant is
+    stored as it happened. So there is no stable backend function to call here, and substituting
+    another internal would only queue up the next AttributeError.
+    """
+    value = value.astimezone(datetime.timezone.utc)
+    midnight = value.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight if midnight == value else midnight + datetime.timedelta(days=1)
+
+
 def cmd_payment(args):
     engine, conn, err = _open()
     try:
@@ -99,7 +113,7 @@ def cmd_payment(args):
             payment_tx=_payment_tx(args.provider, args.payment_id),
             plan=plan,
             purchased_at=now,
-            expiry_at=base.round_datetime_to_next_day(now)
+            expiry_at=_round_up_to_utc_midnight(now)
             + datetime.timedelta(days=args.expiry_days),
             platform_refund_expiry_at=base.EPOCH,
             platform_obfuscated_account_id=_obfuscated_id(args.provider, vk),

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -288,8 +288,8 @@ TEST_CASE("Network", "[network][refresh_min_cache_size]") {
     session::network::config::SnodePool pool_config = {
             std::nullopt,
             std::nullopt,
-            std::chrono::minutes{5},
-            std::chrono::minutes{5},
+            5min,
+            5min,
             false,  // enforce_subnet_diversity
             network::opt::retry_delay{50ms, 200ms},
             opt::netid::Target::testnet,

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -233,8 +233,8 @@ TEST_CASE("Network", "[network][update_cache]") {
     session::network::config::SnodePool pool_config = {
             std::nullopt,
             std::nullopt,
-            std::chrono::minutes{5},
-            std::chrono::minutes{5},
+            5min,
+            5min,
             false,  // enforce_subnet_diversity
             network::opt::retry_delay{50ms, 200ms},
             opt::netid::Target::testnet,

--- a/tests/test_snode_pool.cpp
+++ b/tests/test_snode_pool.cpp
@@ -68,7 +68,41 @@ class TestSnodePool : public SnodePool {
     // Called from the test thread, so this also covers `_update_cache` being entered from off the
     // loop thread
     void update_cache(std::vector<service_node> nodes) { _update_cache("test", std::move(nodes)); }
+
+    void debug_on_refresh_complete(std::vector<std::vector<std::byte>> raw_results) {
+        auto total_requests = static_cast<uint8_t>(raw_results.size());
+        _loop->call_get([&] {
+            _on_refresh_complete("test", std::move(raw_results), false, true, total_requests);
+        });
+    }
 };
+
+// Encodes nodes the way the storage server returns them, so they can be fed to
+// `_on_refresh_complete`: 51 bytes per node, all multi-byte fields big-endian
+std::vector<std::byte> to_snode_cache_bin(const std::vector<service_node>& nodes) {
+    std::vector<std::byte> result;
+    result.reserve(nodes.size() * 51);
+
+    auto append = [&result](uint64_t value, size_t bytes) {
+        for (size_t i = bytes; i-- > 0;)
+            result.push_back(static_cast<std::byte>((value >> (i * 8)) & 0xff));
+    };
+
+    for (const auto& node : nodes) {
+        for (auto byte : node.view_remote_key())
+            result.push_back(static_cast<std::byte>(byte));
+
+        append(node.swarm_id, 8);
+        append(node.ip.addr, 4);
+        append(node.https_port, 2);
+        append(node.omq_port, 2);
+
+        for (auto part : node.storage_server_version)
+            append(part, 1);
+    }
+
+    return result;
+}
 }  // namespace session::network
 
 TEST_CASE("Network", "[network][get_unused_nodes]") {
@@ -248,4 +282,57 @@ TEST_CASE("Network", "[network][update_cache]") {
     // Should have stored the nodes by the time it returns
     snode_pool->update_cache(snode_cache);
     CHECK(snode_pool->size() == snode_cache.size());
+}
+
+TEST_CASE("Network", "[network][refresh_min_cache_size]") {
+    session::network::config::SnodePool pool_config = {
+            std::nullopt,
+            std::nullopt,
+            std::chrono::minutes{5},
+            std::chrono::minutes{5},
+            false,  // enforce_subnet_diversity
+            network::opt::retry_delay{50ms, 200ms},
+            opt::netid::Target::testnet,
+            {},
+            12,  // cache_min_size
+            0,
+            0,
+            3,  // cache_node_strike_threshold
+            false};
+    auto ed_pk = "4cb76fdc6d32278e3f83dbf608360ecc6b65727934b85d2fb86862ff98c46ab7"_hexbytes;
+    std::vector<service_node> snode_cache;
+
+    for (uint16_t i = 0; i < 20; ++i)
+        snode_cache.emplace_back(service_node{
+                ed25519_pubkey::from_bytes(ed_pk),
+                oxen::quic::ipv4{"192.168.0.{}"_format(i)},
+                static_cast<uint16_t>(20000 + i),
+                static_cast<uint16_t>(30000 + i),
+                {2, 11, 0},
+                0});
+
+    auto loop = std::make_shared<oxen::quic::Loop>();
+    auto disk_loop = std::make_shared<oxen::quic::Loop>();
+    auto snode_pool = std::make_shared<TestSnodePool>(pool_config, loop, disk_loop);
+    snode_pool->reset_state_with_cache(snode_cache);
+    REQUIRE(snode_pool->size() == 20);
+
+    // The encoding needs to round-trip or the rest of this test proves nothing
+    REQUIRE(service_node::process_snode_cache_bin(to_snode_cache_bin(snode_cache)).first ==
+            snode_cache);
+
+    // A refresh returning fewer than `cache_min_size` nodes should be discarded rather than
+    // replacing the perfectly good cache we already have
+    std::vector<service_node> too_few(snode_cache.begin(), snode_cache.begin() + 11);
+    snode_pool->debug_on_refresh_complete({to_snode_cache_bin(too_few)});
+    CHECK(snode_pool->size() == 20);
+
+    // ... and an empty refresh likewise
+    snode_pool->debug_on_refresh_complete({{}});
+    CHECK(snode_pool->size() == 20);
+
+    // A refresh with enough nodes should still replace it
+    std::vector<service_node> enough(snode_cache.begin(), snode_cache.begin() + 12);
+    snode_pool->debug_on_refresh_complete({to_snode_cache_bin(enough)});
+    CHECK(snode_pool->size() == 12);
 }


### PR DESCRIPTION
Follow-up to #105. That PR fixed the use-after-free in the post-refresh callbacks; this fixes the thing that made it reachable.

## The bug

`_on_refresh_complete` handed whatever it computed straight to `_update_cache` with no size check:

```cpp
// Update the cache with the combined nodes
_update_cache(refresh_id, std::move(nodes));
```

So a refresh that *succeeded* but produced too few nodes replaced a perfectly good cache. The multi-request path is the easy way in — it keeps only nodes present in at least `cache_min_num_refresh_presence_to_include_node` of the responses, and that intersection can come back near-empty or empty. The client is then left with nothing to route through until the next refresh completes.

This is also what made the #105 use-after-free reachable: an empty `_snode_cache` is what sent the deferred `get_swarm` back round to re-register itself mid-iteration, reallocating the vector being walked.

## The fix

Gate on `cache_min_size` before updating, and treat a shortfall as a failed refresh — keep the existing cache and retry with the same backoff already used for an unparseable response.

`cache_min_size` is already this codebase's "too small to be usable" line, so the gate is consistent rather than a new policy:

- the fallback-pool loader rejects a pool below it (`snode_pool.cpp:510`)
- `refresh_if_needed` triggers a refresh below it (`snode_pool.cpp:1064`)

Empty is rejected outright as well, so a client that opts out with `cache_min_size = 0` still can't be left cacheless.

The retry block is hoisted into a `discard_and_retry` lambda rather than duplicated — it's the same clear-results / bump-failure-count / exponential-backoff / relaunch sequence in both places.

## Trade-off worth a look

On a network with genuinely fewer than `cache_min_size` nodes we now retry indefinitely instead of serving from an undersized pool. I think that's acceptable because `refresh_if_needed` already spins in that situation, so such a deployment needs `cache_min_size` lowered either way — but it is a behaviour change and worth a second opinion, particularly for small local devnets.

## Testing

New `[network][refresh_min_cache_size]` case driving `_on_refresh_complete` with encoded responses. Verified it fails without the gate:

```
CHECK( snode_pool->size() == 20 )   // undersized refresh
with expansion: 11 == 20
CHECK( snode_pool->size() == 20 )   // empty refresh
with expansion:  0 == 20
```

and passes with it. It also asserts the test's own encoder round-trips through `process_snode_cache_bin` first, so a fixture bug can't masquerade as a pass.

Full suite green: 130 cases, 25,755,856 assertions.