### PR TITLE
Carry the file server port in generated download urls

### DIFF
--- a/include/session/network/backends/session_file_server.h
+++ b/include/session/network/backends/session_file_server.h
@@ -14,6 +14,7 @@ extern "C" {
 typedef struct file_server_parsed_download_url {
     char scheme[8];              // "http" or "https" + null
     char host[254];              // 253 max valid DNS length + null
+    uint16_t port;               // 0 if the url stated none, meaning the scheme's default
     char file_id[65];            // id + null terminator
     char custom_pubkey_hex[65];  // 64 hex chars + null terminator, empty string if not present
     bool wants_stream_decryption;
@@ -41,6 +42,8 @@ LIBSESSION_EXPORT bool session_file_server_parse_download_url(
 /// - `scheme` -- [in] the scheme for the target file server, uses the default file server scheme if
 /// null.
 /// - `host` -- [in] the host for the target file server, uses the default file server host if null.
+/// - `port` -- [in] the port for the target file server, uses the default file server port if 0. Only
+/// written into the url when the scheme does not already imply it.
 /// - `pubkey_hex` -- [in] the pubkey for the target file server (in hex), uses the default file
 /// server pubkey if null.
 /// - `use_stream_encryption` -- [in] flag indicating whether the file should use stream encryption.
@@ -54,6 +57,7 @@ LIBSESSION_EXPORT bool session_file_server_generate_download_url(
         const char* file_id,
         const char* scheme,
         const char* host,
+        uint16_t port,
         const char* pubkey_hex,
         bool use_stream_encryption,
         char* out_url,

--- a/include/session/network/backends/session_file_server.h
+++ b/include/session/network/backends/session_file_server.h
@@ -42,8 +42,8 @@ LIBSESSION_EXPORT bool session_file_server_parse_download_url(
 /// - `scheme` -- [in] the scheme for the target file server, uses the default file server scheme if
 /// null.
 /// - `host` -- [in] the host for the target file server, uses the default file server host if null.
-/// - `port` -- [in] the port for the target file server, uses the default file server port if 0. Only
-/// written into the url when the scheme does not already imply it.
+/// - `port` -- [in] the port for the target file server, uses the default file server port if 0.
+/// Only written into the url when the scheme does not already imply it.
 /// - `pubkey_hex` -- [in] the pubkey for the target file server (in hex), uses the default file
 /// server pubkey if null.
 /// - `use_stream_encryption` -- [in] flag indicating whether the file should use stream encryption.

--- a/include/session/network/backends/session_file_server.hpp
+++ b/include/session/network/backends/session_file_server.hpp
@@ -23,6 +23,7 @@ extern const config::FileServer DEFAULT_CONFIG;
 struct DownloadInfo {
     std::string scheme;
     std::string host;
+    std::optional<uint16_t> port;  // Set only when the url stated one explicitly
     std::string file_id;
     std::optional<std::string> custom_pubkey_hex;  // If 'p' fragment present
     bool wants_stream_decryption;                  // If 'd' fragment present

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -73,7 +73,23 @@ std::optional<DownloadInfo> parse_download_url(std::string_view url) {
         return std::nullopt;
 
     info.scheme = std::string{match->base.substr(0, scheme_end)};
-    info.host = match->base.substr(scheme_end + 3);
+
+    // `to_request` builds a `ServerDestination` from host and port SEPARATELY, so a port left inside
+    // the host reaches the network layer as a valid-looking hostname pointing nowhere.
+    auto authority = match->base.substr(scheme_end + 3);
+    auto port_sep = authority.rfind(':');
+
+    if (port_sep != std::string_view::npos) {
+        // `parse_int` requires the WHOLE string to be consumed, so an authority that merely contains
+        // a colon keeps it as part of the host.
+        uint16_t parsed_port = 0;
+        if (quic::parse_int(authority.substr(port_sep + 1), parsed_port) && parsed_port != 0) {
+            info.port = parsed_port;
+            authority = authority.substr(0, port_sep);
+        }
+    }
+
+    info.host = std::string{authority};
     info.wants_stream_decryption = false;
 
     // Parse fragments if present (p=... and/or d)
@@ -98,13 +114,25 @@ std::optional<DownloadInfo> parse_download_url(std::string_view url) {
     return info;
 }
 
+// The port a url does not need to state, because the scheme already implies it.
+static uint16_t default_port_for_scheme(std::string_view scheme) {
+    return (scheme == "https" ? 443 : 80);
+}
+
 std::string generate_download_url(std::string_view file_id, const config::FileServer& config) {
     const auto has_custom_pubkey = (config.pubkey_hex != file_server::DEFAULT_CONFIG.pubkey_hex);
 
+    // Omitted when the scheme already implies it, so urls for the default file server are
+    // byte-identical to those any other client produces for it.
+    const auto port_suffix =
+            (config.port == default_port_for_scheme(config.scheme) ? ""
+                                                                   : fmt::format(":{}", config.port));
+
     auto buf = fmt::format(
-            "{}://{}/{}",
+            "{}://{}{}/{}",
             config.scheme,
             config.host,
+            port_suffix,
             fmt::format(file_server::ENDPOINT_FILE_INDIVIDUAL, file_id));
 
     if (config.use_stream_encryption || has_custom_pubkey) {
@@ -203,13 +231,17 @@ Request to_request(
             (download_info->custom_pubkey_hex.has_value() ? *download_info->custom_pubkey_hex
                                                           : config.pubkey_hex);
 
+    // The url's port, not the local config's: the file lives on the SENDER's file server, which the
+    // recipient may never have heard of.
+    uint16_t port = download_info->port.value_or(config.port);
+
     return Request{
             download_id,
             ServerDestination{
                     std::move(scheme),
                     std::move(host),
                     x25519_pubkey::from_hex(std::move(pubkey_hex)),
-                    config.port,
+                    port,
                     std::nullopt,
                     "GET"},
             fmt::format("{}/{}", file_server::ENDPOINT_FILE, file_id),
@@ -369,6 +401,7 @@ LIBSESSION_C_API bool session_file_server_parse_download_url(
 
     copy(out->scheme, info->scheme);
     copy(out->host, info->host);
+    out->port = info->port.value_or(0);  // 0 means the scheme's default
     copy(out->file_id, info->file_id);
     copy(out->custom_pubkey_hex, info->custom_pubkey_hex.value_or(""));
     out->wants_stream_decryption = info->wants_stream_decryption;
@@ -379,6 +412,7 @@ LIBSESSION_C_API bool session_file_server_generate_download_url(
         const char* file_id,
         const char* scheme,
         const char* host,
+        uint16_t port,
         const char* pubkey_hex,
         bool use_stream_encryption,
         char* out_url,
@@ -391,6 +425,8 @@ LIBSESSION_C_API bool session_file_server_generate_download_url(
         config.scheme = scheme;
     if (host)
         config.host = host;
+    if (port != 0)
+        config.port = port;
     if (pubkey_hex)
         config.pubkey_hex = pubkey_hex;
     config.use_stream_encryption = use_stream_encryption;

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -80,8 +80,9 @@ std::optional<DownloadInfo> parse_download_url(std::string_view url) {
     auto port_sep = authority.rfind(':');
 
     if (port_sep != std::string_view::npos) {
-        // `parse_int` requires the WHOLE string to be consumed, so an authority that merely contains
-        // a colon keeps it as part of the host.
+        // An IPv6 literal is full of colons, so the LAST one is only a port separator when what follows
+        // it is a number. `parse_int` requires the whole string to be consumed, which is what makes
+        // `[::1]` keep its colons and `[::1]:8000` give up just the port.
         uint16_t parsed_port = 0;
         if (quic::parse_int(authority.substr(port_sep + 1), parsed_port) && parsed_port != 0) {
             info.port = parsed_port;

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -74,15 +74,15 @@ std::optional<DownloadInfo> parse_download_url(std::string_view url) {
 
     info.scheme = std::string{match->base.substr(0, scheme_end)};
 
-    // `to_request` builds a `ServerDestination` from host and port SEPARATELY, so a port left inside
-    // the host reaches the network layer as a valid-looking hostname pointing nowhere.
+    // `to_request` builds a `ServerDestination` from host and port SEPARATELY, so a port left
+    // inside the host reaches the network layer as a valid-looking hostname pointing nowhere.
     auto authority = match->base.substr(scheme_end + 3);
     auto port_sep = authority.rfind(':');
 
     if (port_sep != std::string_view::npos) {
-        // An IPv6 literal is full of colons, so the LAST one is only a port separator when what follows
-        // it is a number. `parse_int` requires the whole string to be consumed, which is what makes
-        // `[::1]` keep its colons and `[::1]:8000` give up just the port.
+        // An IPv6 literal is full of colons, so the last one separates a port only when a number
+        // follows it. `parse_int` must consume the whole string, which is what lets `[::1]` keep
+        // its colons while `[::1]:8000` gives up just the port.
         uint16_t parsed_port = 0;
         if (quic::parse_int(authority.substr(port_sep + 1), parsed_port) && parsed_port != 0) {
             info.port = parsed_port;
@@ -126,8 +126,9 @@ std::string generate_download_url(std::string_view file_id, const config::FileSe
     // Omitted when the scheme already implies it, so urls for the default file server are
     // byte-identical to those any other client produces for it.
     const auto port_suffix =
-            (config.port == default_port_for_scheme(config.scheme) ? ""
-                                                                   : fmt::format(":{}", config.port));
+            (config.port == default_port_for_scheme(config.scheme)
+                     ? ""
+                     : fmt::format(":{}", config.port));
 
     auto buf = fmt::format(
             "{}://{}{}/{}",

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -176,9 +176,16 @@ TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
     CHECK(parsed->host == "example.com"sv);
     CHECK_FALSE(parsed->port.has_value());
 
-    // A colon that is not a port leaves the host alone
-    parsed = file_server::parse_download_url("http://example.com:notaport/file/abc123"sv);
+    // An IPv6 literal keeps every colon it came with: the trailing one is a port separator only when a
+    // number follows it, which is the case the whole-string `parse_int` above exists to distinguish.
+    parsed = file_server::parse_download_url("http://[::1]/file/abc123"sv);
     REQUIRE(parsed.has_value());
-    CHECK(parsed->host == "example.com:notaport"sv);
+    CHECK(parsed->host == "[::1]"sv);
     CHECK_FALSE(parsed->port.has_value());
+
+    parsed = file_server::parse_download_url("http://[::1]:8000/file/abc123"sv);
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->host == "[::1]"sv);
+    REQUIRE(parsed->port.has_value());
+    CHECK(*parsed->port == 8000);
 }

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Download url generation", "[backend][session_file_server]") {
              12345,
              true});
     CHECK(url ==
-          "http://example.com/file/"
+          "http://example.com:123/file/"
           "abc123#p=0123456789abcdef0123456789abcdef00000000000000000000000000000000&d");
 
     // Omits the stream encryption fragment when disabled
@@ -111,24 +111,74 @@ TEST_CASE("Download url generation", "[backend][session_file_server]") {
              12345,
              false});
     CHECK(url ==
-          "http://example.com/file/"
+          "http://example.com:123/file/"
           "abc123#p=0123456789abcdef0123456789abcdef00000000000000000000000000000000");
 
     // Omits the pubkey when it matches the default pubkey
     url = file_server::generate_download_url(
             "abc123"sv,
             {"http", "example.com", 123, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, true});
-    CHECK(url == "http://example.com/file/abc123#d");
+    CHECK(url == "http://example.com:123/file/abc123#d");
 
     // Omits all fragments when stream encryption is disabled and the default pubkey is used
     url = file_server::generate_download_url(
             "abc123"sv,
             {"http", "example.com", 123, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, false});
-    CHECK(url == "http://example.com/file/abc123");
+    CHECK(url == "http://example.com:123/file/abc123");
 
     // Works with other values
     url = file_server::generate_download_url(
             "12345678"sv,
             {"https", "example2.com", 321, file_server::DEFAULT_CONFIG.pubkey_hex, 54321, false});
-    CHECK(url == "https://example2.com/file/12345678");
+    CHECK(url == "https://example2.com:321/file/12345678");
+
+    // Omits the port when the scheme already implies it, so urls for a default-port server are
+    // unchanged from every previous version
+    url = file_server::generate_download_url(
+            "abc123"sv, {"http", "example.com", 80, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, false});
+    CHECK(url == "http://example.com/file/abc123");
+
+    url = file_server::generate_download_url(
+            "abc123"sv,
+            {"https", "example.com", 443, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, false});
+    CHECK(url == "https://example.com/file/abc123");
+
+    // The default file server is unaffected
+    url = file_server::generate_download_url("abc123"sv, file_server::DEFAULT_CONFIG);
+    CHECK(url == fmt::format("http://{}/file/abc123", file_server::DEFAULT_CONFIG.host));
+}
+
+TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
+    // A self-hosted file server on a non-default port. Dropping the port here sent every recipient to
+    // 80/443, which returns a response rather than an error -- so it surfaced as an undecryptable
+    // attachment, far from its cause.
+    constexpr auto custom_pubkey =
+            "0123456789abcdef0123456789abcdef00000000000000000000000000000000"sv;
+    auto url = file_server::generate_download_url(
+            "abc123"sv, {"http", "192.168.1.2", 8000, std::string{custom_pubkey}, 12345, false});
+    CHECK(url == fmt::format("http://192.168.1.2:8000/file/abc123#p={}", custom_pubkey));
+
+    auto parsed = file_server::parse_download_url(url);
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->scheme == "http"sv);
+    // The port is split OUT of the host: `to_request` builds a destination from the two separately, so
+    // a host still carrying ":8000" would be a valid-looking hostname pointing nowhere.
+    CHECK(parsed->host == "192.168.1.2"sv);
+    REQUIRE(parsed->port.has_value());
+    CHECK(*parsed->port == 8000);
+    CHECK(parsed->file_id == "abc123"sv);
+    REQUIRE(parsed->custom_pubkey_hex.has_value());
+    CHECK(*parsed->custom_pubkey_hex == custom_pubkey);
+
+    // No explicit port stays absent rather than being invented, so the caller's default applies
+    parsed = file_server::parse_download_url("https://example.com/file/abc123"sv);
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->host == "example.com"sv);
+    CHECK_FALSE(parsed->port.has_value());
+
+    // A colon that is not a port leaves the host alone
+    parsed = file_server::parse_download_url("http://example.com:notaport/file/abc123"sv);
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->host == "example.com:notaport"sv);
+    CHECK_FALSE(parsed->port.has_value());
 }

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -135,7 +135,8 @@ TEST_CASE("Download url generation", "[backend][session_file_server]") {
     // Omits the port when the scheme already implies it, so urls for a default-port server are
     // unchanged from every previous version
     url = file_server::generate_download_url(
-            "abc123"sv, {"http", "example.com", 80, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, false});
+            "abc123"sv,
+            {"http", "example.com", 80, file_server::DEFAULT_CONFIG.pubkey_hex, 12345, false});
     CHECK(url == "http://example.com/file/abc123");
 
     url = file_server::generate_download_url(
@@ -149,9 +150,9 @@ TEST_CASE("Download url generation", "[backend][session_file_server]") {
 }
 
 TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
-    // A self-hosted file server on a non-default port. Dropping the port here sent every recipient to
-    // 80/443, which returns a response rather than an error -- so it surfaced as an undecryptable
-    // attachment, far from its cause.
+    // A self-hosted file server on a non-default port. Dropping the port here sent every recipient
+    // to 80/443, which returns a response rather than an error -- so it surfaced as an
+    // undecryptable attachment, far from its cause.
     constexpr auto custom_pubkey =
             "0123456789abcdef0123456789abcdef00000000000000000000000000000000"sv;
     auto url = file_server::generate_download_url(
@@ -161,8 +162,8 @@ TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
     auto parsed = file_server::parse_download_url(url);
     REQUIRE(parsed.has_value());
     CHECK(parsed->scheme == "http"sv);
-    // The port is split OUT of the host: `to_request` builds a destination from the two separately, so
-    // a host still carrying ":8000" would be a valid-looking hostname pointing nowhere.
+    // The port is split OUT of the host: `to_request` builds a destination from the two separately,
+    // so a host still carrying ":8000" would be a valid-looking hostname pointing nowhere.
     CHECK(parsed->host == "192.168.1.2"sv);
     REQUIRE(parsed->port.has_value());
     CHECK(*parsed->port == 8000);
@@ -176,8 +177,9 @@ TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
     CHECK(parsed->host == "example.com"sv);
     CHECK_FALSE(parsed->port.has_value());
 
-    // An IPv6 literal keeps every colon it came with: the trailing one is a port separator only when a
-    // number follows it, which is the case the whole-string `parse_int` above exists to distinguish.
+    // An IPv6 literal keeps every colon it came with: the trailing one is a port separator only
+    // when a number follows it, which is the case the whole-string `parse_int` above exists to
+    // distinguish.
     parsed = file_server::parse_download_url("http://[::1]/file/abc123"sv);
     REQUIRE(parsed.has_value());
     CHECK(parsed->host == "[::1]"sv);


### PR DESCRIPTION
`generate_download_url` formats `{}://{}/{}` and never uses `config.port`, so a download url for a file server on a non-default port points at 80/443 instead.

It is worse than a broken link: fetching the scheme's default port returns *a* response, just not the file — so it surfaces as an **undecryptable attachment** rather than a connection error, a long way from the cause.

### Three places, not one

The omission is symmetrical, and fixing only the formatter would have left it half-broken:

1. **`generate_download_url`** — emits `:port`, but only when the scheme does not already imply it (80 for http, 443 for https). Urls for the default file server are byte-identical to every previous version.
2. **`parse_download_url`** — `DownloadInfo` had no port at all, and `info.host` took *everything* after `://`, so a port would have ended up inside the hostname. It is now split out, and only a fully-consumed, non-zero number is treated as one.
3. **`to_request`** — took the host from the url but the port from **local** config, so a recipient downloading from someone else's file server used whichever port *it* happened to be configured for. The url's port now wins.

Both are 80 for the default server, which is why none of this has ever shown up.

### C API

`session_file_server_generate_download_url` gains a `port` parameter (0 meaning "the scheme's default"), and `file_server_parsed_download_url` gains a `port` field. The API had no way to express a port, so a caller holding the right one could not pass it — Session iOS's `generateDownloadUrl` was already being handed the port by `withCustomFileServer` and discarding it with `_`.

**This is a breaking signature change.** Session iOS is updated in a companion PR; Android's JNI and Desktop's node bindings call the same symbol and will need the same one-line addition. If that is unacceptable, the alternative is keeping the old symbol and adding a `_with_port` variant.

### Note for reviewers: four existing tests asserted the bug

Every case in "Download url generation" built a config with `port = 123` and expected the port **absent** from the url. Those expectations are corrected here, plus new coverage for the default-port omission, a full round trip on `192.168.1.2:8000`, and a colon that is not a port. If you rebase and see four generation failures, that is what they are.

### Verification

The libSession host unit build does not work on the machine this was found on (static deps fail under Apple clang 17 with `-mmacosx-version-min=10.15`; the system-deps path wants `libngtcp2_crypto_gnutls`), so **the tests here have not been executed** — they are written to the corrected behaviour and want running by someone with a working host build.

It is verified end-to-end instead, through the Session Appium suite: the url in the receiving client's log went from `http://192.168.139.2/file/…` to `http://192.168.139.2:8000/file/…` across this change, and the download then succeeded.


## Unit suite

Run by the `stream-encryption` agent, whose environment has a working host build: **110 assertions across 5 test cases, all passing**, with their `#d=` cases applied on top of #135. Their baseline was 92 assertions with those cases alone on `dev`, so #134's corrected generation tests are in and passing rather than merely compiling.

The linked code was probed rather than trusted, since a stale object would have produced a plausible count:

```
DEFAULT pubkey_hex : b8eef9821445ae16e2e97ef8aa6fe782fd11ad5253cd6723b281341dba22e371   <- #135
url with port 8000 : http://example.com:8000/file/abc123#p=...&d                        <- #134
parsed port        : 8000                                                               <- #134
```

Their method also sidesteps the host static-deps build that blocked the author: compile the test files and link against the prebuilt archives in a checkout that already has a `build/`, putting the changed source file's object **before** the archives on the link line so it wins over the stale archive member.

libsession-util#136 touches the same test file and merges cleanly with this (different regions, `git apply --3way`).
