### PR TITLE
Version Pro Proofs on the outside instead of the inside

### DIFF
--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -62,6 +62,9 @@ typedef enum SESSION_PROTOCOL_PRO_STATUS {  // See session::ProStatus
     SESSION_PROTOCOL_PRO_STATUS_INVALID_USER_SIG,
     SESSION_PROTOCOL_PRO_STATUS_VALID,
     SESSION_PROTOCOL_PRO_STATUS_EXPIRED,
+    // Proof carried a version this client doesn't understand; it could not be verified and the
+    // message is treated as non-pro (see session::ProProofVersion).
+    SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION,
 } SESSION_PROTOCOL_PRO_STATUS;
 
 typedef struct session_protocol_pro_signed_message {

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -70,7 +70,6 @@ typedef struct session_protocol_pro_signed_message {
 } session_protocol_pro_signed_message;
 
 typedef struct session_protocol_pro_proof {
-    uint8_t version;
     bytes32 revocation_tag;
     bytes32 rotating_pubkey;
     int64_t expiry_ts;

--- a/include/session/session_protocol.h
+++ b/include/session/session_protocol.h
@@ -62,9 +62,8 @@ typedef enum SESSION_PROTOCOL_PRO_STATUS {  // See session::ProStatus
     SESSION_PROTOCOL_PRO_STATUS_INVALID_USER_SIG,
     SESSION_PROTOCOL_PRO_STATUS_VALID,
     SESSION_PROTOCOL_PRO_STATUS_EXPIRED,
-    // Proof carried a version this client doesn't understand; it could not be verified and the
-    // message is treated as non-pro (see session::ProProofVersion).
-    SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION,
+    // Nothing could be evaluated, so the proof is unusable (see session::ProStatus::Invalid).
+    SESSION_PROTOCOL_PRO_STATUS_INVALID,
 } SESSION_PROTOCOL_PRO_STATUS;
 
 typedef struct session_protocol_pro_signed_message {

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -119,6 +119,9 @@ enum class ProStatus {
     InvalidUserSig = SESSION_PROTOCOL_PRO_STATUS_INVALID_USER_SIG,
     Valid = SESSION_PROTOCOL_PRO_STATUS_VALID,      // Proof is verified; has not expired
     Expired = SESSION_PROTOCOL_PRO_STATUS_EXPIRED,  // Proof is verified; has expired
+    // Proof's wire version is not one we understand, so it can't be verified; the message is
+    // delivered as non-pro rather than dropped (see ProProofVersion).
+    UnsupportedVersion = SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION,
 };
 
 class ProProof_v0 {

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -72,6 +72,11 @@ inline constexpr int COMMUNITY_OR_1O1_MSG_PADDING = 160;
 // Session Pro 16-byte signing domain prefixes; each prefixes the Ed25519-signed message for its
 // endpoint (pro-wire-protocol.md §2 proof, §3 signed requests). ASCII, `_`-right-padded to 16
 // bytes (formerly the BLAKE2b personalisation, back when messages were pre-hashed).
+//
+// BUILD_PROOF_DOMAIN is also what pins a proof to its format: the `_v0` in it is part of the signed
+// bytes, so a proof of some future format signed under its own domain simply fails verification
+// here. That is why a proof carries no version field of its own -- and why this literal is a wire
+// constant that must not be "tidied up" along with any C++ renaming.
 inline constexpr std::string_view GENERATE_PROOF_DOMAIN = "ProGenerateProof";
 inline constexpr std::string_view BUILD_PROOF_DOMAIN = "ProProof_v0_____";
 inline constexpr std::string_view GET_PRO_STATUS_DOMAIN = "ProGetProStatus_";
@@ -80,11 +85,6 @@ static_assert(GENERATE_PROOF_DOMAIN.size() == 16);
 static_assert(BUILD_PROOF_DOMAIN.size() == 16);
 static_assert(GET_PRO_STATUS_DOMAIN.size() == 16);
 static_assert(GET_PAYMENT_DETAILS_DOMAIN.size() == 16);
-
-/// The Session Pro proof wire-format version. This is a *selector*: it says which ProProof_vN
-/// layout a serialized proof uses; it is deliberately NOT stored as a member of the proof struct
-/// (see ProProof_v0 / the ProProof alias below). Only v0 exists today.
-enum class ProProofVersion : std::uint8_t { v0 = 0 };
 
 /// Rotation window for the Session Pro rotating key: ProProof::rotating_seed yields the same seed
 /// for all timestamps within one such period and a fresh one at each boundary.
@@ -119,12 +119,18 @@ enum class ProStatus {
     InvalidUserSig = SESSION_PROTOCOL_PRO_STATUS_INVALID_USER_SIG,
     Valid = SESSION_PROTOCOL_PRO_STATUS_VALID,      // Proof is verified; has not expired
     Expired = SESSION_PROTOCOL_PRO_STATUS_EXPIRED,  // Proof is verified; has expired
-    // Proof's wire version is not one we understand, so it can't be verified; the message is
-    // delivered as non-pro rather than dropped (see ProProofVersion).
-    UnsupportedVersion = SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION,
+    // Nothing could be evaluated, so whatever is in DecodedPro::proof is not to be trusted. Today
+    // this means the message carried no proof we can read: either the sender attached none, or it
+    // is in a format this client does not know -- a new proof format is a new field/message rather
+    // than a version bump on the existing one, so to an older client it simply does not appear as
+    // `proof`. Deliberately the general "unusable proof" answer rather than a reason-specific one,
+    // so a future unreadable-proof case needs no new status and no caller has to learn one. Such a
+    // message is delivered as non-pro rather than dropped, so a future proof format costs the
+    // sender their Pro affordances on old clients instead of costing them the whole message.
+    Invalid = SESSION_PROTOCOL_PRO_STATUS_INVALID,
 };
 
-class ProProof_v0 {
+class ProProof {
   public:
     /// Opaque revocation tag identifying this proof (from the Session Pro backend)
     array_uc32 revocation_tag;
@@ -246,20 +252,11 @@ class ProProof_v0 {
     static cleared_uc32 rotating_seed(
             std::span<const unsigned char> master_seed, std::chrono::sys_seconds now);
 
-    bool operator==(const ProProof_v0& other) const {
+    bool operator==(const ProProof& other) const {
         return revocation_tag == other.revocation_tag && rotating_pubkey == other.rotating_pubkey &&
                expiry_at == other.expiry_at && sig == other.sig;
     }
 };
-
-/// The Session Pro proof layout this codebase currently speaks. The wire `version`
-/// (ProProofVersion) selects *which* ProProof_vN a serialized proof is, rather than being a field
-/// of the proof: today only v0 exists, so this alias points at it. A future format adds its own
-/// struct -- `struct ProProof_v1 : ProProof_v0 { ... }` to extend, or a fresh `struct ProProof_v2 {
-/// ... }` to replace
-/// -- at which point this alias becomes a std::variant (or a virtual base) over the supported
-/// versions, chosen from the wire version at parse time.
-using ProProof = ProProof_v0;
 
 enum class ProFeaturesForMsgStatus {
     Success = SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_SUCCESS,

--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -81,7 +81,10 @@ static_assert(BUILD_PROOF_DOMAIN.size() == 16);
 static_assert(GET_PRO_STATUS_DOMAIN.size() == 16);
 static_assert(GET_PAYMENT_DETAILS_DOMAIN.size() == 16);
 
-enum ProProofVersion { ProProofVersion_v0 };
+/// The Session Pro proof wire-format version. This is a *selector*: it says which ProProof_vN
+/// layout a serialized proof uses; it is deliberately NOT stored as a member of the proof struct
+/// (see ProProof_v0 / the ProProof alias below). Only v0 exists today.
+enum class ProProofVersion : std::uint8_t { v0 = 0 };
 
 /// Rotation window for the Session Pro rotating key: ProProof::rotating_seed yields the same seed
 /// for all timestamps within one such period and a fresh one at each boundary.
@@ -118,11 +121,8 @@ enum class ProStatus {
     Expired = SESSION_PROTOCOL_PRO_STATUS_EXPIRED,  // Proof is verified; has expired
 };
 
-class ProProof {
+class ProProof_v0 {
   public:
-    /// Version of the proof set by the Session Pro Backend
-    std::uint8_t version;
-
     /// Opaque revocation tag identifying this proof (from the Session Pro backend)
     array_uc32 revocation_tag;
 
@@ -243,12 +243,20 @@ class ProProof {
     static cleared_uc32 rotating_seed(
             std::span<const unsigned char> master_seed, std::chrono::sys_seconds now);
 
-    bool operator==(const ProProof& other) const {
-        return version == other.version && revocation_tag == other.revocation_tag &&
-               rotating_pubkey == other.rotating_pubkey && expiry_at == other.expiry_at &&
-               sig == other.sig;
+    bool operator==(const ProProof_v0& other) const {
+        return revocation_tag == other.revocation_tag && rotating_pubkey == other.rotating_pubkey &&
+               expiry_at == other.expiry_at && sig == other.sig;
     }
 };
+
+/// The Session Pro proof layout this codebase currently speaks. The wire `version`
+/// (ProProofVersion) selects *which* ProProof_vN a serialized proof is, rather than being a field
+/// of the proof: today only v0 exists, so this alias points at it. A future format adds its own
+/// struct -- `struct ProProof_v1 : ProProof_v0 { ... }` to extend, or a fresh `struct ProProof_v2 {
+/// ... }` to replace
+/// -- at which point this alias becomes a std::variant (or a virtual base) over the supported
+/// versions, chosen from the wire version at parse time.
+using ProProof = ProProof_v0;
 
 enum class ProFeaturesForMsgStatus {
     Success = SESSION_PROTOCOL_PRO_FEATURES_FOR_MSG_STATUS_SUCCESS,

--- a/proto/SessionProtos.pb.cc
+++ b/proto/SessionProtos.pb.cc
@@ -486,8 +486,7 @@ PROTOBUF_CONSTEXPR ProProof::ProProof(
   , /*decltype(_impl_.revocationtag_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.rotatingpublickey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.sig_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.expiryunixts_)*/uint64_t{0u}
-  , /*decltype(_impl_.version_)*/0u} {}
+  , /*decltype(_impl_.expiryunixts_)*/uint64_t{0u}} {}
 struct ProProofDefaultTypeInternal {
   PROTOBUF_CONSTEXPR ProProofDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
@@ -10999,9 +10998,6 @@ std::string GroupUpdateDeleteMemberContentMessage::GetTypeName() const {
 class ProProof::_Internal {
  public:
   using HasBits = decltype(std::declval<ProProof>()._impl_._has_bits_);
-  static void set_has_version(HasBits* has_bits) {
-    (*has_bits)[0] |= 16u;
-  }
   static void set_has_revocationtag(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
@@ -11031,8 +11027,7 @@ ProProof::ProProof(const ProProof& from)
     , decltype(_impl_.revocationtag_){}
     , decltype(_impl_.rotatingpublickey_){}
     , decltype(_impl_.sig_){}
-    , decltype(_impl_.expiryunixts_){}
-    , decltype(_impl_.version_){}};
+    , decltype(_impl_.expiryunixts_){}};
 
   _internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
   _impl_.revocationtag_.InitDefault();
@@ -11059,9 +11054,7 @@ ProProof::ProProof(const ProProof& from)
     _this->_impl_.sig_.Set(from._internal_sig(), 
       _this->GetArenaForAllocation());
   }
-  ::memcpy(&_impl_.expiryunixts_, &from._impl_.expiryunixts_,
-    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.version_) -
-    reinterpret_cast<char*>(&_impl_.expiryunixts_)) + sizeof(_impl_.version_));
+  _this->_impl_.expiryunixts_ = from._impl_.expiryunixts_;
   // @@protoc_insertion_point(copy_constructor:SessionProtos.ProProof)
 }
 
@@ -11076,7 +11069,6 @@ inline void ProProof::SharedCtor(
     , decltype(_impl_.rotatingpublickey_){}
     , decltype(_impl_.sig_){}
     , decltype(_impl_.expiryunixts_){uint64_t{0u}}
-    , decltype(_impl_.version_){0u}
   };
   _impl_.revocationtag_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
@@ -11130,11 +11122,7 @@ void ProProof::Clear() {
       _impl_.sig_.ClearNonDefaultToEmpty();
     }
   }
-  if (cached_has_bits & 0x00000018u) {
-    ::memset(&_impl_.expiryunixts_, 0, static_cast<size_t>(
-        reinterpret_cast<char*>(&_impl_.version_) -
-        reinterpret_cast<char*>(&_impl_.expiryunixts_)) + sizeof(_impl_.version_));
-  }
+  _impl_.expiryunixts_ = uint64_t{0u};
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<std::string>();
 }
@@ -11146,15 +11134,6 @@ const char* ProProof::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // optional uint32 version = 1;
-      case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _Internal::set_has_version(&has_bits);
-          _impl_.version_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
       // optional bytes revocationTag = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
@@ -11222,12 +11201,6 @@ uint8_t* ProProof::_InternalSerialize(
   (void) cached_has_bits;
 
   cached_has_bits = _impl_._has_bits_[0];
-  // optional uint32 version = 1;
-  if (cached_has_bits & 0x00000010u) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(1, this->_internal_version(), target);
-  }
-
   // optional bytes revocationTag = 2;
   if (cached_has_bits & 0x00000001u) {
     target = stream->WriteBytesMaybeAliased(
@@ -11269,7 +11242,7 @@ size_t ProProof::ByteSizeLong() const {
   (void) cached_has_bits;
 
   cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x0000001fu) {
+  if (cached_has_bits & 0x0000000fu) {
     // optional bytes revocationTag = 2;
     if (cached_has_bits & 0x00000001u) {
       total_size += 1 +
@@ -11296,11 +11269,6 @@ size_t ProProof::ByteSizeLong() const {
       total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_expiryunixts());
     }
 
-    // optional uint32 version = 1;
-    if (cached_has_bits & 0x00000010u) {
-      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_version());
-    }
-
   }
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     total_size += _internal_metadata_.unknown_fields<std::string>(::PROTOBUF_NAMESPACE_ID::internal::GetEmptyString).size();
@@ -11324,7 +11292,7 @@ void ProProof::MergeFrom(const ProProof& from) {
   (void) cached_has_bits;
 
   cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x0000001fu) {
+  if (cached_has_bits & 0x0000000fu) {
     if (cached_has_bits & 0x00000001u) {
       _this->_internal_set_revocationtag(from._internal_revocationtag());
     }
@@ -11336,9 +11304,6 @@ void ProProof::MergeFrom(const ProProof& from) {
     }
     if (cached_has_bits & 0x00000008u) {
       _this->_impl_.expiryunixts_ = from._impl_.expiryunixts_;
-    }
-    if (cached_has_bits & 0x00000010u) {
-      _this->_impl_.version_ = from._impl_.version_;
     }
     _this->_impl_._has_bits_[0] |= cached_has_bits;
   }
@@ -11374,12 +11339,7 @@ void ProProof::InternalSwap(ProProof* other) {
       &_impl_.sig_, lhs_arena,
       &other->_impl_.sig_, rhs_arena
   );
-  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(ProProof, _impl_.version_)
-      + sizeof(ProProof::_impl_.version_)
-      - PROTOBUF_FIELD_OFFSET(ProProof, _impl_.expiryunixts_)>(
-          reinterpret_cast<char*>(&_impl_.expiryunixts_),
-          reinterpret_cast<char*>(&other->_impl_.expiryunixts_));
+  swap(_impl_.expiryunixts_, other->_impl_.expiryunixts_);
 }
 
 std::string ProProof::GetTypeName() const {

--- a/proto/SessionProtos.pb.h
+++ b/proto/SessionProtos.pb.h
@@ -6455,7 +6455,6 @@ class ProProof final :
     kRotatingPublicKeyFieldNumber = 3,
     kSigFieldNumber = 5,
     kExpiryUnixTsFieldNumber = 4,
-    kVersionFieldNumber = 1,
   };
   // optional bytes revocationTag = 2;
   bool has_revocationtag() const;
@@ -6524,19 +6523,6 @@ class ProProof final :
   void _internal_set_expiryunixts(uint64_t value);
   public:
 
-  // optional uint32 version = 1;
-  bool has_version() const;
-  private:
-  bool _internal_has_version() const;
-  public:
-  void clear_version();
-  uint32_t version() const;
-  void set_version(uint32_t value);
-  private:
-  uint32_t _internal_version() const;
-  void _internal_set_version(uint32_t value);
-  public:
-
   // @@protoc_insertion_point(class_scope:SessionProtos.ProProof)
  private:
   class _Internal;
@@ -6551,7 +6537,6 @@ class ProProof final :
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rotatingpublickey_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr sig_;
     uint64_t expiryunixts_;
-    uint32_t version_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_SessionProtos_2eproto;
@@ -13536,34 +13521,6 @@ inline void GroupUpdateDeleteMemberContentMessage::set_allocated_adminsignature(
 // -------------------------------------------------------------------
 
 // ProProof
-
-// optional uint32 version = 1;
-inline bool ProProof::_internal_has_version() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000010u) != 0;
-  return value;
-}
-inline bool ProProof::has_version() const {
-  return _internal_has_version();
-}
-inline void ProProof::clear_version() {
-  _impl_.version_ = 0u;
-  _impl_._has_bits_[0] &= ~0x00000010u;
-}
-inline uint32_t ProProof::_internal_version() const {
-  return _impl_.version_;
-}
-inline uint32_t ProProof::version() const {
-  // @@protoc_insertion_point(field_get:SessionProtos.ProProof.version)
-  return _internal_version();
-}
-inline void ProProof::_internal_set_version(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000010u;
-  _impl_.version_ = value;
-}
-inline void ProProof::set_version(uint32_t value) {
-  _internal_set_version(value);
-  // @@protoc_insertion_point(field_set:SessionProtos.ProProof.version)
-}
 
 // optional bytes revocationTag = 2;
 inline bool ProProof::_internal_has_revocationtag() const {

--- a/proto/SessionProtos.proto
+++ b/proto/SessionProtos.proto
@@ -390,7 +390,9 @@ message GroupUpdateDeleteMemberContentMessage {
 }
 
 message ProProof {
-  optional uint32 version           = 1;
+  // Numbering starts at 2: field 1 was `version`, dropped because a proof's format is its type
+  // rather than a value it carries -- the format is bound into the signature by the domain prefix
+  // it picks, and a future format arrives as its own message/field.
   optional bytes  revocationTag     = 2; // Opaque identifier of this proof produced by the Session Pro backend
   optional bytes  rotatingPublicKey = 3; // Public key whose signatures is authorised to entitle messages with Session Pro
   optional uint64 expiryUnixTs      = 4; // Epoch timestamps in seconds

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -24,9 +24,9 @@ bool ProConfig::load(std::string_view bt_encoded) {
         auto seed = d.require_span<unsigned char, crypto_sign_ed25519_SEEDBYTES>("r");
         auto sig = d.require_span<unsigned char, sizeof(proof.sig)>("s");
 
-        // The config proof is v0 by definition: a future format would take a new config key, not an
-        // in-dict version marker (an opaque per-key-merged value can't carry a version describing
-        // itself), so there is nothing to select here -- load() only ever produces a ProProof_v0.
+        // A future proof format would take a new config key rather than an in-dict version marker
+        // (an opaque per-key-merged value can't carry a version describing itself), so there is
+        // nothing to select here -- this key holds exactly the proof format below.
         proof.expiry_at = std::chrono::sys_seconds{std::chrono::seconds{expiry}};
         std::memcpy(proof.revocation_tag.data(), tag.data(), proof.revocation_tag.size());
         std::memcpy(proof.sig.data(), sig.data(), proof.sig.size());

--- a/src/config/pro.cpp
+++ b/src/config/pro.cpp
@@ -24,10 +24,9 @@ bool ProConfig::load(std::string_view bt_encoded) {
         auto seed = d.require_span<unsigned char, crypto_sign_ed25519_SEEDBYTES>("r");
         auto sig = d.require_span<unsigned char, sizeof(proof.sig)>("s");
 
-        // The config proof format is v0 by definition (a future format takes a new key, not an
-        // in-dict version marker -- an opaque value can't carry a version that describes itself
-        // across a per-key merge).
-        proof.version = ProProofVersion_v0;
+        // The config proof is v0 by definition: a future format would take a new config key, not an
+        // in-dict version marker (an opaque per-key-merged value can't carry a version describing
+        // itself), so there is nothing to select here -- load() only ever produces a ProProof_v0.
         proof.expiry_at = std::chrono::sys_seconds{std::chrono::seconds{expiry}};
         std::memcpy(proof.revocation_tag.data(), tag.data(), proof.revocation_tag.size());
         std::memcpy(proof.sig.data(), sig.data(), proof.sig.size());

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -511,7 +511,6 @@ LIBSESSION_C_API bool user_profile_get_pro_config(const config_object* conf, pro
         static_assert(sizeof pro->proof.revocation_tag == sizeof(val->proof.revocation_tag));
         static_assert(sizeof pro->proof.rotating_pubkey == sizeof(val->proof.rotating_pubkey));
         static_assert(sizeof pro->proof.sig == sizeof(val->proof.sig));
-        pro->proof.version = val->proof.version;
         std::memcpy(
                 pro->proof.revocation_tag.data,
                 val->proof.revocation_tag.data(),
@@ -533,7 +532,6 @@ LIBSESSION_C_API bool user_profile_get_pro_config(const config_object* conf, pro
 
 LIBSESSION_C_API void user_profile_set_pro_config(config_object* conf, const pro_pro_config* pro) {
     ProConfig val = {};
-    val.proof.version = pro->proof.version;
     std::memcpy(
             val.proof.revocation_tag.data(),
             pro->proof.revocation_tag.data,

--- a/src/json_parser.hpp
+++ b/src/json_parser.hpp
@@ -40,7 +40,8 @@ std::pair<bool, std::string_view> json_is(const nlohmann::json& v) {
     else if constexpr (std::is_enum_v<T>)
         // A (scoped) enum reads as its underlying integer -- nlohmann's default serializer converts
         // through the underlying type (json_extract's get_to) -- so callers can request the enum
-        // directly, e.g. json_require<ProProofVersion>(obj, "version").
+        // directly rather than reading an integer and casting. No caller does today: this arrived
+        // for the proof `version` read, which no longer exists.
         return {v.is_number_integer(), "an integer"};
     else if constexpr (is_one_of<T, std::string, std::string_view>)
         return {v.is_string(), "a string"};

--- a/src/json_parser.hpp
+++ b/src/json_parser.hpp
@@ -10,6 +10,7 @@
 #include <session/parse_error.hpp>
 #include <session/types.hpp>
 #include <string_view>
+#include <type_traits>
 
 namespace session::detail {
 
@@ -35,6 +36,11 @@ std::pair<bool, std::string_view> json_is(const nlohmann::json& v) {
         return {v.is_boolean(), "a boolean"};
     else if constexpr (std::integral<T>)
         // is_number_integer() (not is_number()) so a fractional value is rejected, not truncated.
+        return {v.is_number_integer(), "an integer"};
+    else if constexpr (std::is_enum_v<T>)
+        // A (scoped) enum reads as its underlying integer -- nlohmann's default serializer converts
+        // through the underlying type (json_extract's get_to) -- so callers can request the enum
+        // directly, e.g. json_require<ProProofVersion>(obj, "version").
         return {v.is_number_integer(), "an integer"};
     else if constexpr (is_one_of<T, std::string, std::string_view>)
         return {v.is_string(), "a string"};

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -234,7 +234,10 @@ namespace {
     // Fills the common proof payload (add-payment and generate-proof both reply with exactly a
     // proof) from the already-extracted `result` object.
     void fill_proof(const nlohmann::json::object_t& result_obj, GenerateProProofResponse& result) {
-        result.proof.version = json_require<uint8_t>(result_obj, "version");
+        // No wire `version` to read: this endpoint returns a ProProof_v0 by construction -- the
+        // format is fixed by the endpoint we asked, and the proof's version is bound into its
+        // signature via the personalisation, not carried as a field. A future format is a new
+        // endpoint returning a new ProProof_vN, not a version bump on this response.
         result.proof.expiry_at = json_require<std::chrono::sys_seconds>(result_obj, "expiry_ts");
         json_require_hex(result_obj, "revocation_tag", result.proof.revocation_tag);
         json_require_hex(result_obj, "rotating_pkey", result.proof.rotating_pubkey);
@@ -800,7 +803,6 @@ session_pro_backend_pro_proof_response_parse(const char* json, size_t json_len) 
 
         // Success and error responses fold into one path -- different fields populated.
         const auto& p = owned->proof;
-        result.proof.version = p.version;
         result.proof.expiry_ts = session::epoch_seconds(p.expiry_at);
         std::memcpy(
                 result.proof.revocation_tag.data, p.revocation_tag.data(), p.revocation_tag.size());

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -234,10 +234,9 @@ namespace {
     // Fills the common proof payload (add-payment and generate-proof both reply with exactly a
     // proof) from the already-extracted `result` object.
     void fill_proof(const nlohmann::json::object_t& result_obj, GenerateProProofResponse& result) {
-        // No wire `version` to read: this endpoint returns a ProProof_v0 by construction -- the
-        // format is fixed by the endpoint we asked, and the proof's version is bound into its
-        // signature via the personalisation, not carried as a field. A future format is a new
-        // endpoint returning a new ProProof_vN, not a version bump on this response.
+        // No `version` to read: the format is fixed by the endpoint we asked, and is bound into the
+        // proof's signature by its domain prefix rather than carried as a field. A future format is
+        // a new endpoint returning its own proof type, not a version bump on this response.
         result.proof.expiry_at = json_require<std::chrono::sys_seconds>(result_obj, "expiry_ts");
         json_require_hex(result_obj, "revocation_tag", result.proof.revocation_tag);
         json_require_hex(result_obj, "rotating_pkey", result.proof.rotating_pubkey);

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -111,7 +111,6 @@ static session_protocol_envelope envelope_from_cpp(const session::Envelope& cpp)
 static session_protocol_decoded_pro decoded_pro_from_cpp(const session::DecodedPro& cpp) {
     session_protocol_decoded_pro result = {};
     result.status = static_cast<SESSION_PROTOCOL_PRO_STATUS>(cpp.status);
-    result.proof.version = cpp.proof.version;
     std::memcpy(
             result.proof.revocation_tag.data,
             cpp.proof.revocation_tag.data(),
@@ -856,7 +855,7 @@ DecodedEnvelope decode_envelope(
             session::ProProof& proof = pro.proof;
             // clang-format off
             size_t proof_errors = 0;
-            proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
+            proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion::v0);
             proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
             proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
             proof_errors += !proto_proof.has_expiryunixts();
@@ -1016,7 +1015,7 @@ DecodedCommunityMessage decode_for_community(
         session::ProProof& proof = pro.proof;
         // clang-format off
         size_t proof_errors = 0;
-        proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion_v0);
+        proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion::v0);
         proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
         proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
         proof_errors += !proto_proof.has_expiryunixts();

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -59,9 +59,9 @@ std::vector<unsigned char> proof_signed_message(
         std::span<const std::uint8_t> rotating_pubkey,
         std::int64_t expiry_ts) {
 
-    // This must match the Pro proof signed message in pro-wire-protocol.md §2 (built per §1.1). The
-    // proof version is NOT part of the message; it selects the 16-byte domain prefix (v0 ->
-    // "ProProof_v0_____"), and that choice of prefix is what binds the version into the signature.
+    // This must match the Pro proof signed message in pro-wire-protocol.md §2 (built per §1.1). No
+    // version is part of the message: the 16-byte domain prefix (BUILD_PROOF_DOMAIN) is itself what
+    // binds this proof to its format, since it is covered by the signature.
     return session::pro::signed_message(
             session::BUILD_PROOF_DOMAIN, revocation_tag, rotating_pubkey, expiry_ts);
 }
@@ -846,27 +846,22 @@ DecodedEnvelope decode_envelope(
 
             // Extract the pro message
             const SessionProtos::ProMessage& pro_msg = content.promessage();
-            if (!pro_msg.has_proof())
-                throw std::runtime_error(
-                        "Parse decrypted message failed, pro config missing proof");
-
-            // Parse the proof from protobufs
-            const SessionProtos::ProProof& proto_proof = pro_msg.proof();
             session::ProProof& proof = pro.proof;
             pro.msg_bitset.data = pro_msg.msgbitset();
             pro.profile_bitset.data = pro_msg.profilebitset();
             std::memcpy(result.envelope.pro_sig.data(), pro_sig.data(), pro_sig.size());
 
-            // The wire `version` selects which proof layout this is; we only understand v0. Any
-            // other (or a missing) version is a proof we can't verify -- degrade to a non-pro
-            // message flagged UnsupportedVersion rather than dropping it, so a future proof format
-            // does not shut older clients out of the whole message.
-            if (!proto_proof.has_version() ||
-                static_cast<session::ProProofVersion>(proto_proof.version()) !=
-                        session::ProProofVersion::v0) {
-                pro.status = ProStatus::UnsupportedVersion;
+            // No proof to read: either the sender attached none, or it is in a format we don't
+            // know -- a new proof format is a new field/message rather than a version bump on this
+            // one, so to this client it simply isn't here. Nothing to evaluate, so the proof is
+            // flagged Invalid and the message is delivered as non-pro rather than dropped: a future
+            // proof format costs the sender their Pro affordances here, not the whole message.
+            if (!pro_msg.has_proof()) {
+                pro.status = ProStatus::Invalid;
             } else {
-                // A v0 proof with the wrong shape is corruption, not forward-compat: hard error.
+                // Parse the proof from protobufs
+                const SessionProtos::ProProof& proto_proof = pro_msg.proof();
+                // A proof that is present but the wrong shape is corruption, not forward-compat: hard error.
                 size_t proof_errors = 0;
                 proof_errors +=
                         !proto_proof.has_revocationtag() ||
@@ -1019,25 +1014,21 @@ DecodedCommunityMessage decode_for_community(
         // Extract the pro message
         DecodedPro& pro = result.pro.emplace();
         const SessionProtos::ProMessage& pro_msg = content.promessage();
-        if (!pro_msg.has_proof())
-            throw std::runtime_error("Decoding community message failed, pro config missing proof");
-
-        // Parse the proof from protobufs
-        const SessionProtos::ProProof& proto_proof = pro_msg.proof();
         session::ProProof& proof = pro.proof;
         pro.msg_bitset.data = pro_msg.msgbitset();
         pro.profile_bitset.data = pro_msg.profilebitset();
 
-        // The wire `version` selects which proof layout this is; we only understand v0. Any other
-        // (or a missing) version is a proof we can't verify -- degrade to a non-pro message flagged
-        // UnsupportedVersion rather than dropping it, so a future proof format does not shut older
-        // clients out of the whole message.
-        if (!proto_proof.has_version() ||
-            static_cast<session::ProProofVersion>(proto_proof.version()) !=
-                    session::ProProofVersion::v0) {
-            pro.status = ProStatus::UnsupportedVersion;
+        // No proof to read: either the sender attached none, or it is in a format we don't know --
+        // a new proof format is a new field/message rather than a version bump on this one, so to
+        // this client it simply isn't here. Nothing to evaluate, so the proof is flagged Invalid
+        // and the message is delivered as non-pro rather than dropped: a future proof format costs
+        // the sender their Pro affordances here, not the whole message.
+        if (!pro_msg.has_proof()) {
+            pro.status = ProStatus::Invalid;
         } else {
-            // A v0 proof with the wrong shape is corruption, not forward-compat: hard error.
+            // Parse the proof from protobufs
+            const SessionProtos::ProProof& proto_proof = pro_msg.proof();
+            // A proof that is present but the wrong shape is corruption, not forward-compat: hard error.
             size_t proof_errors = 0;
             proof_errors += !proto_proof.has_revocationtag() ||
                             proto_proof.revocationtag().size() != proof.revocation_tag.max_size();

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -853,44 +853,56 @@ DecodedEnvelope decode_envelope(
             // Parse the proof from protobufs
             const SessionProtos::ProProof& proto_proof = pro_msg.proof();
             session::ProProof& proof = pro.proof;
-            // clang-format off
-            size_t proof_errors = 0;
-            proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion::v0);
-            proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
-            proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
-            proof_errors += !proto_proof.has_expiryunixts();
-            proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
-            // clang-format on
-            if (proof_errors)
-                throw std::runtime_error(
-                        "Parse decrypted message failed, pro metadata was malformed");
-
-            // Fill out the resulting proof structure, we have parsed successfully
             pro.msg_bitset.data = pro_msg.msgbitset();
             pro.profile_bitset.data = pro_msg.profilebitset();
             std::memcpy(result.envelope.pro_sig.data(), pro_sig.data(), pro_sig.size());
 
-            std::memcpy(
-                    proof.revocation_tag.data(),
-                    proto_proof.revocationtag().data(),
-                    proto_proof.revocationtag().size());
-            std::memcpy(
-                    proof.rotating_pubkey.data(),
-                    proto_proof.rotatingpublickey().data(),
-                    proto_proof.rotatingpublickey().size());
-            proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
-            std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
+            // The wire `version` selects which proof layout this is; we only understand v0. Any
+            // other (or a missing) version is a proof we can't verify -- degrade to a non-pro
+            // message flagged UnsupportedVersion rather than dropping it, so a future proof format
+            // does not shut older clients out of the whole message.
+            if (!proto_proof.has_version() ||
+                static_cast<session::ProProofVersion>(proto_proof.version()) !=
+                        session::ProProofVersion::v0) {
+                pro.status = ProStatus::UnsupportedVersion;
+            } else {
+                // A v0 proof with the wrong shape is corruption, not forward-compat: hard error.
+                size_t proof_errors = 0;
+                proof_errors +=
+                        !proto_proof.has_revocationtag() ||
+                        proto_proof.revocationtag().size() != proof.revocation_tag.max_size();
+                proof_errors +=
+                        !proto_proof.has_rotatingpublickey() ||
+                        proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
+                proof_errors += !proto_proof.has_expiryunixts();
+                proof_errors +=
+                        !proto_proof.has_sig() || proto_proof.sig().size() != proof.sig.max_size();
+                if (proof_errors)
+                    throw std::runtime_error(
+                            "Parse decrypted message failed, pro metadata was malformed");
 
-            // Evaluate the pro status given the extracted components (was it signed, is it expired,
-            // was the message signed validly?)
-            //
-            // Note that we sign the envelope content wholesale. For 1o1 which are padded to 160
-            // bytes, this means that we expected the user to have signed the padding as well.
-            auto unix_ts = std::chrono::floor<std::chrono::seconds>(
-                    std::chrono::sys_time<std::chrono::milliseconds>(
-                            std::chrono::milliseconds(content.sigtimestamp())));
-            pro.status = proof.status(
-                    pro_backend_pubkey, unix_ts, to_span(pro_sig), to_span(envelope.content()));
+                std::memcpy(
+                        proof.revocation_tag.data(),
+                        proto_proof.revocationtag().data(),
+                        proto_proof.revocationtag().size());
+                std::memcpy(
+                        proof.rotating_pubkey.data(),
+                        proto_proof.rotatingpublickey().data(),
+                        proto_proof.rotatingpublickey().size());
+                proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
+                std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
+
+                // Evaluate the pro status given the extracted components (was it signed, is it
+                // expired, was the message signed validly?)
+                //
+                // Note that we sign the envelope content wholesale. For 1o1 which are padded to 160
+                // bytes, this means that we expected the user to have signed the padding as well.
+                auto unix_ts = std::chrono::floor<std::chrono::seconds>(
+                        std::chrono::sys_time<std::chrono::milliseconds>(
+                                std::chrono::milliseconds(content.sigtimestamp())));
+                pro.status = proof.status(
+                        pro_backend_pubkey, unix_ts, to_span(pro_sig), to_span(envelope.content()));
+            }
         }
     }
     return result;
@@ -1013,65 +1025,77 @@ DecodedCommunityMessage decode_for_community(
         // Parse the proof from protobufs
         const SessionProtos::ProProof& proto_proof = pro_msg.proof();
         session::ProProof& proof = pro.proof;
-        // clang-format off
-        size_t proof_errors = 0;
-        proof_errors += !proto_proof.has_version()           || proto_proof.version()                  != static_cast<std::uint32_t>(session::ProProofVersion::v0);
-        proof_errors += !proto_proof.has_revocationtag()      || proto_proof.revocationtag().size()      != proof.revocation_tag.max_size();
-        proof_errors += !proto_proof.has_rotatingpublickey() || proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
-        proof_errors += !proto_proof.has_expiryunixts();
-        proof_errors += !proto_proof.has_sig()               || proto_proof.sig().size() != proof.sig.max_size();
-        // clang-format on
-        if (proof_errors)
-            throw std::runtime_error(
-                    "Decoding community message failed, pro metadata was malformed");
-
-        // Fill out the resulting proof structure, we have parsed successfully
         pro.msg_bitset.data = pro_msg.msgbitset();
         pro.profile_bitset.data = pro_msg.profilebitset();
-        std::memcpy(
-                proof.revocation_tag.data(),
-                proto_proof.revocationtag().data(),
-                proto_proof.revocationtag().size());
-        std::memcpy(
-                proof.rotating_pubkey.data(),
-                proto_proof.rotatingpublickey().data(),
-                proto_proof.rotatingpublickey().size());
-        proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
-        std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
-        // Evaluate the pro status given the extracted components (was it signed, is it expired,
-        // was the message signed validly?)
-        //
-        // IMPORTANT: We have to bit-manipulate the content because we're including the signature
-        // inside the payload itself that we had to sign. But we originally signed the payload
-        // without a signature set in it. This is only the case if we're dealing with a `Content`
-        // message that had the signature inside the content instead of the envelope.
-        if (result.envelope) {
-            // Entering the `pro_sig` and `result.envelope` branch means that the envelope must have
-            // a pro signature.
-            assert(result.envelope->flags & SESSION_PROTOCOL_ENVELOPE_FLAGS_PRO_SIG);
-            pro.status = proof.status(
-                    pro_backend_pubkey,
-                    unix_ts,
-                    to_span(*result.pro_sig),
-                    result.content_plaintext);
+        // The wire `version` selects which proof layout this is; we only understand v0. Any other
+        // (or a missing) version is a proof we can't verify -- degrade to a non-pro message flagged
+        // UnsupportedVersion rather than dropping it, so a future proof format does not shut older
+        // clients out of the whole message.
+        if (!proto_proof.has_version() ||
+            static_cast<session::ProProofVersion>(proto_proof.version()) !=
+                    session::ProProofVersion::v0) {
+            pro.status = ProStatus::UnsupportedVersion;
         } else {
-            SessionProtos::Content content_copy_without_sig = content;
-            assert(content_copy_without_sig.has_prosigforcommunitymessageonly());
+            // A v0 proof with the wrong shape is corruption, not forward-compat: hard error.
+            size_t proof_errors = 0;
+            proof_errors += !proto_proof.has_revocationtag() ||
+                            proto_proof.revocationtag().size() != proof.revocation_tag.max_size();
+            proof_errors +=
+                    !proto_proof.has_rotatingpublickey() ||
+                    proto_proof.rotatingpublickey().size() != proof.rotating_pubkey.max_size();
+            proof_errors += !proto_proof.has_expiryunixts();
+            proof_errors +=
+                    !proto_proof.has_sig() || proto_proof.sig().size() != proof.sig.max_size();
+            if (proof_errors)
+                throw std::runtime_error(
+                        "Decoding community message failed, pro metadata was malformed");
 
-            // Remove signature from the payload
-            content_copy_without_sig.clear_prosigforcommunitymessageonly();
-            assert(!content_copy_without_sig.has_prosigforcommunitymessageonly());
+            std::memcpy(
+                    proof.revocation_tag.data(),
+                    proto_proof.revocationtag().data(),
+                    proto_proof.revocationtag().size());
+            std::memcpy(
+                    proof.rotating_pubkey.data(),
+                    proto_proof.rotatingpublickey().data(),
+                    proto_proof.rotatingpublickey().size());
+            proof.expiry_at = as_sys_seconds(proto_proof.expiryunixts());
+            std::memcpy(proof.sig.data(), proto_proof.sig().data(), proto_proof.sig().size());
 
-            // Reserialise the payload without the signature, repad it then verify the signature
-            std::vector<uint8_t> content_copy_without_sig_payload =
-                    pad_message(to_span(content_copy_without_sig.SerializeAsString()));
+            // Evaluate the pro status given the extracted components (was it signed, is it expired,
+            // was the message signed validly?)
+            //
+            // IMPORTANT: We have to bit-manipulate the content because we're including the
+            // signature inside the payload itself that we had to sign. But we originally signed the
+            // payload without a signature set in it. This is only the case if we're dealing with a
+            // `Content` message that had the signature inside the content instead of the envelope.
+            if (result.envelope) {
+                // Entering the `pro_sig` and `result.envelope` branch means that the envelope must
+                // have a pro signature.
+                assert(result.envelope->flags & SESSION_PROTOCOL_ENVELOPE_FLAGS_PRO_SIG);
+                pro.status = proof.status(
+                        pro_backend_pubkey,
+                        unix_ts,
+                        to_span(*result.pro_sig),
+                        result.content_plaintext);
+            } else {
+                SessionProtos::Content content_copy_without_sig = content;
+                assert(content_copy_without_sig.has_prosigforcommunitymessageonly());
 
-            pro.status = proof.status(
-                    pro_backend_pubkey,
-                    unix_ts,
-                    to_span(*result.pro_sig),
-                    to_span(content_copy_without_sig_payload));
+                // Remove signature from the payload
+                content_copy_without_sig.clear_prosigforcommunitymessageonly();
+                assert(!content_copy_without_sig.has_prosigforcommunitymessageonly());
+
+                // Reserialise the payload without the signature, repad it then verify the signature
+                std::vector<uint8_t> content_copy_without_sig_payload =
+                        pad_message(to_span(content_copy_without_sig.SerializeAsString()));
+
+                pro.status = proof.status(
+                        pro_backend_pubkey,
+                        unix_ts,
+                        to_span(*result.pro_sig),
+                        to_span(content_copy_without_sig_payload));
+            }
         }
     }
 

--- a/src/session_protocol.cpp
+++ b/src/session_protocol.cpp
@@ -861,7 +861,8 @@ DecodedEnvelope decode_envelope(
             } else {
                 // Parse the proof from protobufs
                 const SessionProtos::ProProof& proto_proof = pro_msg.proof();
-                // A proof that is present but the wrong shape is corruption, not forward-compat: hard error.
+                // A proof that is present but the wrong shape is corruption, not forward-compat:
+                // hard error.
                 size_t proof_errors = 0;
                 proof_errors +=
                         !proto_proof.has_revocationtag() ||
@@ -1028,7 +1029,8 @@ DecodedCommunityMessage decode_for_community(
         } else {
             // Parse the proof from protobufs
             const SessionProtos::ProProof& proto_proof = pro_msg.proof();
-            // A proof that is present but the wrong shape is corruption, not forward-compat: hard error.
+            // A proof that is present but the wrong shape is corruption, not forward-compat: hard
+            // error.
             size_t proof_errors = 0;
             proof_errors += !proto_proof.has_revocationtag() ||
                             proto_proof.revocationtag().size() != proof.revocation_tag.max_size();

--- a/tests/test_config_pro.cpp
+++ b/tests/test_config_pro.cpp
@@ -23,8 +23,6 @@ TEST_CASE("Pro", "[config][pro]") {
     {
         // CPP
         pro_cpp.rotating_privkey = rotating_sk;
-        // Config never persists the proof version (see ProConfig::load); a loaded proof is v0.
-        pro_cpp.proof.version = session::ProProofVersion_v0;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
         pro_cpp.proof.expiry_at = std::chrono::sys_seconds(1s);
         constexpr auto revocation_tag =
@@ -35,7 +33,6 @@ TEST_CASE("Pro", "[config][pro]") {
 
         // C
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
-        pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
         pro.proof.expiry_ts = pro_cpp.proof.expiry_at.time_since_epoch().count();
         std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
@@ -102,7 +99,6 @@ TEST_CASE("Pro", "[config][pro]") {
         session::config::ProConfig loaded_pro = {};
         CHECK(loaded_pro.load(encoded));
         CHECK(loaded_pro.rotating_privkey == pro_cpp.rotating_privkey);
-        CHECK(loaded_pro.proof.version == session::ProProofVersion_v0);  // never persisted
         CHECK(loaded_pro.proof.revocation_tag == pro_cpp.proof.revocation_tag);
         CHECK(loaded_pro.proof.rotating_pubkey ==
               pro_cpp.proof.rotating_pubkey);  // derived from seed

--- a/tests/test_config_userprofile.cpp
+++ b/tests/test_config_userprofile.cpp
@@ -634,9 +634,6 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
     {
         // CPP
         pro_cpp.rotating_privkey = rotating_sk;
-        // The config does not persist the proof version (dicts merge per-key, so an in-dict version
-        // can't reliably describe its sibling fields); a config-loaded proof is always v0.
-        pro_cpp.proof.version = session::ProProofVersion_v0;
         pro_cpp.proof.rotating_pubkey = rotating_pk;
         pro_cpp.proof.expiry_at = std::chrono::sys_seconds(1s);
         constexpr auto revocation_tag =
@@ -647,7 +644,6 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
 
         // C
         std::memcpy(pro.rotating_privkey.data, rotating_sk.data(), rotating_sk.size());
-        pro.proof.version = pro_cpp.proof.version;
         std::memcpy(pro.proof.rotating_pubkey.data, rotating_pk.data(), rotating_pk.size());
         pro.proof.expiry_ts = pro_cpp.proof.expiry_at.time_since_epoch().count();
         std::memcpy(pro.proof.revocation_tag.data, revocation_tag.data(), revocation_tag.size());
@@ -809,7 +805,6 @@ TEST_CASE("UserProfile Pro Storage", "[config][user_profile][pro]") {
         auto store_proof = [&](std::chrono::sys_seconds expiry) {
             session::config::ProConfig pc = {};
             pc.rotating_privkey = rotating_sk;  // any valid 64-byte key (only sizes matter here)
-            pc.proof.version = session::ProProofVersion_v0;
             pc.proof.rotating_pubkey = rotating_pk;
             pc.proof.expiry_at = expiry;
             pr.set_pro_config(pc);

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -143,7 +143,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             nlohmann::json j;
             j["status"] = "ok";
             j["result"] = {
-                    {"version", 0},
                     {"expiry_ts", unix_ts},
                     {"revocation_tag", oxenc::to_hex(fake_revocation_tag)},
                     {"rotating_pkey", oxenc::to_hex(rotating_pubkey.data)},
@@ -185,7 +184,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
                 auto result_cpp = parse_pro_proof(json);
 
                 // Validate C and CPP variants
-                REQUIRE(result.proof.version == result_cpp.proof.version);
                 REQUIRE(std::memcmp(
                                 result.proof.revocation_tag.data,
                                 result_cpp.proof.revocation_tag.data(),
@@ -775,7 +773,6 @@ TEST_CASE("Pro backend known-answer vectors", "[pro_backend][pro_kat]") {
     }
     SECTION("pro proof") {
         session::ProProof proof;
-        proof.version = 0;
         std::memset(proof.revocation_tag.data(), 0x11, proof.revocation_tag.size());
         std::memcpy(proof.rotating_pubkey.data(), rotating_pk.data(), 32);
         proof.expiry_at = expiry;

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -30,7 +30,8 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
         std::chrono::sys_seconds content_at,
         std::chrono::sys_seconds pro_expiry_at,
         session_protocol_pro_message_bitset msg_bitset,
-        session_protocol_pro_profile_bitset profile_bitset) {
+        session_protocol_pro_profile_bitset profile_bitset,
+        uint32_t proof_version = static_cast<uint32_t>(session::ProProofVersion::v0)) {
     SerialisedProtobufContentWithProForTesting result = {};
 
     // Create protobuf `Content.dataMessage`
@@ -62,7 +63,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
 
     // Create protobuf `Content.proMessage.proof`
     SessionProtos::ProProof* proto_proof = pro->mutable_proof();
-    proto_proof->set_version(static_cast<std::uint32_t>(session::ProProofVersion::v0));
+    proto_proof->set_version(proof_version);
     proto_proof->set_revocationtag(
             result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
     proto_proof->set_rotatingpublickey(
@@ -399,6 +400,61 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         REQUIRE(decrypt_content.has_datamessage());
         const SessionProtos::DataMessage& data = decrypt_content.datamessage();
         REQUIRE(data.body() == data_body);
+        session_protocol_decode_envelope_free(&decrypt_result);
+    }
+
+    SECTION("A future/unknown proof version degrades to non-pro, not a dropped message") {
+        // Same message, but the embedded proof claims a version this client doesn't understand.
+        SerialisedProtobufContentWithProForTesting future_content =
+                build_protobuf_content_with_session_pro(
+                        /*data_body*/ data_body,
+                        /*user_rotating_privkey*/ user_pro_ed_sk,
+                        /*pro_backend_privkey*/ pro_backend_ed_sk,
+                        /*content_at=*/timestamp_s,
+                        /*pro_expiry_at*/ timestamp_s,
+                        /*msg_bitset*/ {},
+                        /*profile_bitset*/ {},
+                        /*proof_version*/ 99);
+
+        session_protocol_encoded_for_destination encrypt_result = session_protocol_encode_for_1o1(
+                future_content.plaintext.data(),
+                future_content.plaintext.size(),
+                keys.ed_sk0.data(),
+                keys.ed_sk0.size(),
+                base_dest.sent_timestamp_ms,
+                &base_dest.recipient_pubkey,
+                user_pro_ed_sk.data(),
+                user_pro_ed_sk.size(),
+                error,
+                sizeof(error));
+        REQUIRE(encrypt_result.error_len_incl_null_terminator == 0);
+
+        span_u8 key = {keys.ed_sk1.data(), keys.ed_sk1.size()};
+        session_protocol_decode_envelope_keys decrypt_keys = {};
+        decrypt_keys.decrypt_keys = &key;
+        decrypt_keys.decrypt_keys_len = 1;
+        session_protocol_decoded_envelope decrypt_result = session_protocol_decode_envelope(
+                &decrypt_keys,
+                encrypt_result.ciphertext.data,
+                encrypt_result.ciphertext.size,
+                pro_backend_ed_pk.data(),
+                pro_backend_ed_pk.size(),
+                error,
+                sizeof(error));
+        // The message is delivered rather than silently swallowed by the unknown version...
+        REQUIRE(decrypt_result.success);
+        REQUIRE(decrypt_result.error_len_incl_null_terminator == 0);
+        session_protocol_encode_for_destination_free(&encrypt_result);
+
+        // ...but the proof degrades to non-pro with an explicit "unsupported version" status.
+        REQUIRE(decrypt_result.pro.status == SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION);
+
+        // The underlying message content survives intact.
+        SessionProtos::Content decrypt_content = {};
+        REQUIRE(decrypt_content.ParseFromArray(
+                decrypt_result.content_plaintext.data, decrypt_result.content_plaintext.size));
+        REQUIRE(decrypt_content.has_datamessage());
+        REQUIRE(decrypt_content.datamessage().body() == data_body);
         session_protocol_decode_envelope_free(&decrypt_result);
     }
 

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -31,7 +31,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
         std::chrono::sys_seconds pro_expiry_at,
         session_protocol_pro_message_bitset msg_bitset,
         session_protocol_pro_profile_bitset profile_bitset,
-        uint32_t proof_version = static_cast<uint32_t>(session::ProProofVersion::v0)) {
+        bool omit_proof = false) {
     SerialisedProtobufContentWithProForTesting result = {};
 
     // Create protobuf `Content.dataMessage`
@@ -62,14 +62,20 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
     pro->set_msgbitset(msg_bitset.data);
 
     // Create protobuf `Content.proMessage.proof`
-    SessionProtos::ProProof* proto_proof = pro->mutable_proof();
-    proto_proof->set_version(proof_version);
-    proto_proof->set_revocationtag(
-            result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
-    proto_proof->set_rotatingpublickey(
-            result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());
-    proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_at));
-    proto_proof->set_sig(result.proof.sig.data(), result.proof.sig.size());
+    //
+    // `omit_proof` leaves it out entirely, which is what a proof this client cannot read looks like
+    // from here: a new proof format arrives as its own field rather than as a version bump on this
+    // one, so an old client simply finds no `proof`. Everything below (serialise, pad, sign) is
+    // deliberately shared with the normal case -- the message itself is unchanged.
+    if (!omit_proof) {
+        SessionProtos::ProProof* proto_proof = pro->mutable_proof();
+        proto_proof->set_revocationtag(
+                result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
+        proto_proof->set_rotatingpublickey(
+                result.proof.rotating_pubkey.data(), result.proof.rotating_pubkey.size());
+        proto_proof->set_expiryunixts(session::epoch_seconds(result.proof.expiry_at));
+        proto_proof->set_sig(result.proof.sig.data(), result.proof.sig.size());
+    }
 
     // Generate the plaintext
     result.plaintext = content.SerializeAsString();
@@ -403,8 +409,9 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
         session_protocol_decode_envelope_free(&decrypt_result);
     }
 
-    SECTION("A future/unknown proof version degrades to non-pro, not a dropped message") {
-        // Same message, but the embedded proof claims a version this client doesn't understand.
+    SECTION("A proof we cannot read degrades to non-pro, not a dropped message") {
+        // Same message, but with no proof this client can read -- what a future proof format looks
+        // like from here, since a new format is a new field rather than a version bump.
         SerialisedProtobufContentWithProForTesting future_content =
                 build_protobuf_content_with_session_pro(
                         /*data_body*/ data_body,
@@ -414,7 +421,7 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                         /*pro_expiry_at*/ timestamp_s,
                         /*msg_bitset*/ {},
                         /*profile_bitset*/ {},
-                        /*proof_version*/ 99);
+                        /*omit_proof*/ true);
 
         session_protocol_encoded_for_destination encrypt_result = session_protocol_encode_for_1o1(
                 future_content.plaintext.data(),
@@ -441,13 +448,13 @@ TEST_CASE("Session protocol helpers C API", "[session-protocol][helpers]") {
                 pro_backend_ed_pk.size(),
                 error,
                 sizeof(error));
-        // The message is delivered rather than silently swallowed by the unknown version...
+        // The message is delivered rather than silently swallowed by the unreadable proof...
         REQUIRE(decrypt_result.success);
         REQUIRE(decrypt_result.error_len_incl_null_terminator == 0);
         session_protocol_encode_for_destination_free(&encrypt_result);
 
-        // ...but the proof degrades to non-pro with an explicit "unsupported version" status.
-        REQUIRE(decrypt_result.pro.status == SESSION_PROTOCOL_PRO_STATUS_UNSUPPORTED_VERSION);
+        // ...but with nothing to evaluate the proof is flagged invalid, i.e. non-pro.
+        REQUIRE(decrypt_result.pro.status == SESSION_PROTOCOL_PRO_STATUS_INVALID);
 
         // The underlying message content survives intact.
         SessionProtos::Content decrypt_content = {};

--- a/tests/test_session_protocol.cpp
+++ b/tests/test_session_protocol.cpp
@@ -62,7 +62,7 @@ static SerialisedProtobufContentWithProForTesting build_protobuf_content_with_se
 
     // Create protobuf `Content.proMessage.proof`
     SessionProtos::ProProof* proto_proof = pro->mutable_proof();
-    proto_proof->set_version(result.proof.version);
+    proto_proof->set_version(static_cast<std::uint32_t>(session::ProProofVersion::v0));
     proto_proof->set_revocationtag(
             result.proof.revocation_tag.data(), result.proof.revocation_tag.size());
     proto_proof->set_rotatingpublickey(


### PR DESCRIPTION
A `version` field into the ProProof structure that goes to the backend was not usable: it could not meaningfully change it from the existing endpoint without breaking all clients.  This simplifies it: the "ProProof" is implicitly a "v0" identified by the endpoint invoked (`generate_pro_proof`).  If we need to change the proof structure, that will have to go via some new endpoint (e.g. `generate_pro_proof_v2`) that a client would only call if it supports and expects a "v2" proof.

This commit them removes this useless version field (which pro-backend will stop sending soon) and just makes "v0" part of the type, rather than a separate field.

Note that v0 *is* still a part of the protobuf, because that is inherent extendable and is (probably) how a future version would carry it, but C++ structs just don't map to that, and so this removes it on the C++ side that doesn't need or want it.

Needed before clients can speak with the pro-backend with <https://github.com/session-foundation/session-pro-backend/pull/21> deployed.