### PR TITLE
Treat the file server pubkey as Ed25519, as Android and Desktop do

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(libsession-util
-    VERSION 1.8.0
+    VERSION 1.9.0
     DESCRIPTION "Session client utility library"
     LANGUAGES ${LANGS})
 

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -8,6 +8,8 @@
 
 #include "../session_network_internal.hpp"
 #include "session/blinding.hpp"
+#include "session/network/key_types.hpp"
+#include "session/util.hpp"
 #include "session/network/backends/backend_util.hpp"
 #include "session/network/backends/session_file_server.h"
 #include "session/random.hpp"
@@ -30,7 +32,13 @@ const config::FileServer DEFAULT_CONFIG = {
         .scheme = "http",
         .host = "filev2.getsession.org",
         .port = 80,
-        .pubkey_hex = "da21e1d886c6fbaea313f75298bd64aab03a97ce985b46bb2dad9f2089c8ee59",
+        // ED25519. `p=` in a download url carries the Ed form on every client, and the X25519 form
+        // for onion requests is derived from it.
+        //
+        // NOT the file server's X25519-only key (`da21e1d886c6...ee59`), which cannot be used here:
+        // it has no Ed private key and cannot be given one, since deriving Ed from X would mean
+        // reversing a hash. A file server has to publish a real Ed keypair to be addressable this way.
+        .pubkey_hex = "b8eef9821445ae16e2e97ef8aa6fe782fd11ad5253cd6723b281341dba22e371",
         .max_file_size = 10'000'000};
 
 constexpr std::string_view HEADER_CONTENT_TYPE = "Content-Type";
@@ -206,7 +214,7 @@ Request to_request(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    x25519_pubkey::from_hex(config.pubkey_hex),
+                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -242,7 +250,7 @@ Request to_request(
             ServerDestination{
                     std::move(scheme),
                     std::move(host),
-                    x25519_pubkey::from_hex(std::move(pubkey_hex)),
+                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(pubkey_hex))),
                     port,
                     std::nullopt,
                     "GET"},
@@ -324,7 +332,7 @@ Request extend_ttl(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    x25519_pubkey::from_hex(config.pubkey_hex),
+                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -352,7 +360,7 @@ Request get_client_version(
     auto blinded_keys = blind_version_key_pair(to_span(seckey.view()));
     auto timestamp = epoch_seconds(std::chrono::system_clock::now());
     auto signature = blind_version_sign(to_span(seckey.view()), platform, timestamp);
-    auto pubkey = x25519_pubkey::from_hex(DEFAULT_CONFIG.pubkey_hex);
+    auto pubkey = compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(DEFAULT_CONFIG.pubkey_hex)));
     std::string blinded_pk_hex;
     blinded_pk_hex.reserve(66);
     blinded_pk_hex += "07";

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -8,11 +8,11 @@
 
 #include "../session_network_internal.hpp"
 #include "session/blinding.hpp"
-#include "session/network/key_types.hpp"
-#include "session/util.hpp"
 #include "session/network/backends/backend_util.hpp"
 #include "session/network/backends/session_file_server.h"
+#include "session/network/key_types.hpp"
 #include "session/random.hpp"
+#include "session/util.hpp"
 
 #if defined(__APPLE__) || !defined(__cpp_lib_chrono) || __cpp_lib_chrono < 201907L || \
         (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 190000)
@@ -37,7 +37,8 @@ const config::FileServer DEFAULT_CONFIG = {
         //
         // NOT the file server's X25519-only key (`da21e1d886c6...ee59`), which cannot be used here:
         // it has no Ed private key and cannot be given one, since deriving Ed from X would mean
-        // reversing a hash. A file server has to publish a real Ed keypair to be addressable this way.
+        // reversing a hash. A file server has to publish a real Ed keypair to be addressable this
+        // way.
         .pubkey_hex = "b8eef9821445ae16e2e97ef8aa6fe782fd11ad5253cd6723b281341dba22e371",
         .max_file_size = 10'000'000};
 
