### PR TITLE
attachments: validate file encryption inputs

### DIFF
--- a/src/attachments.cpp
+++ b/src/attachments.cpp
@@ -301,13 +301,19 @@ std::array<std::byte, ENCRYPT_KEY_SIZE> encrypt(
         const std::filesystem::path& file,
         Domain domain,
         std::function<std::span<std::byte>(size_t enc_size)> make_buffer,
-        bool /*allow_large*/) {
+        bool allow_large) {
+
+    if (seed.size() < 32)
+        throw std::invalid_argument{"attachment::encrypt requires a 32-byte uploader seed"};
 
     std::ifstream in;
     in.exceptions(std::ios::badbit);
     in.open(file, std::ios::binary | std::ios::ate);
     size_t size = in.tellg();
     in.seekg(0, std::ios::beg);
+
+    if (size > MAX_REGULAR_SIZE && !allow_large)
+        throw std::invalid_argument{"data to encrypt is too large"};
 
     size = encrypted_size(size);
 

--- a/tests/test_attachment_encrypt.cpp
+++ b/tests/test_attachment_encrypt.cpp
@@ -247,6 +247,26 @@ TEST_CASE(
     CHECK(!!(decr == make_data(DATA_SIZE)));
 }
 
+TEST_CASE("Attachment file encryption validates its inputs", "[attachments][files][encrypt]") {
+    auto seed = "5123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_b;
+    temp_data_file f{0};
+
+    CHECK_THROWS_MATCHES(
+            attachment::encrypt(
+                    std::span{seed}.first<31>(), f.path, attachment::Domain::ATTACHMENT),
+            std::invalid_argument,
+            Message("attachment::encrypt requires a 32-byte uploader seed"));
+
+    std::filesystem::resize_file(f.path, attachment::MAX_REGULAR_SIZE + 1);
+    CHECK_THROWS_MATCHES(
+            attachment::encrypt(seed, f.path, attachment::Domain::ATTACHMENT),
+            std::invalid_argument,
+            Message("data to encrypt is too large"));
+
+    auto [enc, key] = attachment::encrypt(seed, f.path, attachment::Domain::ATTACHMENT, true);
+    CHECK(attachment::decrypt(enc, key).size() == attachment::MAX_REGULAR_SIZE + 1);
+}
+
 static std::vector<std::byte> slurp_file(const std::filesystem::path& filename) {
     std::ifstream in;
     in.exceptions(std::ios::failbit | std::ios::badbit);


### PR DESCRIPTION
## summary

the file-based attachment encryption overloads currently read 32 bytes from `seed` without checking its size, unlike the buffer overloads. they also ignore `allow_large`, so files above `MAX_REGULAR_SIZE` are accepted when the flag is false

this validates both inputs before hashing the file while keeping oversized file support when `allow_large=true`

## tests

- `./Build/tests/testAll "Attachment file encryption validates its inputs"`
- `./Build/tests/testAll "[attachments]"`
- `./Build/tests/testAll`
- `./utils/ci/drone-format-verify.sh`