### PR TITLE
multi_encrypt: randomize empty nonce inputs

### DIFF
--- a/src/multi_encrypt.cpp
+++ b/src/multi_encrypt.cpp
@@ -139,7 +139,7 @@ std::vector<unsigned char> encrypt_for_multiple_simple(
     oxenc::bt_dict_producer d;
 
     std::array<unsigned char, 24> random_nonce;
-    if (!nonce) {
+    if (!nonce || nonce->empty()) {
         randombytes_buf(random_nonce.data(), random_nonce.size());
         nonce.emplace(random_nonce.data(), random_nonce.size());
     } else if (nonce->size() != 24) {

--- a/tests/test_multi_encrypt.cpp
+++ b/tests/test_multi_encrypt.cpp
@@ -407,3 +407,43 @@ TEST_CASE("Multi-recipient encryption, simpler interface", "[encrypt][multi][sim
             session::to_span(x_keys[0].second),
             "test suite"));
 }
+
+TEST_CASE(
+        "Multi-recipient encryption generates a nonce for empty input",
+        "[encrypt][multi][simple]") {
+    auto sender_seed = "0123456789abcdef0123456789abcdef00000000000000000000000000000000"_hexbytes;
+    auto recipient_seed =
+            "0123456789abcdef111111111111111100000000000000000000000000000000"_hexbytes;
+
+    std::array<unsigned char, 32> sender_ed_pubkey;
+    std::array<unsigned char, 64> sender_ed_secret;
+    crypto_sign_ed25519_seed_keypair(
+            sender_ed_pubkey.data(), sender_ed_secret.data(), sender_seed.data());
+
+    auto sender_x = to_x_keys(sender_seed);
+    auto recipient_x = to_x_keys(recipient_seed);
+    std::vector<std::span<const unsigned char>> recipients{session::to_span(recipient_x.second)};
+
+    auto default_nonce = session::encrypt_for_multiple_simple(
+            "hello", recipients, session::to_span(sender_ed_secret), "test suite");
+    auto empty_nonce = session::encrypt_for_multiple_simple(
+            "hello",
+            recipients,
+            session::to_span(sender_x.first),
+            session::to_span(sender_x.second),
+            "test suite",
+            std::span<const unsigned char>{});
+
+    CHECK(default_nonce != empty_nonce);
+
+    for (const auto& encrypted : {default_nonce, empty_nonce}) {
+        auto decrypted = session::decrypt_for_multiple_simple(
+                encrypted,
+                session::to_span(recipient_x.first),
+                session::to_span(recipient_x.second),
+                session::to_span(sender_x.second),
+                "test suite");
+        REQUIRE(decrypted);
+        CHECK(session::to_string(*decrypted) == "hello");
+    }
+}


### PR DESCRIPTION
## summary

`encrypt_for_multiple_simple()` documents that an omitted or empty nonce generates a random nonce, but the X25519 overload only handled an omitted optional

the Ed25519 overload defaults to an empty span, so calling it without a nonce currently throws `Invalid nonce: nonce must be 24 bytes`

this treats empty spans like omitted nonces while still rejecting non-empty values that are not 24 bytes

## tests

- `./Build-ci/tests/testAll "[encrypt][multi][simple]"`
- `./Build-ci/tests/testLogging`
- `./Build-ci/tests/testAll`
- `./Build-release/tests/testLogging`
- `./Build-release/tests/testAll`
- `./utils/format.sh verify`
