### PR TITLE
tests: pin that a valueless `d=` is not the stream-encryption fragment

### DIFF
--- a/tests/test_backed_session_open_group_server.cpp
+++ b/tests/test_backed_session_open_group_server.cpp
@@ -35,6 +35,14 @@ TEST_CASE("Download url parsing", "[backend][session_open_group_server]") {
     CHECK(parsed_download_url->file_id == 123);
     CHECK(parsed_download_url->wants_stream_decryption);
 
+    // A valueless `d=` is NOT the stream-encryption fragment; see the equivalent case in
+    // test_backend_session_file_server.cpp for why a client can end up writing it.
+    parsed_download_url =
+            open_group_server::parse_download_url("https://example.com/room/test/file/123/#d="sv);
+    REQUIRE(parsed_download_url.has_value());
+    CHECK(parsed_download_url->file_id == 123);
+    CHECK_FALSE(parsed_download_url->wants_stream_decryption);
+
     // Maintains the room casing
     parsed_download_url =
             open_group_server::parse_download_url("https://example.com/room/TeST/file/123"sv);

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -78,6 +78,21 @@ TEST_CASE("Download url parsing", "[backend][session_file_server]") {
           "0123456789abcdef0123456789abcdef00000000000000000000000000000000"sv);
     CHECK(parsed_download_url->wants_stream_decryption);
 
+    // A valueless `d=` is NOT the stream-encryption fragment.  Session Desktop builds its fragment
+    // with URLSearchParams, which serialises a valueless key with the `=`, so its stream-encrypted
+    // uploads are read as legacy by every client that parses the url through here.
+    parsed_download_url = file_server::parse_download_url("https://example.com/file/abc123#d="sv);
+    REQUIRE(parsed_download_url.has_value());
+    CHECK(parsed_download_url->file_id == "abc123"sv);
+    CHECK_FALSE(parsed_download_url->wants_stream_decryption);
+
+    parsed_download_url = file_server::parse_download_url(
+            "https://example.com/file/abc123#p=0123456789abcdef0123456789abcdef00000000000000000000000000000000&d="sv);
+    REQUIRE(parsed_download_url.has_value());
+    CHECK(parsed_download_url->custom_pubkey_hex ==
+          "0123456789abcdef0123456789abcdef00000000000000000000000000000000"sv);
+    CHECK_FALSE(parsed_download_url->wants_stream_decryption);
+
     // Doesn't have an issue with a legacy url
     parsed_download_url = file_server::parse_download_url(
             "http://filev2.getsession.org/files/2478430809375318"sv);


### PR DESCRIPTION
`parse_download_url` compares each fragment against `d` with string equality, so a valueless `d=` is not recognised as the stream-encryption flag. Nothing asserted that.

The distinction is not academic. Session Desktop built its fragment with `URLSearchParams`, which serialises a valueless key with the `=`, so every stream-encrypted file it uploaded was read as **legacy** by libSession-based clients — on iOS that meant the ciphertext was stored as the attachment and the download reported success. Android tolerates both spellings and has a regression test for it, which is why only iOS was affected.

Adds the case to both the file server and the open group server url tests. It pins current behaviour, so if libSession is ever taught to accept both spellings there is one line to flip rather than a silent change.

Desktop now writes the bare `d` (session-desktop#1992), so this is documenting the contract rather than blocking anything.

### Testing

Test-only; no source changes. **92 assertions in 4 test cases, all passing** on `dev`.

The host static-deps build fails under Apple clang 17, so this was run by compiling the test files and linking them against the prebuilt archives of an existing `build/` — same approach used to verify #134 and #135, both of which also pass with these cases applied (110 assertions in 5 cases).

### Note for whoever merges

#134 also edits `tests/test_backend_session_file_server.cpp`. The two apply cleanly to each other (`git apply --3way` merges without conflict — different regions), but if you would rather these cases simply rode along with #134, that is fine by me and I will close this.
