### PR TITLE
Use fixed-size span for Ed25519 pubkey conversion

### DIFF
--- a/include/session/network/key_types.hpp
+++ b/include/session/network/key_types.hpp
@@ -98,7 +98,7 @@ using x25519_keypair = std::pair<x25519_pubkey, x25519_seckey>;
 legacy_pubkey parse_legacy_pubkey(std::string_view pubkey_in);
 ed25519_pubkey parse_ed25519_pubkey(std::string_view pubkey_in);
 x25519_pubkey parse_x25519_pubkey(std::string_view pubkey_in);
-x25519_pubkey compute_x25519_pubkey(std::span<const unsigned char> ed25519_pk);
+x25519_pubkey compute_x25519_pubkey(std::span<const unsigned char, 32> ed25519_pk);
 
 }  // namespace session::network
 

--- a/src/network/backends/session_file_server.cpp
+++ b/src/network/backends/session_file_server.cpp
@@ -215,8 +215,7 @@ Request to_request(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    compute_x25519_pubkey(
-                            to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
+                    compute_x25519_pubkey(ed25519_pubkey::from_hex(config.pubkey_hex)),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -252,7 +251,7 @@ Request to_request(
             ServerDestination{
                     std::move(scheme),
                     std::move(host),
-                    compute_x25519_pubkey(to_span<unsigned char>(oxenc::from_hex(pubkey_hex))),
+                    compute_x25519_pubkey(ed25519_pubkey::from_hex(pubkey_hex)),
                     port,
                     std::nullopt,
                     "GET"},
@@ -334,8 +333,7 @@ Request extend_ttl(
             ServerDestination{
                     config.scheme,
                     config.host,
-                    compute_x25519_pubkey(
-                            to_span<unsigned char>(oxenc::from_hex(config.pubkey_hex))),
+                    compute_x25519_pubkey(ed25519_pubkey::from_hex(config.pubkey_hex)),
                     config.port,
                     std::move(headers),
                     "POST"},
@@ -363,8 +361,7 @@ Request get_client_version(
     auto blinded_keys = blind_version_key_pair(to_span(seckey.view()));
     auto timestamp = epoch_seconds(std::chrono::system_clock::now());
     auto signature = blind_version_sign(to_span(seckey.view()), platform, timestamp);
-    auto pubkey = compute_x25519_pubkey(
-            to_span<unsigned char>(oxenc::from_hex(DEFAULT_CONFIG.pubkey_hex)));
+    auto pubkey = compute_x25519_pubkey(ed25519_pubkey::from_hex(DEFAULT_CONFIG.pubkey_hex));
     std::string blinded_pk_hex;
     blinded_pk_hex.reserve(66);
     blinded_pk_hex += "07";

--- a/src/network/key_types.cpp
+++ b/src/network/key_types.cpp
@@ -81,7 +81,7 @@ ed25519_pubkey parse_ed25519_pubkey(std::string_view pubkey_in) {
 x25519_pubkey parse_x25519_pubkey(std::string_view pubkey_in) {
     return parse_pubkey<x25519_pubkey>(pubkey_in);
 }
-x25519_pubkey compute_x25519_pubkey(std::span<const unsigned char> ed25519_pk) {
+x25519_pubkey compute_x25519_pubkey(std::span<const unsigned char, 32> ed25519_pk) {
     std::array<unsigned char, 32> xpk;
     if (0 != crypto_sign_ed25519_pk_to_curve25519(xpk.data(), ed25519_pk.data()))
         throw std::runtime_error{

--- a/src/onionreq/builder.cpp
+++ b/src/onionreq/builder.cpp
@@ -89,9 +89,8 @@ Builder::Builder(
 }
 
 void Builder::add_hop(std::span<const unsigned char> remote_key) {
-    hops_.push_back(
-            {network::ed25519_pubkey::from_bytes(remote_key),
-             network::compute_x25519_pubkey(remote_key)});
+    auto ed25519_key = network::ed25519_pubkey::from_bytes(remote_key);
+    hops_.push_back({ed25519_key, network::compute_x25519_pubkey(ed25519_key)});
 }
 
 void Builder::set_destination(network_destination destination) {

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -213,8 +213,19 @@ TEST_CASE("Default file server onion pubkey", "[backend][session_file_server]") 
     // form, so every request derives one from the other. Pinned here because the two forms are 32
     // bytes either way: using the wrong one produces a perfectly well-formed key that simply never
     // decrypts, and the only symptom is the file server rejecting the request without naming a key.
-    const auto derived = compute_x25519_pubkey(session::to_span<unsigned char>(
-            oxenc::from_hex(file_server::DEFAULT_CONFIG.pubkey_hex)));
+    const auto derived =
+            compute_x25519_pubkey(ed25519_pubkey::from_hex(file_server::DEFAULT_CONFIG.pubkey_hex));
 
     CHECK(derived.hex() == "09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34");
+}
+
+TEST_CASE("File server requests reject oversized pubkeys", "[backend][session_file_server]") {
+    auto config = file_server::DEFAULT_CONFIG;
+    config.pubkey_hex += "00";
+
+    DownloadRequest request{};
+    request.download_url = "https://example.com/file/abc123";
+
+    CHECK_THROWS_AS(
+            file_server::to_request("download", config, std::move(request)), std::runtime_error);
 }


### PR DESCRIPTION
## summary

`compute_x25519_pubkey()` now requires a 32-byte view, so dynamic spans with the wrong size cannot reach libsodium through this API accidentally

file server keys are parsed as fixed-size `ed25519_pubkey` values before conversion, rejecting oversized values that were previously accepted with trailing bytes ignored

this intentionally changes the C++ helper signature to match the fixed-size crypto input pattern already used elsewhere in libsession

## tests

- `./utils/format.sh verify`
- release build with GCC 15.2 and `WARNINGS_AS_ERRORS=ON`
- `./Build/tests/testAll "[backend][session_file_server]"`
- `./Build/tests/testAll`
- `./Build/tests/testLogging`
- release build with Clang 19 and `WARNINGS_AS_ERRORS=ON`
- `./Build-clang/tests/testAll "[backend][session_file_server]"`
- `./Build-clang/tests/testAll`
- `./Build-clang/tests/testLogging`