### PR TITLE
quic: actually apply disable_mtu_discovery when the config asks for it

### DIFF
--- a/src/network/transport/quic_transport.cpp
+++ b/src/network/transport/quic_transport.cpp
@@ -145,10 +145,13 @@ void QuicTransport::send_request(Request request, network_response_callback_t ca
 // MARK: Internal Logic
 
 void QuicTransport::_recreate_endpoint() {
+    // The optional must CONTAIN the option to have any effect: libquic's optional-taking
+    // handle_ep_opt overload does nothing when the optional is empty, so a default-constructed
+    // std::optional<disable_mtu_discovery>{} silently leaves discovery enabled.
     _endpoint = quic::Endpoint::endpoint(
             *_loop,
             quic::Address{},
-            (_config.disable_mtu_discovery ? std::optional<quic::opt::disable_mtu_discovery>{}
+            (_config.disable_mtu_discovery ? std::make_optional<quic::opt::disable_mtu_discovery>()
                                            : std::nullopt));
 }
 


### PR DESCRIPTION
### The bug

Both arms of the ternary in `QuicTransport::_recreate_endpoint` produced an **empty** `std::optional`:

```cpp
(_config.disable_mtu_discovery ? std::optional<quic::opt::disable_mtu_discovery>{}
                               : std::nullopt)
```

libquic's optional-taking overload does nothing when the optional is empty — from `endpoint.hpp`:

```cpp
// Takes a std::optional-wrapped option that does nothing if the optional is empty, …
template <typename Opt>
void handle_ep_opt(std::optional<Opt> option)
{
    if (option)
        handle_ep_opt(std::move(*option));
}
```

So `quic_disable_mtu_discovery` has had no effect since it was introduced in 8c09031e, and no client
could switch MTU discovery off.

### Why it matters

MTU discovery used to be disabled unconditionally in `Network::get_endpoint` — added in 795b47a8 with
the note *"caused issues with some networks"*. That call site went away with the old network code in
3f681767 (2025-09-08), and the config option meant to replace it never worked. Net effect: discovery has
been enabled for every client since then.

That reproduces a recurring support pattern: MTU probing uses oversized datagrams, which reduced-MTU
paths (tunnelled and IPv6-transition mobile carriers, commonly 1400–1428) black-hole rather than reject,
so sending fails on cellular while Wi-Fi is fine. TCP transports get MSS clamping and kernel
black-hole detection for free; QUIC has to probe for itself.

### The change

`std::make_optional<quic::opt::disable_mtu_discovery>()` in the true arm, plus a comment recording the
invariant so the empty-optional form isn't reintroduced.

**The default stays `false`** — this restores the switch, it does not flip it. Clients that want
discovery off must set `quic_disable_mtu_discovery` explicitly.

### Testing

The semantics were checked with a standalone reproduction of libquic's `handle_ep_opt(std::optional<Opt>)`
and both spellings:

```
OLD  disable=0 -> applied=0     NEW  disable=0 -> applied=0
OLD  disable=1 -> applied=0     NEW  disable=1 -> applied=1
```

confirming the old form was a silent no-op even when asked for. That is not a substitute for a full
build of this library, which has not been run here.