@@ -214,7 +215,8 @@ Request to_request(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
+                    compute_x25519_pubkey(
+                            to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -332,7 +334,8 @@ Request extend_ttl(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
+                    compute_x25519_pubkey(
+                            to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -360,7 +363,8 @@ Request get_client_version(
     auto blinded_keys = blind_version_key_pair(to_span(seckey.view()));
     auto timestamp = epoch_seconds(std::chrono::system_clock::now());
     auto signature = blind_version_sign(to_span(seckey.view()), platform, timestamp);
-    auto pubkey = compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(DEFAULT_CONFIG.pubkey_hex)));
+    auto pubkey = compute_x25519_pubkey(
+            to_span<unsigned char>(oxenc::from_hex(DEFAULT_CONFIG.pubkey_hex)));
     std::string blinded_pk_hex;
     blinded_pk_hex.reserve(66);
     blinded_pk_hex += "07";

--- a/src/network/session_network.cpp
+++ b/src/network/session_network.cpp
@@ -35,9 +35,6 @@ namespace {
 
     inline auto cat = log::Cat("network");
 
-    constexpr auto file_server = "filev2.getsession.org"sv;
-    constexpr auto file_server_pubkey =
-            "da21e1d886c6fbaea313f75298bd64aab03a97ce985b46bb2dad9f2089c8ee59"sv;
     constexpr auto clock_out_of_sync_error = "Clock out of sync";
 
     config::FileServer build_file_server_config(const config::Config& main_config) {

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <session/network/backends/session_file_server.hpp>
+#include <session/util.hpp>
 
 #include "utils.hpp"
 
@@ -205,4 +206,15 @@ TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
     CHECK(parsed->host == "[::1]"sv);
     REQUIRE(parsed->port.has_value());
     CHECK(*parsed->port == 8000);
+}
+
+TEST_CASE("Default file server onion pubkey", "[backend][session_file_server]") {
+    // A download url carries the file server's ED25519 key, while an onion request needs the X25519
+    // form, so every request derives one from the other. Pinned here because the two forms are 32 bytes
+    // either way: using the wrong one produces a perfectly well-formed key that simply never decrypts,
+    // and the only symptom is the file server rejecting the request without naming a key.
+    const auto derived = compute_x25519_pubkey(
+            session::to_span<unsigned char>(oxenc::from_hex(file_server::DEFAULT_CONFIG.pubkey_hex)));
+
+    CHECK(derived.hex() == "09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34");
 }

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -210,11 +210,11 @@ TEST_CASE("Download url port round trip", "[backend][session_file_server]") {
 
 TEST_CASE("Default file server onion pubkey", "[backend][session_file_server]") {
     // A download url carries the file server's ED25519 key, while an onion request needs the X25519
-    // form, so every request derives one from the other. Pinned here because the two forms are 32 bytes
-    // either way: using the wrong one produces a perfectly well-formed key that simply never decrypts,
-    // and the only symptom is the file server rejecting the request without naming a key.
-    const auto derived = compute_x25519_pubkey(
-            session::to_span<unsigned char>(oxenc::from_hex(file_server::DEFAULT_CONFIG.pubkey_hex)));
+    // form, so every request derives one from the other. Pinned here because the two forms are 32
+    // bytes either way: using the wrong one produces a perfectly well-formed key that simply never
+    // decrypts, and the only symptom is the file server rejecting the request without naming a key.
+    const auto derived = compute_x25519_pubkey(session::to_span<unsigned char>(
+            oxenc::from_hex(file_server::DEFAULT_CONFIG.pubkey_hex)));
 
     CHECK(derived.hex() == "09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34");
 }


### PR DESCRIPTION
`p=` in a download url carries the file server's **Ed25519** key on Session Android and Session Desktop. libSession wrote and read it as **X25519** — so a url from either of them was rejected as an invalid curve point, and a url from libSession was rejected by them.

Found by a cross-client attachment test: iOS could not send an attachment to Android or Desktop, and neither could decrypt what it produced.

### The two clients agree with each other

Both store the *same* default constant and treat it the same way:

| | default file server key | `p=` written as | `p=` read as |
|---|---|---|---|
| Session Android | `b8eef98214…e371` | Ed25519 | Ed25519 |
| Session Desktop | `b8eef98214…e371` | Ed25519 | Ed25519 |
| libSession | `da21e1d886…ee59` | X25519 | X25519 |

Android derives the X25519 form itself (`FileServer.x25519PubKeyHex`); Desktop keeps both forms but writes only `edPk`. libSession is the outlier on all three axes.

### Why the constant differs, and why this can be a clean switch

`da21e1d886…ee59` is the file server's **X25519-only legacy key**. It has no Ed private key and cannot be given one — deriving Ed from X would mean reversing a hash. That is why this was not simply fixed at the time.

The file server now holds a real Ed25519 keypair and accepts both, which is what makes a clean switch possible rather than a hard-coded special case for one key:

```
File server Ed25519 pubkey: b8eef9821445ae16e2e97ef8aa6fe782fd11ad5253cd6723b281341dba22e371
... which is X25519 pubkey: 09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34
File server X25519-only pubkey: da21e1d886c6fbaea313f75298bd64aab03a97ce985b46bb2dad9f2089c8ee59
```

### What changed

- `DEFAULT_CONFIG.pubkey_hex` becomes the Ed key, and the field now *means* Ed25519.
- Onion requests still need X25519, so it is derived at each call site via the existing `compute_x25519_pubkey` rather than stored — one key in the config, one meaning for the fragment.

No back-compat for the old behaviour: nothing in circulation emits an X25519 `p=` fragment.

Stacked on #134 (the port fix) — the two were found together and the end-to-end verification needed both. Happy to rebase them apart if you would rather review them independently.

### Verification

**Every direction of the 3×3 cross-client attachment matrix passes**, on one build, including iOS↔Android which no test had exercised before:

| | | | |
|---|---|---|---|
| android → desktop | 31s | ios → desktop | 30s |
| desktop → android | 24s | desktop → ios | 38s |
| ios → android | 35s | android → ios | 47s |

The file server logs no `Failed to decrypt onion request` for any of them, which is the independent check that uploads are genuinely accepted rather than merely appearing to succeed.

**The libSession unit suite has not been run** — the host static-deps build fails on the machine this was developed on (see #134). The same dependencies build fine under the iOS toolchain, so this is verified end-to-end rather than by unit test.


## Unit suite

Run by the `stream-encryption` agent, whose environment has a working host build: **110 assertions across 5 test cases, all passing**, with their `#d=` cases applied on top of #135. Their baseline was 92 assertions with those cases alone on `dev`, so #134's corrected generation tests are in and passing rather than merely compiling.

The linked code was probed rather than trusted, since a stale object would have produced a plausible count:

```
DEFAULT pubkey_hex : b8eef9821445ae16e2e97ef8aa6fe782fd11ad5253cd6723b281341dba22e371   <- #135
url with port 8000 : http://example.com:8000/file/abc123#p=...&d                        <- #134
parsed port        : 8000                                                               <- #134
```

Their method also sidesteps the host static-deps build that blocked the author: compile the test files and link against the prebuilt archives in a checkout that already has a `build/`, putting the changed source file's object **before** the archives on the link line so it wins over the stale archive member.

libsession-util#136 touches the same test file and merges cleanly with this (different regions, `git apply --3way`).
