### PR TITLE
onionreq: reject truncated XChaCha20 ciphertexts

### DIFF
--- a/src/onionreq/hop_encryption.cpp
+++ b/src/onionreq/hop_encryption.cpp
@@ -211,16 +211,16 @@ std::vector<unsigned char> HopEncryption::encrypt_xchacha20(
 
 std::vector<unsigned char> HopEncryption::decrypt_xchacha20(
         std::vector<unsigned char> ciphertext_, const network::x25519_pubkey& pubKey) const {
+    if (ciphertext_.size() <
+        crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + crypto_aead_xchacha20poly1305_ietf_ABYTES)
+        throw std::invalid_argument{
+                "Invalid ciphertext: too short to contain valid encrypted data"};
+
     std::span<const unsigned char> ciphertext = to_span(ciphertext_);
 
     // Extract nonce from the beginning of the ciphertext:
     auto nonce = ciphertext.subspan(0, crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
     ciphertext = ciphertext.subspan(nonce.size());
-
-    if (!response_long_enough(EncryptType::xchacha20, ciphertext_.size()))
-        throw std::invalid_argument{
-                "Ciphertext data is too short: " +
-                std::string(reinterpret_cast<const char*>(ciphertext_.data()))};
 
     const auto key = xchacha20_shared_key(public_key_, private_key_, pubKey, !server_);
 

--- a/tests/test_onionreq.cpp
+++ b/tests/test_onionreq.cpp
@@ -42,6 +42,18 @@ TEST_CASE("Onion request encryption", "[encryption][onionreq]") {
     CHECK_THROWS(e.decrypt_aesgcm(enc_xchacha20_broken2, x25519_pubkey::from_bytes(A)));
     CHECK_THROWS(e.decrypt_xchacha20(enc_xchacha20_broken1, x25519_pubkey::from_bytes(A)));
     CHECK_THROWS(e.decrypt_xchacha20(enc_xchacha20_broken2, x25519_pubkey::from_bytes(A)));
+
+    auto enc_xchacha20_empty = e.encrypt_xchacha20({}, x25519_pubkey::from_bytes(A));
+    CHECK(enc_xchacha20_empty.size() == 24 + 16);
+    CHECK(e.decrypt_xchacha20(enc_xchacha20_empty, x25519_pubkey::from_bytes(A)).empty());
+
+    for (size_t size : {0, 1, 15, 16, 23, 24, 39}) {
+        INFO("ciphertext size: " << size);
+        CHECK_THROWS_AS(
+                e.decrypt_xchacha20(
+                        std::vector<unsigned char>(size, 0x41), x25519_pubkey::from_bytes(A)),
+                std::invalid_argument);
+    }
 }
 
 TEST_CASE("Onion request parser", "[onionreq][parser]") {


### PR DESCRIPTION
## summary

`HopEncryption::decrypt_xchacha20()` currently extracts the 24-byte nonce before checking the ciphertext length, while the existing check only requires the 16-byte authentication tag

inputs shorter than the nonce violate the `std::span::subspan()` precondition, and inputs between 24 and 39 bytes underflow the plaintext size

this validates the full nonce + tag minimum before slicing and keeps the legacy AES response fallback unchanged

## tests

- `./Build/tests/testAll "[onionreq]" --colour-mode none`
- `valgrind --quiet --error-exitcode=99 --leak-check=full ./Build/tests/testAll "Onion request encryption" --colour-mode none`
- `./Build/tests/testAll --colour-mode none`
- `./Build/tests/testLogging --colour-mode none`
- `./utils/format.sh verify`