### PR TITLE
Run clang-format over the branch

### DIFF
--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <oxen/quic/loop.hpp>
-
 #include <filesystem>
 #include <optional>
+#include <oxen/quic/loop.hpp>
 #include <session/client/attachment.hpp>
 #include <session/client/callbacks.hpp>
 #include <session/client/conversation.hpp>
@@ -62,7 +61,7 @@ namespace SessionProtos {
 class Content;
 class DataExtractionNotification;
 class UnsendRequest;
-}
+}  // namespace SessionProtos
 
 namespace session::client {
 
@@ -232,9 +231,9 @@ class Client {
     /// Sends to a conversation named by id, creating it if it does not exist.
     ///
     /// The same operation as `Conversation::send_message`, and forwards to it; it is here as well
-    /// because this is the one thing that cannot require a conversation to already exist — messaging
-    /// an account you have never spoken to is how the conversation begins.  With one in hand, send
-    /// through it and skip the lookup.
+    /// because this is the one thing that cannot require a conversation to already exist —
+    /// messaging an account you have never spoken to is how the conversation begins.  With one in
+    /// hand, send through it and skip the lookup.
     ///
     /// See `Conversation::send_message` for what the arguments mean and what `on_upload` reports.
     ///
@@ -258,7 +257,6 @@ class Client {
             wait_t);
     int64_t send_message(const ConversationId& id, OutgoingMessage msg, wait_t);
 
-
     /// Sends a failed message again, resuming rather than restarting: attachments that already
     /// reached the file server are left alone and only the ones that did not are uploaded, because
     /// what each upload achieved is recorded against the message.  A message whose files all got
@@ -279,8 +277,7 @@ class Client {
                     void(size_t index, int64_t sent, int64_t total, std::optional<int> result)>
                     on_upload,
             failable_function<void(bool started)> cb);
-    bool retry_send(
-            int64_t message_id, Conversation::upload_progress on_upload, wait_t);
+    bool retry_send(int64_t message_id, Conversation::upload_progress on_upload, wait_t);
     bool retry_send(int64_t message_id, wait_t);
 
     /// Deletes one message from this device: its body, its decrypted content and everything it
@@ -295,8 +292,8 @@ class Client {
     /// looking new.
     ///
     /// Files are not touched.  An attachment's path names a file the user chose -- one they picked
-    /// to send, or a place they asked a download to be put -- so it is theirs in both directions and
-    /// nothing here has ever unlinked one.  The rows that described the attachments do go.
+    /// to send, or a place they asked a download to be put -- so it is theirs in both directions
+    /// and nothing here has ever unlinked one.  The rows that described the attachments do go.
     ///
     /// Deleting an unread incoming message makes it read, since there is no longer anything to
     /// read; the conversation's unread count follows.
@@ -395,8 +392,7 @@ class Client {
     /// stored wire form, one whose content has been deleted, and one whose content some later
     /// pruning removed.  Also nullopt if the stored bytes no longer parse, which is corruption
     /// rather than absence and is logged as such.
-    void message_debug(
-            int64_t message_id, failable_function<void(std::optional<std::string>)> cb);
+    void message_debug(int64_t message_id, failable_function<void(std::optional<std::string>)> cb);
     std::optional<std::string> message_debug(int64_t message_id, wait_t);
 
     /// Fetches one of a message's attachments and writes it to `dest`, decrypting it on the way.
@@ -412,11 +408,12 @@ class Client {
     /// `dest` and is renamed only once it has been decrypted and verified, so an interrupted save
     /// leaves no half-file that looks finished.
     ///
-    /// **`cb` reports where it actually went**, which is not always `dest`.  Whether `dest` was free
-    /// is something the caller decided when it asked its user; the rename happens when the download
-    /// finishes, which may be minutes later, and anything that has appeared there in between is a
-    /// file nobody agreed to lose.  So by default the finished file takes the next free `name (2)`
-    /// instead — before the extension, since only that still opens on a double-click.
+    /// **`cb` reports where it actually went**, which is not always `dest`.  Whether `dest` was
+    /// free is something the caller decided when it asked its user; the rename happens when the
+    /// download finishes, which may be minutes later, and anything that has appeared there in
+    /// between is a file nobody agreed to lose.  So by default the finished file takes the next
+    /// free `name (2)` instead — before the extension, since only that still opens on a
+    /// double-click.
     ///
     /// A caller whose user has *already* been shown what is there and said replace it passes
     /// `replace` and gets `dest` whatever has happened since.  That is not the same decision and
@@ -440,8 +437,8 @@ class Client {
     /// false is not overruled.
     ///
     /// Which of Session's two attachment encryptions applies is read from the url, so a caller
-    /// neither chooses nor needs to know: current clients still send the legacy scheme, and files we
-    /// send use the stream one.
+    /// neither chooses nor needs to know: current clients still send the legacy scheme, and files
+    /// we send use the stream one.
     ///
     /// The error a failure reports is worth showing rather than a generic one: an attachment that
     /// the file server no longer holds, one whose sender described it wrongly, and one that failed
@@ -481,17 +478,16 @@ class Client {
     /// nothing else writes.  Point this at a directory with other things in it and they will go.
     ///
     /// Calling this starts one such pass, in the background, against what the database says should
-    /// be there.  It is a net for what no code of ours was running to see -- a crash between writing
-    /// a file and recording it, a contact whose row went by cascade -- so it is done once, here,
-    /// rather than on a timer: those are things that happen while we are not looking, and this is
-    /// the moment we look.  It runs off the event loop and reports only to the log.
+    /// be there.  It is a net for what no code of ours was running to see -- a crash between
+    /// writing a file and recording it, a contact whose row went by cascade -- so it is done once,
+    /// here, rather than on a timer: those are things that happen while we are not looking, and
+    /// this is the moment we look.  It runs off the event loop and reports only to the log.
     ///
     /// Contents are encrypted under a key generated once and kept in the database, so they outlive
     /// the message or config entry whose key originally opened them — and so the files are not
     /// readable by whoever ends up with the disk.  That protection is only as good as the
     /// database's: with an unencrypted database the key sits in plaintext beside them.
     void set_cache_dir(std::filesystem::path dir);
-
 
     /// A conversation's picture, decrypted and ready to decode.
     ///
@@ -579,8 +575,8 @@ class Client {
     /// Whether to tell somebody when we save a file they sent us.
     ///
     /// Follows the account, so turning it off on one device turns it off everywhere.  Composes with
-    /// `save_attachment`'s `notify_sender` in one direction only: this can refuse a notification and
-    /// cannot require one, so a caller passing false is never overruled, and a client with no
+    /// `save_attachment`'s `notify_sender` in one direction only: this can refuse a notification
+    /// and cannot require one, so a caller passing false is never overruled, and a client with no
     /// setting of its own still honours a choice made elsewhere.
     void notify_media_saved(failable_function<void(bool)> cb);
     bool notify_media_saved(wait_t);
@@ -733,7 +729,8 @@ class Client {
     // Writes `data` into the attachment cache under `url`, and records it.  The row is an index
     // over the file, so it is written after the file exists.
     void _cache_attachment(
-            const std::string& url, std::span<const std::byte, 32> key,
+            const std::string& url,
+            std::span<const std::byte, 32> key,
             std::span<const std::byte> data);
     // Marks a cache entry as used now, which is what makes eviction least-recently-used.
     void _touch_cached(const std::string& name);
@@ -780,8 +777,7 @@ class Client {
 
     // The deciding half of `_sweep_cache`, on the loop.  Takes the directory listings because
     // taking them is the slow part and does not belong here.
-    void _reconcile_cache(
-            std::vector<std::string> attachments, std::vector<std::string> pictures);
+    void _reconcile_cache(std::vector<std::string> attachments, std::vector<std::string> pictures);
 
     // Runs the listing half of a sweep.  Joined before anything it touches goes away, which is why
     // it hands its result back with `call_get`: joining a thread that had merely *posted* a job
@@ -793,7 +789,6 @@ class Client {
             size_t index,
             std::function<void(const AttachmentProgress&)> on_progress,
             failable_function<void(std::vector<std::byte>)> cb);
-
 
     // Decides what an arriving message's attachments are worth fetching unasked, sets whether it is
     // shown as a gallery, and starts whatever it decided on.  Does nothing without a cache
@@ -828,7 +823,6 @@ class Client {
             const ConversationId& id,
             const OutgoingMessage& msg,
             std::function<void(size_t, int64_t, int64_t, std::optional<int>)> on_upload);
-
 
     // Uploads the message's first attachment that has no url yet and, when there are none left,
     // finishes the send.  Each upload's completion calls this again, so the chain runs one file at
@@ -865,8 +859,8 @@ class Client {
     // which are different for no reason anyone chose — see `attachment::legacy_display_pic_decrypt`
     // — and which nothing in the bytes distinguishes.
     enum class DownloadKind {
-        attachment,    ///< A file sent with a message.
-        display_pic,   ///< A profile picture or a group avatar.
+        attachment,   ///< A file sent with a message.
+        display_pic,  ///< A profile picture or a group avatar.
     };
 
     // Downloads `url`, decrypts it, and hands the plaintext to `on_plain` — possibly in pieces, and
@@ -883,9 +877,9 @@ class Client {
     //   - no key at all -> plaintext.  Community images are stored that way.
     //
     // `kind` is a parameter rather than something inferred from the key's length because the caller
-    // knows which it asked for, and inference would be a guess standing in for a fact: it happens to
-    // work today only because the two legacy key sizes differ, and would misroute silently the first
-    // time something else turned up with a 32-byte key and no `d`.
+    // knows which it asked for, and inference would be a guess standing in for a fact: it happens
+    // to work today only because the two legacy key sizes differ, and would misroute silently the
+    // first time something else turned up with a 32-byte key and no `d`.
     //
     // The stream scheme decrypts as it arrives; both legacy ones have to accumulate, because their
     // authentication covers the whole ciphertext and cannot be checked until all of it is here.
@@ -895,11 +889,11 @@ class Client {
     // each chunk as it arrives, so a failure surfaces when the bad chunk does -- which may be the
     // first or may be most of the way in, but is not "once the whole file is here".
     //
-    // `on_progress` reports in encrypted bytes, unindexed; a caller that reports per-attachment adds
-    // its own index.  `on_done` fires exactly once, with the failure if there was one.
+    // `on_progress` reports in encrypted bytes, unindexed; a caller that reports per-attachment
+    // adds its own index.  `on_done` fires exactly once, with the failure if there was one.
     //
-    // Throws, before starting anything, if the url is not a download url, if no network is attached,
-    // or if the key or digest is the wrong length for the scheme that resolves to.
+    // Throws, before starting anything, if the url is not a download url, if no network is
+    // attached, or if the key or digest is the wrong length for the scheme that resolves to.
     void _download_decrypted(
             const std::string& url,
             DownloadKind kind,
@@ -922,9 +916,9 @@ class Client {
     // Serves a file from the cache, joins a fetch of it already running, or starts one.
     //
     // The joining is what this exists for.  Two things want the same file routinely -- an arrival
-    // starts a download and the display then asks for the very thing being downloaded -- so a second
-    // request attaches to the first, picking up its progress from wherever it has reached, rather
-    // than fetching the same bytes twice and caching them twice.
+    // starts a download and the display then asks for the very thing being downloaded -- so a
+    // second request attaches to the first, picking up its progress from wherever it has reached,
+    // rather than fetching the same bytes twice and caching them twice.
     //
     // `on_hit` runs when the cache answered and `store` after a fetch completes, both on the loop.
     // They are the whole of the difference between a cached attachment, which is indexed and
@@ -950,8 +944,7 @@ class Client {
 
     // Fetches a display picture into the cache for nobody in particular, reporting to
     // `display_picture_progress` as it goes.
-    void _fetch_picture(
-            const ConversationId& id, std::string url, std::vector<std::byte> key);
+    void _fetch_picture(const ConversationId& id, std::string url, std::vector<std::byte> key);
 
     // Starts the download behind save_attachment.  Everything after the row lookup happens off the
     // loop, on the network's thread: the file is decrypted and written there, and nothing about it
@@ -1089,8 +1082,9 @@ class Client {
     //
     // Re-derived from the rows rather than applied alongside each change, so the mapping lives in
     // one place and cannot drift from the tables it describes: a caller has to remember to call
-    // this, but it cannot remember to call it *wrongly*.  Idempotent -- assigning a config field its
-    // existing value does not dirty it -- so it is safe to call whenever a row might have moved.
+    // this, but it cannot remember to call it *wrongly*.  Idempotent -- assigning a config field
+    // its existing value does not dirty it -- so it is safe to call whenever a row might have
+    // moved.
     //
     // Not for our own account: our profile is UserProfile's, and we are not a contact.
     void _sync_contact(const ConversationId& id);

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -86,9 +86,9 @@ struct callbacks {
     /// to a server, carrying 0 of 0 — so a row can show that a fetch is beginning rather than
     /// appearing to do nothing until the first bytes land.  Exactly one report carries a `result`.
     ///
-    /// Reports are rate limited (see `set_dispatch_interval`) to keep the cost off the application's
-    /// thread.  That is all the limiting is for: how often a spinner turns is the application's own
-    /// business, and it should not be reading motion into the arrival of these.
+    /// Reports are rate limited (see `set_dispatch_interval`) to keep the cost off the
+    /// application's thread.  That is all the limiting is for: how often a spinner turns is the
+    /// application's own business, and it should not be reading motion into the arrival of these.
     std::function<void(const ConversationId&, const AttachmentProgress&)> attachment_progress;
 
     /// The same, for a display picture, which belongs to a conversation rather than to a message —
@@ -97,7 +97,8 @@ struct callbacks {
     ///
     /// Display pictures are always fetched, with no setting to turn that off, so this fires for
     /// every one that is not already cached.
-    std::function<void(const ConversationId&, int64_t done, int64_t total, std::optional<int> result)>
+    std::function<void(
+            const ConversationId&, int64_t done, int64_t total, std::optional<int> result)>
             display_picture_progress;
 };
 

--- a/include/session/client/conversation.hpp
+++ b/include/session/client/conversation.hpp
@@ -130,8 +130,8 @@ class Conversation {
     ///
     /// Deleted messages are left out unless `include_deleted` is passed.  Out by default because a
     /// deleted message carries no body, so a caller that has not thought about `Message::deleted`
-    /// would draw an empty row that looks like a bug.  A client that wants to show "message deleted"
-    /// asks for them, and gets them in place, in order.
+    /// would draw an empty row that looks like a bug.  A client that wants to show "message
+    /// deleted" asks for them, and gets them in place, in order.
     ///
     /// Filtered in the query rather than left to the caller, because the alternative breaks paging:
     /// a page of 50 that is mostly deleted would hand back a handful of rows with nothing to say
@@ -151,21 +151,18 @@ class Conversation {
     std::vector<Message> messages(int limit, wait_t) const;
     std::vector<Message> messages(int limit, std::optional<MessageCursor> before, wait_t) const;
     std::vector<Message> messages(
-            int limit,
-            std::optional<MessageCursor> before,
-            bool include_deleted,
-            wait_t) const;
+            int limit, std::optional<MessageCursor> before, bool include_deleted, wait_t) const;
 
     /// Removes every deleted message's leftover row from this conversation, and says how many went.
     ///
-    /// A deletion leaves a row behind deliberately — see `Client::delete_message` — and this is what
-    /// finally removes them, for a client that would rather not accumulate them or show them.
+    /// A deletion leaves a row behind deliberately — see `Client::delete_message` — and this is
+    /// what finally removes them, for a client that would rather not accumulate them or show them.
     ///
     /// **This can bring a message back.** A message deleted only here is still in our swarm, and
-    /// that row's swarm hash is the only thing that recognises it if it is delivered again — which a
-    /// storage server makes likely rather than hypothetical, since it stops honouring a `last_hash`
-    /// once that has expired and answers the next poll with the whole retention window.  Removing
-    /// the row removes the memory of it, and the message returns looking new.
+    /// that row's swarm hash is the only thing that recognises it if it is delivered again — which
+    /// a storage server makes likely rather than hypothetical, since it stops honouring a
+    /// `last_hash` once that has expired and answers the next poll with the whole retention window.
+    /// Removing the row removes the memory of it, and the message returns looking new.
     ///
     /// The alternative — deleting our swarm copy too, so there is nothing to come back — is worse
     /// and is deliberately not done: that copy is what our *other devices* poll, so destroying it
@@ -220,9 +217,7 @@ class Conversation {
     /// alone: a timer with no mode does not expire, and a mode with no timer has nothing to count.
     /// `expiration_mode::none` clears the timer whatever is passed with it.
     void set_expiry(
-            config::expiration_mode mode,
-            std::chrono::seconds timer,
-            failable_function<void()> cb);
+            config::expiration_mode mode, std::chrono::seconds timer, failable_function<void()> cb);
     void set_expiry(config::expiration_mode mode, std::chrono::seconds timer, wait_t);
 
     /// Sets what this conversation fetches without being asked.
@@ -292,10 +287,11 @@ class Conversation {
     /// @throws std::invalid_argument if any attachment's file cannot be opened or exceeds the file
     /// server's limit, or if `reply_to` names a message that does not exist or belongs to another
     /// conversation; thrown on the calling thread, before anything is stored or dispatched.
-    using upload_progress =
-            std::function<void(size_t index, int64_t sent, int64_t total, std::optional<int> result)>;
+    using upload_progress = std::function<void(
+            size_t index, int64_t sent, int64_t total, std::optional<int> result)>;
     void send_message(
-            OutgoingMessage msg, upload_progress on_upload,
+            OutgoingMessage msg,
+            upload_progress on_upload,
             failable_function<void(int64_t message_id)> cb);
     void send_message(OutgoingMessage msg, failable_function<void(int64_t message_id)> cb);
     int64_t send_message(OutgoingMessage msg, upload_progress on_upload, wait_t);
@@ -497,14 +493,14 @@ class AnyConversation {
 
 // Forwarded rather than reimplemented, so that an overload added to Conversation is reachable here
 // without anything being added below.
-#define SESSION_CONVO_FORWARD(name)                                        \
-    template <typename... A>                                               \
-    decltype(auto) name(A&&... a) {                                        \
-        return base().name(std::forward<A>(a)...);                         \
-    }                                                                      \
-    template <typename... A>                                               \
-    decltype(auto) name(A&&... a) const {                                  \
-        return base().name(std::forward<A>(a)...);                         \
+#define SESSION_CONVO_FORWARD(name)                \
+    template <typename... A>                       \
+    decltype(auto) name(A&&... a) {                \
+        return base().name(std::forward<A>(a)...); \
+    }                                              \
+    template <typename... A>                       \
+    decltype(auto) name(A&&... a) const {          \
+        return base().name(std::forward<A>(a)...); \
     }
 
     SESSION_CONVO_FORWARD(messages)

--- a/include/session/client/message.hpp
+++ b/include/session/client/message.hpp
@@ -190,8 +190,8 @@ struct Message {
     /// Whether it *is* being shown that way.
     ///
     /// Stored, because it is a decision rather than a property: it is made when the message is
-    /// processed — on if the conversation was auto-downloading then — and the conversation's setting
-    /// may have changed since, so recomputing it later would not give the same answer.
+    /// processed — on if the conversation was auto-downloading then — and the conversation's
+    /// setting may have changed since, so recomputing it later would not give the same answer.
     ///
     /// Never true when `gallery_viewable` is false: a stored decision that no longer agrees with
     /// the current rule is dropped rather than honoured, so a message that qualified under an older

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -102,8 +102,8 @@ struct contact_info {
     int64_t created = 0;  // Unix timestamp (seconds) when this contact was added
 
     /// Messages in this conversation older than this are to be deleted, and arriving ones older
-    /// than it dropped.  This is what makes clearing a conversation, and deleting one, mean the same
-    /// thing on every device: the instruction is recorded rather than inferred from when some
+    /// than it dropped.  This is what makes clearing a conversation, and deleting one, mean the
+    /// same thing on every device: the instruction is recorded rather than inferred from when some
     /// config happened to be written.  Epoch (the default) means no such instruction.
     std::chrono::sys_seconds delete_before{};
 

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -315,9 +315,9 @@ LIBSESSION_EXPORT void user_profile_set_blinded_msgreqs(config_object* conf, int
 
 /// API: user_profile/user_profile_get_notify_media_saved
 ///
-/// Returns true if we tell somebody when we save a file they sent us.  True is the default, and what
-/// an account that has never set this returns: Session's clients report it, so it is what a sender
-/// expects.
+/// Returns true if we tell somebody when we save a file they sent us.  True is the default, and
+/// what an account that has never set this returns: Session's clients report it, so it is what a
+/// sender expects.
 ///
 /// Declaration:
 /// ```cpp

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -258,7 +258,8 @@ class UserProfile : public ConfigBase {
 
     /// API: user_profile/UserProfile::get_nts_delete_attach_before
     ///
-    /// As `get_nts_delete_before`, but covering the attachments alone: the messages themselves stay.
+    /// As `get_nts_delete_before`, but covering the attachments alone: the messages themselves
+    /// stay.
     ///
     /// Only ever holds a value that says something `get_nts_delete_before` does not: deleting a
     /// message takes its attachments with it, so setting either of the pair clears this one when

--- a/include/session/core.hpp
+++ b/include/session/core.hpp
@@ -334,8 +334,9 @@ class Core {
 
     // Sends one round of retrieves to `node` for `namespaces`.  A retrieve is capped by the storage
     // server, so one round may not exhaust a namespace; `round` counts continuations and bounds
-    // them.  Every round goes to the same node: the retrieve cursor is stored per (namespace, node),
-    // so continuing against a different swarm member would resume from that member's position.
+    // them.  Every round goes to the same node: the retrieve cursor is stored per (namespace,
+    // node), so continuing against a different swarm member would resume from that member's
+    // position.
     void _send_poll(
             network::Network* net,
             network::service_node node,

--- a/include/session/core/callbacks.hpp
+++ b/include/session/core/callbacks.hpp
@@ -180,7 +180,9 @@ struct callbacks {
     /// - swarm_hash -- the hash the swarm assigned the stored message, on `success` and when the
     ///   storage server reported one.  Unset for every other status.
     std::function<void(
-            int64_t message_id, MessageSendStatus status, std::optional<std::string_view> swarm_hash)>
+            int64_t message_id,
+            MessageSendStatus status,
+            std::optional<std::string_view> swarm_hash)>
             message_send_status;
 
     /// Callback fired when merging config messages from the swarm changed one or more of the

--- a/include/session/core/configs.hpp
+++ b/include/session/core/configs.hpp
@@ -128,8 +128,8 @@ class Configs : public detail::CoreComponent {
     ///
     /// A config is dumped when it changes, which is right when nobody knows any better -- but a
     /// caller working through a batch of messages does know better, and dumping between them writes
-    /// intermediate states nobody will ever read.  Holding one of these says "there is more coming";
-    /// releasing it says "now".
+    /// intermediate states nobody will ever read.  Holding one of these says "there is more
+    /// coming"; releasing it says "now".
     ///
     /// This is what keeps the timer honest.  Debouncing is a guess at where a batch ended, and a
     /// guess is only needed where nothing knows: with a batch held across the work, dumping happens

--- a/include/session/network/network_opt.hpp
+++ b/include/session/network/network_opt.hpp
@@ -48,45 +48,40 @@ namespace opt {
         static netid mainnet() {
             auto seed_nodes = {
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "1f000f09a7b07828dcb72af7cd16857050c10c02bd58a"
-                                    "fb0e38111fb6cda1fef"),
+                            ed25519_pubkey::from_hex("1f000f09a7b07828dcb72af7cd16857050c10c02bd58a"
+                                                     "fb0e38111fb6cda1fef"),
                             oxen::quic::ipv4{"95.216.33.113"},
                             uint16_t{22100},
                             uint16_t{20200},
                             {2, 11, 0},
                             swarm::INVALID_SWARM_ID},
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "1f101f0acee4db6f31aaa8b4df134e85ca8a4878efaef"
-                                    "7f971e88ab144c1a7ce"),
+                            ed25519_pubkey::from_hex("1f101f0acee4db6f31aaa8b4df134e85ca8a4878efaef"
+                                                     "7f971e88ab144c1a7ce"),
                             oxen::quic::ipv4{"37.27.236.229"},
                             uint16_t{22101},
                             uint16_t{20201},
                             {2, 11, 0},
                             swarm::INVALID_SWARM_ID},
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "1f202f00f4d2d4acc01e20773999a291cf3e3136c3254"
-                                    "74d159814e06199919f"),
+                            ed25519_pubkey::from_hex("1f202f00f4d2d4acc01e20773999a291cf3e3136c3254"
+                                                     "74d159814e06199919f"),
                             oxen::quic::ipv4{"172.96.140.124"},
                             uint16_t{22102},
                             uint16_t{20202},
                             {2, 11, 0},
                             swarm::INVALID_SWARM_ID},
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "1f303f1d7523c46fa5398826740d13282d26b5de90fba"
-                                    "e5749442f66afb6d78b"),
+                            ed25519_pubkey::from_hex("1f303f1d7523c46fa5398826740d13282d26b5de90fba"
+                                                     "e5749442f66afb6d78b"),
                             oxen::quic::ipv4{"208.73.207.54"},
                             uint16_t{22103},
                             uint16_t{20203},
                             {2, 11, 0},
                             swarm::INVALID_SWARM_ID},
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "1f604f1c858a121a681d8f9b470ef72e6946ee1b9c5ad"
-                                    "15a35e16b50c28db7b0"),
+                            ed25519_pubkey::from_hex("1f604f1c858a121a681d8f9b470ef72e6946ee1b9c5ad"
+                                                     "15a35e16b50c28db7b0"),
                             oxen::quic::ipv4{"104.194.8.115"},
                             uint16_t{22104},
                             uint16_t{20204},
@@ -108,9 +103,8 @@ namespace opt {
                     //         swarm::INVALID_SWARM_ID},  // This is the original one
 
                     service_node{
-                            ed25519_pubkey::from_hex(
-                                    "decaf20025ca6389d8225bda6a32d7fc4ee5176d21e3b"
-                                    "2e9e08c3505a48a811a"),
+                            ed25519_pubkey::from_hex("decaf20025ca6389d8225bda6a32d7fc4ee5176d21e3b"
+                                                     "2e9e08c3505a48a811a"),
                             oxen::quic::ipv4{"23.88.6.250"},
                             uint16_t{35520},
                             uint16_t{35420},

--- a/src/attachments.cpp
+++ b/src/attachments.cpp
@@ -428,8 +428,7 @@ std::vector<std::byte> legacy_display_pic_decrypt(
     body = body.subspan(0, body.size() - LEGACY_DISPLAY_PIC_TAG_SIZE);
 
     std::vector<std::byte> plaintext(body.size());
-    gcm_aes256_decrypt(
-            &ctx, body.size(), to_unsigned(plaintext.data()), to_unsigned(body.data()));
+    gcm_aes256_decrypt(&ctx, body.size(), to_unsigned(plaintext.data()), to_unsigned(body.data()));
 
     std::array<unsigned char, LEGACY_DISPLAY_PIC_TAG_SIZE> tag_out;
     gcm_aes256_digest(&ctx, tag_out.size(), tag_out.data());
@@ -452,7 +451,8 @@ std::vector<std::byte> legacy_decrypt(
 
     // Bounded by what the file server will actually store, so a caller cannot be talked into
     // holding an arbitrary amount by anything a sender claims.  This has to be all in memory: the
-    // authenticators below cover the whole ciphertext, and nothing may be decrypted until they pass.
+    // authenticators below cover the whole ciphertext, and nothing may be decrypted until they
+    // pass.
     if (encrypted.size() > LEGACY_MAX_ENCRYPTED_SIZE)
         throw std::runtime_error{
                 "Legacy attachment decryption failed: {}B exceeds the {}B maximum"_format(

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1,10 +1,10 @@
 #include <SQLiteCpp/Transaction.h>
 #include <SessionProtos.pb.h>
-#include <debug_print.hpp>
 #include <oxenc/hex.h>
 
 #include <algorithm>
 #include <charconv>
+#include <debug_print.hpp>
 #include <fstream>
 #include <oxen/log.hpp>
 #include <oxen/quic/loop.hpp>
@@ -16,10 +16,10 @@
 #include <session/config/user_profile.hpp>
 #include <session/format.hpp>
 #include <session/hash.hpp>
-#include <session/random.hpp>
 #include <session/network/backends/session_file_server.hpp>
 #include <session/network/session_network.hpp>
 #include <session/placeholders.hpp>
+#include <session/random.hpp>
 #include <session/sqlite.hpp>
 #include <set>
 #include <stdexcept>
@@ -305,10 +305,9 @@ static bool approve_recipient(sqlite::Connection& c, const ConversationId& id, C
         return false;
     auto account = identity_id(c, id);
     auto made = ensure_contact(c, account, true);
-    auto flagged =
-            c.prepared_exec(
-                    "UPDATE contacts SET approved = 1 WHERE account = ? AND NOT approved", account) >
-            0;
+    auto flagged = c.prepared_exec(
+                           "UPDATE contacts SET approved = 1 WHERE account = ? AND NOT approved",
+                           account) > 0;
     return made || flagged;
 }
 
@@ -650,8 +649,7 @@ void Client::retry_send(
             std::move(cb));
 }
 
-bool Client::retry_send(
-        int64_t message_id, Conversation::upload_progress on_upload, wait_t) {
+bool Client::retry_send(int64_t message_id, Conversation::upload_progress on_upload, wait_t) {
     return loop.call_get([this, message_id, on_upload = std::move(on_upload)] {
         return _retry_send(message_id, on_upload);
     });
@@ -676,7 +674,8 @@ void Client::delete_message(int64_t message_id, failable_function<void(bool)> cb
 }
 
 bool Client::delete_message(int64_t message_id, wait_t) {
-    return loop.call_get([this, message_id] { return _delete_message(message_id, Deletion::here); });
+    return loop.call_get(
+            [this, message_id] { return _delete_message(message_id, Deletion::here); });
 }
 
 void Client::set_cache_dir(std::filesystem::path dir) {
@@ -774,7 +773,6 @@ void Client::_reconcile_cache(
                 unreferenced);
 }
 
-
 const b32& Client::_cache_encryption_key() {
     if (!_cache_key) {
         auto& key = _cache_key.emplace();
@@ -803,7 +801,8 @@ void Client::profile_picture(
 }
 
 void Client::profile_picture(
-        const ConversationId& id, failable_function<void(std::optional<std::vector<std::byte>>)> cb) {
+        const ConversationId& id,
+        failable_function<void(std::optional<std::vector<std::byte>>)> cb) {
     profile_picture(id, nullptr, std::move(cb));
 }
 
@@ -883,7 +882,8 @@ static void set_limit(core::Globals& g, std::string_view key, std::optional<int6
         g.erase(key);
 }
 
-void Client::set_attachment_cache_limit(std::optional<int64_t> bytes, failable_function<void()> cb) {
+void Client::set_attachment_cache_limit(
+        std::optional<int64_t> bytes, failable_function<void()> cb) {
     _async([this, bytes] { set_limit(core.globals, CACHE_LIMIT_KEY, bytes); }, std::move(cb));
 }
 void Client::set_attachment_cache_limit(std::optional<int64_t> bytes, wait_t) {
@@ -896,7 +896,8 @@ std::optional<int64_t> Client::attachment_cache_limit(wait_t) {
     return loop.call_get([this] { return core.globals.get_integer(CACHE_LIMIT_KEY); });
 }
 
-void Client::set_auto_download_max_size(std::optional<int64_t> bytes, failable_function<void()> cb) {
+void Client::set_auto_download_max_size(
+        std::optional<int64_t> bytes, failable_function<void()> cb) {
     _async([this, bytes] { set_limit(core.globals, AUTO_DL_MAX_KEY, bytes); }, std::move(cb));
 }
 void Client::set_auto_download_max_size(std::optional<int64_t> bytes, wait_t) {
@@ -979,11 +980,10 @@ void Client::_attachment_data(
     // The caller's own progress reporting, identified and hopped out to their thread.
     std::function<void(int64_t, int64_t, std::optional<int>)> progress;
     if (on_progress)
-        progress = _dispatch_progress(
-                [on_progress = std::move(on_progress), message_id, index](
-                        int64_t done, int64_t total, std::optional<int> r) {
-                    on_progress(AttachmentProgress{message_id, index, done, total, r});
-                });
+        progress = _dispatch_progress([on_progress = std::move(on_progress), message_id, index](
+                                              int64_t done, int64_t total, std::optional<int> r) {
+            on_progress(AttachmentProgress{message_id, index, done, total, r});
+        });
 
     std::function<void(std::span<const std::byte>)> store;
     if (!_cache_dir.empty())
@@ -1116,10 +1116,11 @@ void Client::send_message(
         std::function<void(std::optional<std::string>, int64_t)> cb) {
     _require_sendable("send_message", id, msg);
 
-    _async([this, id, msg = std::move(msg), on_upload = std::move(on_upload)] {
-        return _send_message(id, msg, on_upload);
-    },
-           std::move(cb));
+    _async(
+            [this, id, msg = std::move(msg), on_upload = std::move(on_upload)] {
+                return _send_message(id, msg, on_upload);
+            },
+            std::move(cb));
 }
 
 void Client::send_message(
@@ -1142,7 +1143,9 @@ void Client::message_requests(
 }
 
 void Client::set_blocked(
-        const ConversationId& id, bool blocked, std::function<void(std::optional<std::string>)> cb) {
+        const ConversationId& id,
+        bool blocked,
+        std::function<void(std::optional<std::string>)> cb) {
     _require_contact("set_blocked", id);
     _async([this, id, blocked] { _set_blocked(id, blocked); }, std::move(cb));
 }
@@ -1197,7 +1200,9 @@ static std::optional<DM> as_dm(std::optional<AnyConversation> convo) {
     return std::nullopt;
 }
 
-void Client::dm(const ConversationId& id, std::function<void(std::optional<std::string>, std::optional<DM>)> cb) {
+void Client::dm(
+        const ConversationId& id,
+        std::function<void(std::optional<std::string>, std::optional<DM>)> cb) {
     _require_dm("dm", id);
     _async([this, id] { return as_dm(_conversation(id)); }, std::move(cb));
 }
@@ -1217,7 +1222,9 @@ void Client::open_dm(
 
 DM Client::open_dm(const ConversationId& id, wait_t) {
     _require_dm("open_dm", id);
-    return loop.call_get([this, id] { return *as_dm(std::optional<AnyConversation>{_create_conversation(id)}); });
+    return loop.call_get([this, id] {
+        return *as_dm(std::optional<AnyConversation>{_create_conversation(id)});
+    });
 }
 
 void Client::message(
@@ -1237,11 +1244,9 @@ void Client::save_attachment(
     // Checked on the calling thread so a caller's own mistake surfaces at the call site, where they
     // still have a stack to make sense of it.
     if (std::filesystem::is_directory(dest))
-        throw std::invalid_argument{
-                "save_attachment: {} is a directory"_format(dest.string())};
+        throw std::invalid_argument{"save_attachment: {} is a directory"_format(dest.string())};
     if (auto dir = dest.parent_path(); !dir.empty() && !std::filesystem::is_directory(dir))
-        throw std::invalid_argument{
-                "save_attachment: {} does not exist"_format(dir.string())};
+        throw std::invalid_argument{"save_attachment: {} does not exist"_format(dir.string())};
 
     // Not _async: what that reports is the *start* of the transfer, and the answer a caller wants
     // is whether the file arrived, which is minutes away.  So the callback is carried down to the
@@ -1306,9 +1311,29 @@ template <typename... Bind>
 static std::vector<AnyConversation> query_conversations(
         Client& client, sqlite::Connection& c, const std::string& query, const Bind&... bind) {
     std::vector<AnyConversation> out;
-    for (auto [convo, sid, gid, url, room, display_name, activity, preview, unread, priority,
-               approved, approved_me, marked_unread, blocked, name, nickname, notifications,
-               mute_until, exp_mode, exp_timer, pic_url, pic_key, auto_download] :
+    for (auto [convo,
+               sid,
+               gid,
+               url,
+               room,
+               display_name,
+               activity,
+               preview,
+               unread,
+               priority,
+               approved,
+               approved_me,
+               marked_unread,
+               blocked,
+               name,
+               nickname,
+               notifications,
+               mute_until,
+               exp_mode,
+               exp_timer,
+               pic_url,
+               pic_key,
+               auto_download] :
          c.prepared_results<
                  int64_t,
                  std::optional<sqlite::blob_guts<b33>>,
@@ -1412,8 +1437,7 @@ std::optional<AnyConversation> Client::_conversation(const ConversationId& id) {
     auto convo = find_conversation(c, id);
     if (!convo)
         return std::nullopt;
-    auto found = query_conversations(
-            *this, c, "{} WHERE c.id = ?"_format(CONVO_COLUMNS), *convo);
+    auto found = query_conversations(*this, c, "{} WHERE c.id = ?"_format(CONVO_COLUMNS), *convo);
     if (found.empty())
         return std::nullopt;
     return std::move(found.front());
@@ -1521,8 +1545,7 @@ void Client::_set_marked_unread(const ConversationId& id, bool unread) {
 // The settings below all live on the conversation row and all reach the config the same way, so
 // they share one shape: update where it differs, and if it did, re-derive and report.
 template <typename T>
-void Client::_set_conversation_setting(
-        const ConversationId& id, std::string_view column, T value) {
+void Client::_set_conversation_setting(const ConversationId& id, std::string_view column, T value) {
     int changed = 0;
     {
         auto c = core.database().conn();
@@ -1920,8 +1943,12 @@ bool Client::_delete_message_everywhere(int64_t message_id) {
     sys_ms timestamp{};
     {
         auto c = core.database().conn();
-        auto row = c.prepared_maybe_get<int, std::optional<std::string>, int64_t,
-                                        std::optional<int64_t>, sqlite::blob_guts<b33>>(
+        auto row = c.prepared_maybe_get<
+                int,
+                std::optional<std::string>,
+                int64_t,
+                std::optional<int64_t>,
+                sqlite::blob_guts<b33>>(
                 R"(
             SELECT m.outgoing, m.swarm_hash, m.timestamp, m.msgid, a.session_id
             FROM messages m
@@ -2210,21 +2237,19 @@ bool Client::_update_profile(
 
     // `IS NOT` rather than `!=`: these columns are NULL until a profile is known, and `NULL != 'x'`
     // is NULL, so `!=` would never fire for the first name or picture we learn.
-    bool changed =
-            source == ProfileSource::config
-                    ? c.prepared_exec(
-                              R"(
+    bool changed = source == ProfileSource::config ? c.prepared_exec(
+                                                             R"(
 UPDATE accounts SET name = ?2, profile_pic_url = ?3, profile_pic_key = ?4, profile_updated = ?5
 WHERE id = ?1
   AND (name, profile_pic_url, profile_pic_key, profile_updated) IS NOT (?2, ?3, ?4, ?5)
 )",
-                              account,
-                              name,
-                              pic_url,
-                              pic_key,
-                              updated) > 0
-                    : c.prepared_exec(
-                              R"(
+                                                             account,
+                                                             name,
+                                                             pic_url,
+                                                             pic_key,
+                                                             updated) > 0
+                                                   : c.prepared_exec(
+                                                             R"(
 UPDATE accounts
    SET name = coalesce(?2, name),
        profile_pic_url = coalesce(?3, profile_pic_url),
@@ -2237,11 +2262,11 @@ UPDATE accounts
                coalesce(?4, profile_pic_key),
                ?5)
 )",
-                              account,
-                              name,
-                              pic_url,
-                              pic_key,
-                              updated) > 0;
+                                                             account,
+                                                             name,
+                                                             pic_url,
+                                                             pic_key,
+                                                             updated) > 0;
 
     // Read back rather than compared against the argument: under `message` a null url leaves the
     // old one in place, so what the account now points at is not what was passed in.
@@ -2305,8 +2330,7 @@ void Client::_prefetch_picture(sqlite::Connection& c, int64_t account, const std
     }
 }
 
-void Client::_fetch_picture(
-        const ConversationId& id, std::string url, std::vector<std::byte> key) {
+void Client::_fetch_picture(const ConversationId& id, std::string url, std::vector<std::byte> key) {
     try {
         std::function<void(int64_t, int64_t, std::optional<int>)> progress;
         if (_cbs->display_picture_progress)
@@ -2320,7 +2344,11 @@ void Client::_fetch_picture(
         // coming, and a picture that will not come down now is tried again the moment something
         // asks for it.
         _fetch_cached(
-                {url, std::move(key), {}, std::nullopt, DownloadKind::display_pic,
+                {url,
+                 std::move(key),
+                 {},
+                 std::nullopt,
+                 DownloadKind::display_pic,
                  cache::PROFILE_DIR},
                 std::move(progress),
                 nullptr,
@@ -2359,9 +2387,9 @@ void Client::_reconcile_contacts() {
         auto c = core.database().conn();
         SQLite::Transaction tx{c.sql};
 
-        // Ordered rather than a vector because the deletion pass below looks every stored contact up
-        // in it: scanning instead would make a routine merge quadratic in the size of the contact
-        // list, which is exactly the size that is allowed to be large.
+        // Ordered rather than a vector because the deletion pass below looks every stored contact
+        // up in it: scanning instead would make a routine merge quadratic in the size of the
+        // contact list, which is exactly the size that is allowed to be large.
         std::set<b33> in_config;
 
         for (const auto& entry : contacts) {
@@ -2393,7 +2421,8 @@ void Client::_reconcile_contacts() {
             // message that arrived late must not displace a newer one.
             bool renamed = false;
             if (epoch_seconds(entry.profile_updated) >=
-                c.prepared_get<int64_t>("SELECT profile_updated FROM accounts WHERE id = ?", account))
+                c.prepared_get<int64_t>(
+                        "SELECT profile_updated FROM accounts WHERE id = ?", account))
                 renamed = _update_profile(
                         c,
                         account,
@@ -2413,10 +2442,9 @@ void Client::_reconcile_contacts() {
             // Read before the upsert rather than derived from it: what moves a conversation between
             // the two lists is this one column, and the upsert reports only that *something* in the
             // row changed.
-            bool was_request =
-                    !c.prepared_get<int>(
-                            "SELECT coalesce((SELECT approved FROM contacts WHERE account = ?), 0)",
-                            account);
+            bool was_request = !c.prepared_get<int>(
+                    "SELECT coalesce((SELECT approved FROM contacts WHERE account = ?), 0)",
+                    account);
 
             // Existence here *is* being a contact, so this is an upsert rather than an update: the
             // row appearing is the fact being recorded.
@@ -2427,21 +2455,21 @@ void Client::_reconcile_contacts() {
             // clients clear both flags on their way to deleting a contact, and a device that merged
             // the clearing but not the deletion would otherwise file the conversation back under
             // message requests.
-            bool new_contact = c.prepared_exec(
-                                       R"(
+            bool new_contact =
+                    c.prepared_exec(
+                            R"(
 INSERT INTO contacts (account, nickname, approved, approved_me, blocked) VALUES (?1, ?2, ?3, ?4, ?5)
 ON CONFLICT (account) DO UPDATE
     SET nickname = ?2, approved = max(approved, ?3), approved_me = max(approved_me, ?4), blocked = ?5
 WHERE (nickname, approved, approved_me, blocked)
    IS NOT (?2, max(approved, ?3), max(approved_me, ?4), ?5)
 )",
-                                       account,
-                                       entry.nickname.empty()
-                                               ? std::optional<std::string>{}
-                                               : std::optional<std::string>{entry.nickname},
-                                       entry.approved ? 1 : 0,
-                                       entry.approved_me ? 1 : 0,
-                                       entry.blocked ? 1 : 0) > 0;
+                            account,
+                            entry.nickname.empty() ? std::optional<std::string>{}
+                                                   : std::optional<std::string>{entry.nickname},
+                            entry.approved ? 1 : 0,
+                            entry.approved_me ? 1 : 0,
+                            entry.blocked ? 1 : 0) > 0;
 
             // The config saying a contact exists is what brings the conversation into being -- a
             // conversation is not defined by having messages in it, or emptying one would lose it.
@@ -2449,9 +2477,7 @@ WHERE (nickname, approved, approved_me, blocked)
             bool created = false;
             if (!convo) {
                 auto row = ensure_conversation(
-                        c,
-                        id,
-                        entry.created > 0 ? from_epoch_s(entry.created) : clock_now_ms());
+                        c, id, entry.created > 0 ? from_epoch_s(entry.created) : clock_now_ms());
                 convo = row.id;
                 created = row.created;
             }
@@ -2471,8 +2497,7 @@ WHERE id = ?1
                             entry.mute_until,
                             static_cast<int>(entry.exp_mode),
                             static_cast<int64_t>(entry.exp_timer.count()),
-                            entry.created > 0 ? entry.created
-                                              : epoch_seconds(clock_now_ms())) > 0;
+                            entry.created > 0 ? entry.created : epoch_seconds(clock_now_ms())) > 0;
 
             // Retroactive by definition: what a delete-before instruction is about is the history
             // that was there when someone chose to destroy it, so it is applied to what we hold and
@@ -2482,8 +2507,8 @@ WHERE id = ?1
             if (entry.delete_before > std::chrono::sys_seconds{})
                 history_changed = delete_messages_before(c, *convo, sys_ms{entry.delete_before});
             if (entry.delete_attach_before > std::chrono::sys_seconds{})
-                history_changed |= delete_attachments_before(
-                        c, *convo, sys_ms{entry.delete_attach_before});
+                history_changed |=
+                        delete_attachments_before(c, *convo, sys_ms{entry.delete_attach_before});
             if (history_changed)
                 cleared.push_back(id);
 
@@ -2503,8 +2528,8 @@ WHERE id = ?1
         // *hiding* is a negative priority and arrives as an ordinary settings change above, so an
         // absent entry can only mean the stronger thing.
         //
-        // The account row stays: we may have seen them in a group or community, and their profile is
-        // needed to render that.  What is deleted is the relationship, not the person.
+        // The account row stays: we may have seen them in a group or community, and their profile
+        // is needed to render that.  What is deleted is the relationship, not the person.
         //
         // Safe because the outward sweep runs first (see _reconcile_all): a contact of ours the
         // config has never heard of gets published rather than reaching here.
@@ -2608,17 +2633,16 @@ WHERE id = ?1 AND (pro_revocation_tag, pro_expiry) IS NOT (?2, ?3)
             // backwards on purpose, so that a client can reset one -- and a conflict between two
             // devices at the same seqno resolves by a tie-break that knows nothing about which
             // value is newer.  Left alone, that would make messages someone has read unread again.
-            bool read_changed =
-                    c.prepared_exec(
-                            R"(
+            bool read_changed = c.prepared_exec(
+                                        R"(
 UPDATE conversations
 SET last_read = ?2,
     unread_count = (SELECT COUNT(*) FROM messages
                      WHERE conversation = ?1 AND {} AND timestamp > ?2)
 WHERE id = ?1 AND last_read < ?2
 )"_format(UNREAD),
-                            *convo,
-                            entry.last_read) > 0;
+                                        *convo,
+                                        entry.last_read) > 0;
 
             // The flag is an ordinary setting, though: someone marking a conversation unread on
             // another device is telling us to, and there is no ordering to preserve.
@@ -2674,7 +2698,8 @@ void Client::_sync_convo_volatile(const ConversationId& id) {
     auto& volatiles = core.configs.convo_info_volatile();
 
     // Built on the entry that is there, which is what keeps the Pro fields alive: they are set from
-    // a proof we verified rather than from any row here, so there is nothing to re-derive them from.
+    // a proof we verified rather than from any row here, so there is nothing to re-derive them
+    // from.
     auto entry = volatiles.get_or_construct_1to1(oxenc::to_hex(id.session_id()));
 
     // Forwards only here too, and for the same reason as the merge: our value can be the stale one,
@@ -2705,8 +2730,7 @@ void Client::_sync_conversation(const ConversationId& id) {
 }
 
 void Client::_sync_contact(const ConversationId& id) {
-    if (id.type() != ConversationId::Type::dm ||
-        is_me(id.session_id()))
+    if (id.type() != ConversationId::Type::dm || is_me(id.session_id()))
         return;
 
     auto& contacts = core.configs.contacts();
@@ -2714,18 +2738,18 @@ void Client::_sync_contact(const ConversationId& id) {
 
     auto c = core.database().conn();
     auto row = c.prepared_maybe_get<
-            std::optional<std::string>,   // name
+            std::optional<std::string>,  // name
             std::optional<std::string>,  // profile_pic_url
             // By value rather than as a `blob`, which is a view into the column: the statement is
             // finished by the time this tuple is returned, so a view in it is already dangling and
             // the key reads back with its first bytes overwritten.
             std::optional<sqlite::blob_guts<b32>>,  // profile_pic_key
             int64_t,                                // profile_updated
-            int64_t,                      // pro_flags
-            std::optional<std::string>,   // nickname
-            int,                          // approved
-            int,                          // approved_me
-            int>(                         // blocked
+            int64_t,                                // pro_flags
+            std::optional<std::string>,             // nickname
+            int,                                    // approved
+            int,                                    // approved_me
+            int>(                                   // blocked
             R"(
         SELECT a.name, a.profile_pic_url, a.profile_pic_key, a.profile_updated, a.pro_flags,
                ct.nickname, ct.approved, ct.approved_me, ct.blocked
@@ -2742,7 +2766,14 @@ void Client::_sync_contact(const ConversationId& id) {
         return;
     }
 
-    auto [name, pic_url, pic_key, profile_updated, pro_flags, nickname, approved, approved_me,
+    auto [name,
+          pic_url,
+          pic_key,
+          profile_updated,
+          pro_flags,
+          nickname,
+          approved,
+          approved_me,
           blocked] = *row;
 
     auto convo = c.prepared_maybe_get<int, int, int64_t, int, int64_t, int64_t>(
@@ -2786,8 +2817,7 @@ void Client::_sync_contact(const ConversationId& id) {
 }
 
 void Client::_reveal_note_to_self(const ConversationId& id) {
-    if (id.type() != ConversationId::Type::dm ||
-        !is_me(id.session_id()))
+    if (id.type() != ConversationId::Type::dm || !is_me(id.session_id()))
         return;
 
     auto& profile = core.configs.user_profile();
@@ -2844,9 +2874,9 @@ void Client::_reconcile_user_profile() {
                 ProfileSource::config);
 
         // The config is what says a conversation exists -- a conversation is not defined by having
-        // messages in it, or emptying one would lose it, and reimporting an account would lose every
-        // conversation that happened to be empty.  For note to self that statement is the priority
-        // itself: negative means there is no such conversation, so no row is made for one.
+        // messages in it, or emptying one would lose it, and reimporting an account would lose
+        // every conversation that happened to be empty.  For note to self that statement is the
+        // priority itself: negative means there is no such conversation, so no row is made for one.
         //
         // Guarded by find_conversation rather than calling ensure_conversation outright, because
         // that helper bumps last_activity on a row that already exists: unguarded, every config
@@ -2859,21 +2889,19 @@ void Client::_reconcile_user_profile() {
         }
 
         if (convo) {
-            order_changed =
-                    c.prepared_exec(
-                            "UPDATE conversations SET priority = ?2"
-                            " WHERE id = ?1 AND priority IS NOT ?2",
-                            *convo,
-                            priority) > 0;
-            convo_changed =
-                    c.prepared_exec(
-                            R"(
+            order_changed = c.prepared_exec(
+                                    "UPDATE conversations SET priority = ?2"
+                                    " WHERE id = ?1 AND priority IS NOT ?2",
+                                    *convo,
+                                    priority) > 0;
+            convo_changed = c.prepared_exec(
+                                    R"(
 UPDATE conversations SET exp_mode = ?2, exp_timer = ?3
 WHERE id = ?1 AND (exp_mode, exp_timer) IS NOT (?2, ?3)
 )",
-                            *convo,
-                            exp_mode,
-                            exp_timer) > 0;
+                                    *convo,
+                                    exp_mode,
+                                    exp_timer) > 0;
 
             // Retroactive, and idempotent, for the reasons given in _reconcile_contacts.
             auto delete_before = profile.get_nts_delete_before();
@@ -2913,7 +2941,8 @@ WHERE id = ?1 AND (exp_mode, exp_timer) IS NOT (?2, ?3)
 // reads -- which matters more than being right in a case the wire cannot disambiguate.  And it
 // collapses a multi-match to one row rather than multiplying the outer query.
 //
-// Guarded by the NULL check so a message that is not a reply -- almost all of them -- costs nothing.
+// Guarded by the NULL check so a message that is not a reply -- almost all of them -- costs
+// nothing.
 static constexpr auto WIRE_REF_TARGET = R"(
     CASE WHEN m.reply_timestamp IS NULL THEN NULL ELSE (
         SELECT min(q.id) FROM messages q
@@ -2972,7 +3001,16 @@ static void load_attachments(sqlite::Connection& c, std::vector<Message>& msgs) 
     for (const auto& m : msgs)
         st->bind(n++, m.id);
 
-    for (auto&& [message, idx, ctype, fname, caption, flags, width, height, size, uploaded,
+    for (auto&& [message,
+                 idx,
+                 ctype,
+                 fname,
+                 caption,
+                 flags,
+                 width,
+                 height,
+                 size,
+                 uploaded,
                  saved_at] :
          sqlite::IterableStatementWrapper<
                  int64_t,
@@ -3033,47 +3071,57 @@ static std::vector<Message> build_messages(
         SQLite::Statement& st) {
     std::vector<Message> out;
     while (st.executeStep()) {
-        auto [id, swarm_hash, sender, outgoing, ts, body, send_state, sync_send_state, deleted,
-              gallery, reply_author, reply_ts, reply_id] =
-                sqlite::get<int64_t,
-                            std::optional<std::string>,
-                            sqlite::blob_guts<b33>,
-                            int,
-                            int64_t,
-                            std::string,
-                            std::optional<int>,
-                            std::optional<int>,
-                            std::optional<int>,
-                            int,
-                            std::optional<sqlite::blob_guts<b33>>,
-                            std::optional<int64_t>,
-                            std::optional<int64_t>>(st);
-        out.push_back(
-                Message{.id = id,
-                        .conversation = convo,
-                        .sender = sender,
-                        .outgoing = outgoing != 0,
-                        .timestamp = from_epoch_ms(ts),
-                        .body = std::move(body),
-                        .send_state = send_state
-                                            ? std::optional{static_cast<SendState>(*send_state)}
-                                            : std::nullopt,
-                        .sync_send_state = sync_send_state ? std::optional{static_cast<SendState>(
-                                                                     *sync_send_state)}
-                                                           : std::nullopt,
-                        .hash = std::move(swarm_hash),
-                        .gallery = gallery != 0,
-                        // The author and timestamp are what the wire carried, so they are known
-                        // whether or not the reference resolved; `message_id` is the resolution.
-                        // The message itself is filled in afterwards, in one query for the page.
-                        .reply = reply_author && reply_ts
-                                       ? std::optional{Reply{
-                                                 .author = *reply_author,
-                                                 .timestamp = from_epoch_ms(*reply_ts),
-                                                 .message_id = reply_id}}
-                                       : std::nullopt,
-                        .deleted = deleted ? std::optional{static_cast<Deletion>(*deleted)}
-                                           : std::nullopt});
+        auto [id,
+              swarm_hash,
+              sender,
+              outgoing,
+              ts,
+              body,
+              send_state,
+              sync_send_state,
+              deleted,
+              gallery,
+              reply_author,
+              reply_ts,
+              reply_id] =
+                sqlite::get<
+                        int64_t,
+                        std::optional<std::string>,
+                        sqlite::blob_guts<b33>,
+                        int,
+                        int64_t,
+                        std::string,
+                        std::optional<int>,
+                        std::optional<int>,
+                        std::optional<int>,
+                        int,
+                        std::optional<sqlite::blob_guts<b33>>,
+                        std::optional<int64_t>,
+                        std::optional<int64_t>>(st);
+        out.push_back(Message{
+                .id = id,
+                .conversation = convo,
+                .sender = sender,
+                .outgoing = outgoing != 0,
+                .timestamp = from_epoch_ms(ts),
+                .body = std::move(body),
+                .send_state = send_state ? std::optional{static_cast<SendState>(*send_state)}
+                                         : std::nullopt,
+                .sync_send_state = sync_send_state
+                                         ? std::optional{static_cast<SendState>(*sync_send_state)}
+                                         : std::nullopt,
+                .hash = std::move(swarm_hash),
+                .gallery = gallery != 0,
+                // The author and timestamp are what the wire carried, so they are known
+                // whether or not the reference resolved; `message_id` is the resolution.
+                // The message itself is filled in afterwards, in one query for the page.
+                .reply = reply_author && reply_ts ? std::optional{Reply{
+                                                            .author = *reply_author,
+                                                            .timestamp = from_epoch_ms(*reply_ts),
+                                                            .message_id = reply_id}}
+                                                  : std::nullopt,
+                .deleted =
+                        deleted ? std::optional{static_cast<Deletion>(*deleted)} : std::nullopt});
     }
 
     // Done here rather than by each caller so that every path that produces Messages produces whole
@@ -3081,9 +3129,9 @@ static std::vector<Message> build_messages(
     load_attachments(c, out);
 
     // Only now can the question be answered, since it is about the attachments.  A stored decision
-    // that the current rule no longer supports is dropped rather than honoured -- and dropped in the
-    // database too, so that the next read does not have to reach the same conclusion again, and so
-    // that a client toggling it sees the same state we just reported.
+    // that the current rule no longer supports is dropped rather than honoured -- and dropped in
+    // the database too, so that the next read does not have to reach the same conclusion again, and
+    // so that a client toggling it sees the same state we just reported.
     for (auto& m : out) {
         m.gallery_viewable = gallery_viewable(m.attachments);
         if (m.gallery && !m.gallery_viewable) {
@@ -3238,43 +3286,43 @@ std::optional<std::string> Client::_message_debug(int64_t message_id) {
 
 namespace {
 
-// The reference a quote puts on the wire, read from the message being replied to.
-struct WireRef {
-    b33 author;
-    sys_ms timestamp;
-    std::optional<int64_t> msgid;
-};
+    // The reference a quote puts on the wire, read from the message being replied to.
+    struct WireRef {
+        b33 author;
+        sys_ms timestamp;
+        std::optional<int64_t> msgid;
+    };
 
-// Nullopt if the message is gone by the time the send happens: a send is not worth failing over a
-// reference that can simply be omitted.
-std::optional<WireRef> wire_ref(sqlite::Connection& c, int64_t message_id) {
-    auto row = c.prepared_maybe_get<sqlite::blob_guts<b33>, int64_t, std::optional<int64_t>>(
-            R"(
+    // Nullopt if the message is gone by the time the send happens: a send is not worth failing over
+    // a reference that can simply be omitted.
+    std::optional<WireRef> wire_ref(sqlite::Connection& c, int64_t message_id) {
+        auto row = c.prepared_maybe_get<sqlite::blob_guts<b33>, int64_t, std::optional<int64_t>>(
+                R"(
         SELECT a.session_id, m.timestamp, m.msgid
         FROM messages m JOIN accounts a ON a.id = m.sender
         WHERE m.id = ?
     )",
-            message_id);
-    if (!row)
-        return std::nullopt;
+                message_id);
+        if (!row)
+            return std::nullopt;
 
-    auto& [author, ts, msgid] = *row;
-    return WireRef{.author = author, .timestamp = from_epoch_ms(ts), .msgid = msgid};
-}
+        auto& [author, ts, msgid] = *row;
+        return WireRef{.author = author, .timestamp = from_epoch_ms(ts), .msgid = msgid};
+    }
 
-// Writes a quote naming `ref` onto an outgoing DataMessage.
-//
-// Only the reference goes on.  `text` and the quoted attachments are left unset, because current
-// clients do not populate them either, and one that arrives is not to be trusted: a sender can put
-// whatever words they like in someone else's mouth that way.  Receivers render from their own copy
-// of the message, or from nothing.
-void set_quote(SessionProtos::DataMessage& data, const WireRef& ref) {
-    auto* q = data.mutable_quote();
-    q->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(ref.timestamp)));
-    q->set_author(oxenc::to_hex(ref.author.begin(), ref.author.end()));
-    if (ref.msgid)
-        q->set_msgid(*ref.msgid);
-}
+    // Writes a quote naming `ref` onto an outgoing DataMessage.
+    //
+    // Only the reference goes on.  `text` and the quoted attachments are left unset, because
+    // current clients do not populate them either, and one that arrives is not to be trusted: a
+    // sender can put whatever words they like in someone else's mouth that way.  Receivers render
+    // from their own copy of the message, or from nothing.
+    void set_quote(SessionProtos::DataMessage& data, const WireRef& ref) {
+        auto* q = data.mutable_quote();
+        q->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(ref.timestamp)));
+        q->set_author(oxenc::to_hex(ref.author.begin(), ref.author.end()));
+        if (ref.msgid)
+            q->set_msgid(*ref.msgid);
+    }
 
 }  // namespace
 
@@ -3645,82 +3693,77 @@ void Client::_upload_next(
         };
     }
 
-    req.on_complete =
-            [this, client_id, index, on_upload, plaintext_size](
-                    std::variant<std::pair<network::file_metadata, cleared_b32>, int16_t> result,
-                    bool /*timeout*/) {
-                // Delivered on the network's loop; everything below touches the database, which is
-                // Core's loop's alone.  Nobody is waiting on a callback here -- this is Client's
-                // own continuation -- so a failure has to be turned into the message failing, which
-                // is what the application is watching.
-                loop.call([this,
-                           client_id,
-                           index,
-                           on_upload,
-                           plaintext_size,
-                           result = std::move(result)] {
-                    try {
-                        if (auto* err = std::get_if<int16_t>(&result)) {
-                            log::warning(
-                                    cat,
-                                    "Upload of attachment {} of message {} failed: {}",
-                                    index,
-                                    client_id,
-                                    *err);
-                            if (on_upload)
-                                on_upload(index, 0, 0, *err);
-                            return _fail_attachment_send(client_id);
-                        }
+    req.on_complete = [this, client_id, index, on_upload, plaintext_size](
+                              std::variant<std::pair<network::file_metadata, cleared_b32>, int16_t>
+                                      result,
+                              bool /*timeout*/) {
+        // Delivered on the network's loop; everything below touches the database, which is
+        // Core's loop's alone.  Nobody is waiting on a callback here -- this is Client's
+        // own continuation -- so a failure has to be turned into the message failing, which
+        // is what the application is watching.
+        loop.call([this, client_id, index, on_upload, plaintext_size, result = std::move(result)] {
+            try {
+                if (auto* err = std::get_if<int16_t>(&result)) {
+                    log::warning(
+                            cat,
+                            "Upload of attachment {} of message {} failed: {}",
+                            index,
+                            client_id,
+                            *err);
+                    if (on_upload)
+                        on_upload(index, 0, 0, *err);
+                    return _fail_attachment_send(client_id);
+                }
 
-                        const auto& [meta, key] = std::get<0>(result);
-                        // upload_file always encrypts with the stream scheme, so the url has to say
-                        // so: without the fragment a recipient reaches for the legacy scheme and
-                        // cannot open the file at all.
-                        auto url = network::file_server::generate_download_url(
-                                meta.id,
-                                core.network()->file_server_config,
-                                /*stream_encrypted=*/true);
+                const auto& [meta, key] = std::get<0>(result);
+                // upload_file always encrypts with the stream scheme, so the url has to say
+                // so: without the fragment a recipient reaches for the legacy scheme and
+                // cannot open the file at all.
+                auto url = network::file_server::generate_download_url(
+                        meta.id,
+                        core.network()->file_server_config,
+                        /*stream_encrypted=*/true);
 
-                        {
-                            auto c = core.database().conn();
-                            // The file's own size, not the encrypted one the server reports back:
-                            // `size` on the pointer means the plaintext length everywhere else in
-                            // Session, and for a legacy-encrypted attachment it is what a recipient
-                            // trims the padding by, so an encrypted size there would be wrong in a
-                            // way that breaks decryption rather than merely misreporting.
-                            c.prepared_exec(
-                                    "UPDATE message_attachments SET url = ?, key = ?, size = ?"
-                                    " WHERE message = ? AND idx = ?",
-                                    url,
-                                    std::span<const std::byte>{key},
-                                    plaintext_size,
-                                    client_id,
-                                    static_cast<int64_t>(index));
-                        }
+                {
+                    auto c = core.database().conn();
+                    // The file's own size, not the encrypted one the server reports back:
+                    // `size` on the pointer means the plaintext length everywhere else in
+                    // Session, and for a legacy-encrypted attachment it is what a recipient
+                    // trims the padding by, so an encrypted size there would be wrong in a
+                    // way that breaks decryption rather than merely misreporting.
+                    c.prepared_exec(
+                            "UPDATE message_attachments SET url = ?, key = ?, size = ?"
+                            " WHERE message = ? AND idx = ?",
+                            url,
+                            std::span<const std::byte>{key},
+                            plaintext_size,
+                            client_id,
+                            static_cast<int64_t>(index));
+                }
 
-                        log::debug(
-                                cat,
-                                "Uploaded attachment {} of message {} ({} bytes) to {}",
-                                index,
-                                client_id,
-                                meta.size,
-                                url);
+                log::debug(
+                        cat,
+                        "Uploaded attachment {} of message {} ({} bytes) to {}",
+                        index,
+                        client_id,
+                        meta.size,
+                        url);
 
-                        if (on_upload)
-                            on_upload(index, meta.size, meta.size, 0);
+                if (on_upload)
+                    on_upload(index, meta.size, meta.size, 0);
 
-                        _upload_next(client_id, on_upload);
-                    } catch (const std::exception& e) {
-                        log::error(
-                                cat,
-                                "Recording attachment {} of message {} failed: {}",
-                                index,
-                                client_id,
-                                e.what());
-                        _fail_attachment_send(client_id);
-                    }
-                });
-            };
+                _upload_next(client_id, on_upload);
+            } catch (const std::exception& e) {
+                log::error(
+                        cat,
+                        "Recording attachment {} of message {} failed: {}",
+                        index,
+                        client_id,
+                        e.what());
+                _fail_attachment_send(client_id);
+            }
+        });
+    };
 
     log::debug(cat, "Uploading attachment {} of message {}: {}", idx, client_id, path);
     // Bound to a name: the accessor's span is deliberately unavailable on a temporary.
@@ -3799,14 +3842,14 @@ bool Client::_retry_send(
 // user asked for.
 //
 // `.sessiondl` rather than the conventional `.part` because opening it destroys whatever is already
-// there: somebody's own `report.pdf.part`, from a browser or another downloader, is a plausible file
-// to find next to `report.pdf`, and one named after us is not.  Numbered when even that is taken,
-// which is what lets two saves of the same file into one directory proceed at once.
+// there: somebody's own `report.pdf.part`, from a browser or another downloader, is a plausible
+// file to find next to `report.pdf`, and one named after us is not.  Numbered when even that is
+// taken, which is what lets two saves of the same file into one directory proceed at once.
 //
-// Claiming the name *is* the open, given `std::ios::noreplace` -- C++23, so not here yet, since this
-// builds at C++20 and the macro is guarded on the language version rather than on the library.  With
-// it the open fails when the file exists and two saves cannot pick the same name however they are
-// timed.  Without it the check and the open are two steps, so they still can; that is a much
+// Claiming the name *is* the open, given `std::ios::noreplace` -- C++23, so not here yet, since
+// this builds at C++20 and the macro is guarded on the language version rather than on the library.
+// With it the open fails when the file exists and two saves cannot pick the same name however they
+// are timed.  Without it the check and the open are two steps, so they still can; that is a much
 // narrower window than the fixed name it replaces, which collided every time, and the loser of the
 // race gets a failed save rather than anyone losing a file of their own.  Building at C++23 closes
 // it with no other change.
@@ -3839,8 +3882,7 @@ static std::filesystem::path open_partial(std::ofstream& out, const std::filesys
 // browsers and both desktop file managers produce.
 static std::filesystem::path numbered(const std::filesystem::path& dest, int n) {
     auto out = dest;
-    out.replace_filename(
-            "{} ({}){}"_format(dest.stem().string(), n, dest.extension().string()));
+    out.replace_filename("{} ({}){}"_format(dest.stem().string(), n, dest.extension().string()));
     return out;
 }
 
@@ -3978,7 +4020,7 @@ void Client::_download_decrypted(
     req.request_timeout = ATTACHMENT_REQUEST_TIMEOUT;
     req.overall_timeout = ATTACHMENT_OVERALL_TIMEOUT;
 
-    req.on_data =[state, stream, on_progress, throttle, cancel](
+    req.on_data = [state, stream, on_progress, throttle, cancel](
                           const network::file_metadata& meta, std::span<const std::byte> data) {
         if (state->failure)
             return;
@@ -4032,8 +4074,7 @@ void Client::_download_decrypted(
 
         if (auto* err = std::get_if<int16_t>(&result))
             return fail(
-                    timeout ? "download timed out"s
-                            : "download failed with status {}"_format(*err),
+                    timeout ? "download timed out"s : "download failed with status {}"_format(*err),
                     *err);
 
         if (state->failure)
@@ -4051,9 +4092,8 @@ void Client::_download_decrypted(
                     // and never consults the pointer -- so without it a sender can describe one
                     // file and deliver another.
                     if (claimed_size && state->delivered != *claimed_size)
-                        throw std::runtime_error{
-                                "attachment is {}B but its sender said {}B"_format(
-                                        state->delivered, *claimed_size)};
+                        throw std::runtime_error{"attachment is {}B but its sender said {}B"_format(
+                                state->delivered, *claimed_size)};
                     break;
 
                 case Scheme::plaintext:
@@ -4169,8 +4209,7 @@ void Client::_evict_cache(const std::string& keep) {
     if (!limit)
         return;
 
-    auto total = c.prepared_get<std::optional<int64_t>>(
-                          "SELECT sum(size) FROM attachment_cache")
+    auto total = c.prepared_get<std::optional<int64_t>>("SELECT sum(size) FROM attachment_cache")
                          .value_or(0);
     if (total <= *limit)
         return;
@@ -4236,71 +4275,69 @@ void Client::_save_attachment(
 
     auto finish = [this, state, message_id, index, notify_sender, replace, cb](
                           std::optional<std::string> error) {
-                auto fail = [&](std::string why) {
-                    state->out.close();
-                    std::error_code ec;
-                    std::filesystem::remove(state->partial, ec);
-                    _report(cb, std::optional{std::move(why)}, std::filesystem::path{});
-                };
+        auto fail = [&](std::string why) {
+            state->out.close();
+            std::error_code ec;
+            std::filesystem::remove(state->partial, ec);
+            _report(cb, std::optional{std::move(why)}, std::filesystem::path{});
+        };
 
-                if (error)
-                    return fail(std::move(*error));
+        if (error)
+            return fail(std::move(*error));
 
-                try {
-                    state->out.close();
-                    if (!state->out)
-                        throw std::runtime_error{
-                                "writing {} failed"_format(state->partial.string())};
+        try {
+            state->out.close();
+            if (!state->out)
+                throw std::runtime_error{"writing {} failed"_format(state->partial.string())};
 
-                    // Only now does it get a name a user would recognise -- and only now can it be
-                    // known whether the one they asked for is still free, which is why the choice
-                    // is here rather than where the caller made it.
-                    state->saved_to = final_path(state->dest, replace);
-                    std::filesystem::rename(state->partial, state->saved_to);
-                } catch (const std::exception& e) {
-                    return fail(e.what());
-                }
+            // Only now does it get a name a user would recognise -- and only now can it be
+            // known whether the one they asked for is still free, which is why the choice
+            // is here rather than where the caller made it.
+            state->saved_to = final_path(state->dest, replace);
+            std::filesystem::rename(state->partial, state->saved_to);
+        } catch (const std::exception& e) {
+            return fail(e.what());
+        }
 
-                _report(cb, std::optional<std::string>{}, state->saved_to);
+        _report(cb, std::optional<std::string>{}, state->saved_to);
 
-                // Both of these say the same thing -- that the recipient now has the file -- one to
-                // ourselves and one to the sender, and neither is true until it is on disk under
-                // its final name, which is why they are here rather than anywhere earlier.
-                // Recording it does not depend on telling them: a caller who saved privately still
-                // gets to see that they did.
-                //
-                // Both are also only true when the recipient is *us*.  `saved_at` says the
-                // recipient saved it, which is what lets a sender read it as "the file reached a
-                // person rather than a file server", so stamping it for our own save of something
-                // we sent would claim they have a file they may never have opened.  A note to self
-                // is exempt: there the recipient is us, so saving it really is the recipient
-                // saving it.
-                loop.call([this, message_id, index, notify_sender] {
-                    if (_saved_by_recipient(message_id))
-                        _record_saved(message_id, index, clock_now_ms());
+        // Both of these say the same thing -- that the recipient now has the file -- one to
+        // ourselves and one to the sender, and neither is true until it is on disk under
+        // its final name, which is why they are here rather than anywhere earlier.
+        // Recording it does not depend on telling them: a caller who saved privately still
+        // gets to see that they did.
+        //
+        // Both are also only true when the recipient is *us*.  `saved_at` says the
+        // recipient saved it, which is what lets a sender read it as "the file reached a
+        // person rather than a file server", so stamping it for our own save of something
+        // we sent would claim they have a file they may never have opened.  A note to self
+        // is exempt: there the recipient is us, so saving it really is the recipient
+        // saving it.
+        loop.call([this, message_id, index, notify_sender] {
+            if (_saved_by_recipient(message_id))
+                _record_saved(message_id, index, clock_now_ms());
 
-                    // The account's own answer overrides the caller's, and only downwards.
-                    // Somebody who has said not to report their saves has said it for every client
-                    // on the account, and a client that forgot to ask -- or never grew the setting
-                    // -- would otherwise report them anyway.  A caller passing false is still
-                    // respected: this can refuse a notification, never require one.
-                    if (notify_sender && core.configs.user_profile().get_notify_media_saved())
-                        _notify_media_saved(message_id, index);
-                });
+            // The account's own answer overrides the caller's, and only downwards.
+            // Somebody who has said not to report their saves has said it for every client
+            // on the account, and a client that forgot to ask -- or never grew the setting
+            // -- would otherwise report them anyway.  A caller passing false is still
+            // respected: this can refuse a notification, never require one.
+            if (notify_sender && core.configs.user_profile().get_notify_media_saved())
+                _notify_media_saved(message_id, index);
+        });
     };
 
     // Writes what was fetched to the destination and finishes as a completed download would, for
     // the two paths that hand over a whole buffer rather than streaming into it.
-    auto write_and_finish = [state, finish](
-                                    std::optional<std::string> error,
-                                    const std::vector<std::byte>& data) {
-        if (error)
-            return finish(std::move(error));
-        state->out.write(
-                reinterpret_cast<const char*>(data.data()),
-                static_cast<std::streamsize>(data.size()));
-        finish(std::nullopt);
-    };
+    auto write_and_finish =
+            [state, finish](std::optional<std::string> error, const std::vector<std::byte>& data) {
+                if (error)
+                    return finish(std::move(error));
+                state->out.write(
+                        reinterpret_cast<const char*>(data.data()),
+                        static_cast<std::streamsize>(data.size()));
+                finish(std::nullopt);
+            };
 
     // Served from the cache when it is there.  Indistinguishable to everyone else: the file lands
     // where it was asked to, and the sender is still told we saved it, because being able to skip
@@ -4332,8 +4369,7 @@ void Client::_save_attachment(
             found->second.progress.push_back(report);
         }
         found->second.waiting.push_back(
-                [write_and_finish](
-                        std::optional<std::string> error, std::vector<std::byte> data) {
+                [write_and_finish](std::optional<std::string> error, std::vector<std::byte> data) {
                     write_and_finish(std::move(error), data);
                 });
         return;
@@ -4503,8 +4539,7 @@ void Client::_notify_media_saved(int64_t message_id, size_t index) {
         note->set_msgid(*msgid);
     note->set_attindex(static_cast<int32_t>(index));
 
-    log::debug(
-            cat, "Telling the sender we saved attachment {} of message {}", index, message_id);
+    log::debug(cat, "Telling the sender we saved attachment {} of message {}", index, message_id);
 
     // Registered rather than fired blind: Core reports on every send, and a status for an id nobody
     // claims would sit in _early_status for the life of the process.
@@ -4558,8 +4593,7 @@ void Client::_finish_attachment_send(int64_t client_id) {
         if (reply_author && reply_ts)
             set_quote(
                     *data,
-                    WireRef{
-                            .author = *reply_author,
+                    WireRef{.author = *reply_author,
                             .timestamp = from_epoch_ms(*reply_ts),
                             .msgid = reply_msgid});
 

--- a/src/client/conversation.cpp
+++ b/src/client/conversation.cpp
@@ -7,17 +7,18 @@
 // rather than split by direction.
 //
 // **A handler form must not capture `this`.**  It returns before the work runs, and the caller is
-// under no obligation to keep this object alive until then: the natural way to write any of these is
-// on a temporary (`client.conversation(id, …)` hands one to a handler, and
+// under no obligation to keep this object alive until then: the natural way to write any of these
+// is on a temporary (`client.conversation(id, …)` hands one to a handler, and
 // `*client.conversation(id, wait)` is a temporary outright), and a list element dies whenever the
 // list is replaced.  So each captures the two things the work needs -- the Client, which outlives
 // everything here, and the id, which is a value -- and nothing else.  Capturing `this` reads the id
 // out of freed memory, which surfaces as a `ConversationId::Type` outside the enum and an
 // "unhandled conversation kind" from a long way away.
 //
-// The waiting forms are exempt: `call_get` runs the work before returning, inline when it is already
-// the loop's thread, so there is no window in which the object could have gone.  That asymmetry is
-// also why tests written entirely in the waiting form prove nothing about the handler form.
+// The waiting forms are exempt: `call_get` runs the work before returning, inline when it is
+// already the loop's thread, so there is no window in which the object could have gone.  That
+// asymmetry is also why tests written entirely in the waiting form prove nothing about the handler
+// form.
 
 namespace session::client {
 
@@ -107,16 +108,16 @@ void Conversation::set_priority(int priority, wait_t) {
 }
 
 void Conversation::set_notifications(config::notify_mode mode, failable_function<void()> cb) {
-    _client->_async([c = _client, id = id, mode] { c->_set_notifications(id, mode); },
-                    std::move(cb));
+    _client->_async(
+            [c = _client, id = id, mode] { c->_set_notifications(id, mode); }, std::move(cb));
 }
 void Conversation::set_notifications(config::notify_mode mode, wait_t) {
     _client->loop.call_get([this, mode] { _client->_set_notifications(id, mode); });
 }
 
 void Conversation::set_mute_until(std::chrono::sys_seconds until, failable_function<void()> cb) {
-    _client->_async([c = _client, id = id, until] { c->_set_mute_until(id, until); },
-                    std::move(cb));
+    _client->_async(
+            [c = _client, id = id, until] { c->_set_mute_until(id, until); }, std::move(cb));
 }
 void Conversation::set_mute_until(std::chrono::sys_seconds until, wait_t) {
     _client->loop.call_get([this, until] { _client->_set_mute_until(id, until); });
@@ -124,16 +125,17 @@ void Conversation::set_mute_until(std::chrono::sys_seconds until, wait_t) {
 
 void Conversation::set_expiry(
         config::expiration_mode mode, std::chrono::seconds timer, failable_function<void()> cb) {
-    _client->_async([c = _client, id = id, mode, timer] { c->_set_expiry(id, mode, timer); },
-                    std::move(cb));
+    _client->_async(
+            [c = _client, id = id, mode, timer] { c->_set_expiry(id, mode, timer); },
+            std::move(cb));
 }
 void Conversation::set_expiry(config::expiration_mode mode, std::chrono::seconds timer, wait_t) {
     _client->loop.call_get([this, mode, timer] { _client->_set_expiry(id, mode, timer); });
 }
 
 void Conversation::set_auto_download(AutoDownload mode, failable_function<void()> cb) {
-    _client->_async([c = _client, id = id, mode] { c->_set_auto_download(id, mode); },
-                    std::move(cb));
+    _client->_async(
+            [c = _client, id = id, mode] { c->_set_auto_download(id, mode); }, std::move(cb));
 }
 void Conversation::set_auto_download(AutoDownload mode, wait_t) {
     _client->loop.call_get([this, mode] { _client->_set_auto_download(id, mode); });
@@ -142,7 +144,8 @@ void Conversation::set_auto_download(AutoDownload mode, wait_t) {
 // -- Sending ------------------------------------------------------------------------------------
 
 void Conversation::send_message(
-        OutgoingMessage msg, upload_progress on_upload,
+        OutgoingMessage msg,
+        upload_progress on_upload,
         failable_function<void(int64_t message_id)> cb) {
     _client->_require_sendable("send_message", id, msg);
     _client->_async(
@@ -160,9 +163,8 @@ int64_t Conversation::send_message(OutgoingMessage msg, wait_t) {
 }
 int64_t Conversation::send_message(OutgoingMessage msg, upload_progress on_upload, wait_t) {
     _client->_require_sendable("send_message", id, msg);
-    return _client->loop.call_get([&] {
-        return _client->_send_message(id, msg, std::move(on_upload));
-    });
+    return _client->loop.call_get(
+            [&] { return _client->_send_message(id, msg, std::move(on_upload)); });
 }
 
 // -- Destroying ---------------------------------------------------------------------------------
@@ -190,17 +192,16 @@ void Conversation::delete_conversation(wait_t) {
 }
 void Conversation::delete_conversation(bool keep_messages, wait_t) {
     _client->_require_dm("delete_conversation", id);
-    _client->loop.call_get([this, keep_messages] {
-        _client->_delete_conversation(id, keep_messages);
-    });
+    _client->loop.call_get(
+            [this, keep_messages] { _client->_delete_conversation(id, keep_messages); });
 }
 
 // -- One-to-one only ----------------------------------------------------------------------------
 
 void DM::set_blocked(bool blocked, failable_function<void()> cb) {
     _client->_require_contact("set_blocked", id);
-    _client->_async([c = _client, id = id, blocked] { c->_set_blocked(id, blocked); },
-                    std::move(cb));
+    _client->_async(
+            [c = _client, id = id, blocked] { c->_set_blocked(id, blocked); }, std::move(cb));
 }
 void DM::set_blocked(bool blocked, wait_t) {
     _client->_require_contact("set_blocked", id);
@@ -210,7 +211,9 @@ void DM::set_blocked(bool blocked, wait_t) {
 void DM::set_nickname(std::string_view nickname, failable_function<void()> cb) {
     _client->_require_contact("set_nickname", id);
     _client->_async(
-            [c = _client, id = id, nickname = std::string{nickname}] { c->_set_nickname(id, nickname); },
+            [c = _client, id = id, nickname = std::string{nickname}] {
+                c->_set_nickname(id, nickname);
+            },
             std::move(cb));
 }
 void DM::set_nickname(std::string_view nickname, wait_t) {

--- a/src/client/download_cache.cpp
+++ b/src/client/download_cache.cpp
@@ -1,14 +1,14 @@
 #include "download_cache.hpp"
 
-#include <oxen/log.hpp>
 #include <oxenc/hex.h>
+
+#include <cstring>
+#include <fstream>
+#include <oxen/log.hpp>
 #include <session/attachments.hpp>
 #include <session/format.hpp>
 #include <session/hash.hpp>
 #include <session/random.hpp>
-
-#include <cstring>
-#include <fstream>
 
 namespace session::client::cache {
 
@@ -17,11 +17,11 @@ static auto cat = log::Cat("client");
 
 namespace {
 
-std::string_view base_url(std::string_view url) {
-    if (auto q = url.find_first_of("?#"); q != std::string_view::npos)
-        url = url.substr(0, q);
-    return url;
-}
+    std::string_view base_url(std::string_view url) {
+        if (auto q = url.find_first_of("?#"); q != std::string_view::npos)
+            url = url.substr(0, q);
+        return url;
+    }
 
 }  // namespace
 
@@ -43,8 +43,7 @@ std::optional<std::vector<std::byte>> read(
 
         std::vector<std::byte> encrypted(static_cast<size_t>(in.tellg()));
         in.seekg(0);
-        in.read(
-                reinterpret_cast<char*>(encrypted.data()),
+        in.read(reinterpret_cast<char*>(encrypted.data()),
                 static_cast<std::streamsize>(encrypted.size()));
 
         return attachment::decrypt(encrypted, key);

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -217,11 +217,9 @@ void Contacts::set(const contact_info& contact) {
     set_ts(info["d"], contact.delete_before);
     // Deleting the messages takes their attachments with them, so an attachment instruction at or
     // before that point says nothing further and is dropped rather than stored.
-    set_ts(
-            info["D"],
-            contact.delete_attach_before <= contact.delete_before
-                    ? std::chrono::sys_seconds{}
-                    : contact.delete_attach_before);
+    set_ts(info["D"],
+           contact.delete_attach_before <= contact.delete_before ? std::chrono::sys_seconds{}
+                                                                 : contact.delete_attach_before);
 
     set_flag(info["a"], contact.approved);
     set_flag(info["A"], contact.approved_me);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -158,19 +158,14 @@ void Core::_poll() {
 
     log::debug(cat, "Polling swarm for {}", globals.session_id_hex());
 
-    net->get_swarm(
-            globals.pubkey_x25519(), false, [this, net](auto, auto swarm) {
-                if (swarm.empty()) {
-                    log::warning(cat, "Cannot poll: no swarm nodes available");
-                    return;
-                }
+    net->get_swarm(globals.pubkey_x25519(), false, [this, net](auto, auto swarm) {
+        if (swarm.empty()) {
+            log::warning(cat, "Cannot poll: no swarm nodes available");
+            return;
+        }
 
-                _send_poll(
-                        net,
-                        swarm.front(),
-                        {POLL_NAMESPACES.begin(), POLL_NAMESPACES.end()},
-                        0);
-            });
+        _send_poll(net, swarm.front(), {POLL_NAMESPACES.begin(), POLL_NAMESPACES.end()}, 0);
+    });
 }
 
 void Core::_send_poll(
@@ -717,10 +712,7 @@ void Core::delete_from_swarm(
 
                 net->send_request(
                         swarm_request(
-                                swarm.front(),
-                                globals.pubkey_x25519(),
-                                "delete",
-                                std::move(body)),
+                                swarm.front(), globals.pubkey_x25519(), "delete", std::move(body)),
                         [this, hashes = std::move(hashes), on_complete](
                                 bool success,
                                 bool timeout,
@@ -867,7 +859,9 @@ void Core::_send_to_swarm(
                                         hash = h->get<std::string>();
                                 } catch (const std::exception& e) {
                                     log::warning(
-                                            cat, "Could not read stored message hash: {}", e.what());
+                                            cat,
+                                            "Could not read stored message hash: {}",
+                                            e.what());
                                 }
                             }
                             on_complete(

--- a/src/core/configs.cpp
+++ b/src/core/configs.cpp
@@ -1,10 +1,9 @@
 #include "session/core/configs.hpp"
 
-#include <oxen/log.hpp>
-#include <oxen/quic/loop.hpp>
-
 #include <algorithm>
 #include <nlohmann/json.hpp>
+#include <oxen/log.hpp>
+#include <oxen/quic/loop.hpp>
 #include <session/clock.hpp>
 #include <session/config/base.hpp>
 #include <session/config/contacts.hpp>
@@ -44,8 +43,7 @@ void Configs::_load() {
     // reused as the iteration advances.
     std::unordered_map<std::string, std::vector<std::byte>> dumps;
     for (auto [type, data] : conn().prepared_results<std::string, sqlite::blob>(
-                 "SELECT type, data FROM config_dumps WHERE pubkey = ?",
-                 core.globals.session_id()))
+                 "SELECT type, data FROM config_dumps WHERE pubkey = ?", core.globals.session_id()))
         dumps.emplace(std::move(type), std::vector<std::byte>{data.begin(), data.end()});
 
     auto stored = [&dumps](std::string_view type) -> std::optional<std::span<const std::byte>> {
@@ -236,10 +234,7 @@ void Configs::initialise_new_account() {
 
 std::vector<config::ConfigBase*> Configs::_pushable() {
     _load();
-    return {_user_profile.get(),
-            _contacts.get(),
-            _convo_info_volatile.get(),
-            _user_groups.get()};
+    return {_user_profile.get(), _contacts.get(), _convo_info_volatile.get(), _user_groups.get()};
 }
 
 bool Configs::needs_push() {

--- a/src/core/devices.cpp
+++ b/src/core/devices.cpp
@@ -846,12 +846,12 @@ std::vector<std::byte> Devices::encrypt_device_data(const device::map& devices) 
     // Dynamic ss subspan accessor of ml_ss_raw, but *doesn't* go through the pos_map (unlike the
     // above constructs), and only goes up to the actual number of devices, not the padded number
     // (because this is never transmitted, and so not shuffled or padded).
-    auto ml_ss = std::views::iota(size_t{0}, recipients.size()) |
-                 std::views::transform([&](size_t i) {
-                     return std::span<std::byte, mlkem768::SHAREDSECRETBYTES>{
-                             ml_ss_raw.data() + i * mlkem768::SHAREDSECRETBYTES,
-                             mlkem768::SHAREDSECRETBYTES};
-                 });
+    auto ml_ss =
+            std::views::iota(size_t{0}, recipients.size()) | std::views::transform([&](size_t i) {
+                return std::span<std::byte, mlkem768::SHAREDSECRETBYTES>{
+                        ml_ss_raw.data() + i * mlkem768::SHAREDSECRETBYTES,
+                        mlkem768::SHAREDSECRETBYTES};
+            });
 
     cleared_b32 rnd;
     int i = -1;
@@ -1054,7 +1054,7 @@ void Devices::receive_device_group_message(std::span<const std::byte> data) {
         // device that was never in the group: our own row before the group is established, and a
         // denied link request.  Those must still be able to register.
         auto kicked = c.prepared_maybe_get<std::optional<int64_t>>(
-                              "SELECT kicked_timestamp FROM devices WHERE unique_id = ?", id)
+                               "SELECT kicked_timestamp FROM devices WHERE unique_id = ?", id)
                               .value_or(std::nullopt);
         if (kicked) {
             log::warning(

--- a/src/network/routing/session_router_router.cpp
+++ b/src/network/routing/session_router_router.cpp
@@ -361,10 +361,7 @@ void SessionRouter::_start_file_upload(
                         return nullptr;
 
                     return &_get_file_client(
-                            *pubkey,
-                            "::1",
-                            held.tunnel->local_port,
-                            TUNNELED_QUIC_MAX_UDP_PAYLOAD);
+                            *pubkey, "::1", held.tunnel->local_port, TUNNELED_QUIC_MAX_UDP_PAYLOAD);
                 });
 
         _jq.call([this, upload_id] { _cleanup_upload(upload_id); });
@@ -1095,28 +1092,28 @@ void SessionRouter::_download_internal(DownloadRequest request) {
 
     auto& held = _tunnel(quic_target->address);
     held.tunnel = srouter->establish_udp(
-                quic_target->address,
-                quic_target->port,
-                [weak_self = weak_from_this(), this, request, download_id, file_id](
-                        router::tunnel_info info) mutable {
-                    if (auto self = weak_self.lock())
-                        _quic_download_via_tunnel(
-                                request, download_id, std::move(file_id), std::move(info));
-                },
-                [weak_self = weak_from_this(), this, request, download_id](
-                        router::tunnel_failure failure) {
-                    if (auto self = weak_self.lock()) {
-                        bool timeout = failure == router::tunnel_failure::timeout;
-                        log::error(
-                                cat,
-                                "[Download {}]: Tunnel establishment failed: {}.",
-                                download_id,
-                                timeout ? "timed out" : "remote is unreachable");
-                        _active_downloads.erase(download_id);
-                        request.on_complete(
-                                timeout ? ERROR_BUILD_TIMEOUT : ERROR_INVALID_DESTINATION, timeout);
-                    }
-                });
+            quic_target->address,
+            quic_target->port,
+            [weak_self = weak_from_this(), this, request, download_id, file_id](
+                    router::tunnel_info info) mutable {
+                if (auto self = weak_self.lock())
+                    _quic_download_via_tunnel(
+                            request, download_id, std::move(file_id), std::move(info));
+            },
+            [weak_self = weak_from_this(), this, request, download_id](
+                    router::tunnel_failure failure) {
+                if (auto self = weak_self.lock()) {
+                    bool timeout = failure == router::tunnel_failure::timeout;
+                    log::error(
+                            cat,
+                            "[Download {}]: Tunnel establishment failed: {}.",
+                            download_id,
+                            timeout ? "timed out" : "remote is unreachable");
+                    _active_downloads.erase(download_id);
+                    request.on_complete(
+                            timeout ? ERROR_BUILD_TIMEOUT : ERROR_INVALID_DESTINATION, timeout);
+                }
+            });
     if (!held.tunnel) {
         // Neither callback fires when the remote is unreachable, so this is the only chance to
         // report it.
@@ -1283,10 +1280,7 @@ void SessionRouter::_establish_tunnel(
 
                     for (auto&& [req, cb] : std::move(requests_to_process))
                         _send_via_tunnel(
-                                info.remote,
-                                info.local_port,
-                                std::move(req),
-                                std::move(cb));
+                                info.remote, info.local_port, std::move(req), std::move(cb));
                 }
             },
             [weak_self = weak_from_this(), this, address_pubkey_hex, initiating_req_id](

--- a/src/network/session_network.cpp
+++ b/src/network/session_network.cpp
@@ -1358,7 +1358,6 @@ LIBSESSION_C_API session_network_config session_network_config_default() {
         default: config.transport = SESSION_NETWORK_TRANSPORT_QUIC;
     }
 
-
     config.increase_no_file_limit = cpp_defaults.increase_no_file_limit;
     config.path_length = cpp_defaults.path_length;
     config.enforce_subnet_diversity = cpp_defaults.enforce_subnet_diversity;
@@ -1488,41 +1487,36 @@ LIBSESSION_C_API bool session_network_init(
             cpp_opts.emplace_back(opt::disable_subnet_diversity{});
 
         if (config->min_retry_delay_ms > 0 || config->max_retry_delay_ms > 0)
-            cpp_opts.emplace_back(
-                    opt::retry_delay{
-                            std::chrono::milliseconds{config->min_retry_delay_ms},
-                            std::chrono::milliseconds{config->max_retry_delay_ms}});
+            cpp_opts.emplace_back(opt::retry_delay{
+                    std::chrono::milliseconds{config->min_retry_delay_ms},
+                    std::chrono::milliseconds{config->max_retry_delay_ms}});
 
         // A `0` value is valid for this option
         cpp_opts.emplace_back(opt::redirect_retry_count{config->redirect_retry_count});
 
         if (config->num_nodes_to_check_for_network_offset > 0)
-            cpp_opts.emplace_back(
-                    opt::num_nodes_to_check_for_network_offset{
-                            config->num_nodes_to_check_for_network_offset});
+            cpp_opts.emplace_back(opt::num_nodes_to_check_for_network_offset{
+                    config->num_nodes_to_check_for_network_offset});
 
         if (config->min_resume_clock_resync_interval_minutes > 0)
-            cpp_opts.emplace_back(
-                    opt::min_resume_clock_resync_interval{std::chrono::minutes{
-                            config->min_resume_clock_resync_interval_minutes}});
+            cpp_opts.emplace_back(opt::min_resume_clock_resync_interval{
+                    std::chrono::minutes{config->min_resume_clock_resync_interval_minutes}});
 
         // Snode cache
         if (config->cache_dir)
             cpp_opts.emplace_back(opt::cache_directory{std::filesystem::path{config->cache_dir}});
 
         if (config->fallback_snode_pool_path)
-            cpp_opts.emplace_back(
-                    opt::fallback_snode_pool_path{
-                            std::filesystem::path{config->fallback_snode_pool_path}});
+            cpp_opts.emplace_back(opt::fallback_snode_pool_path{
+                    std::filesystem::path{config->fallback_snode_pool_path}});
 
         if (config->cache_expiration_minutes > 0)
             cpp_opts.emplace_back(
                     opt::cache_expiration{std::chrono::minutes{config->cache_expiration_minutes}});
 
         if (config->cache_min_lifetime_ms > 0)
-            cpp_opts.emplace_back(
-                    opt::cache_min_lifetime{
-                            std::chrono::milliseconds{config->cache_min_lifetime_ms}});
+            cpp_opts.emplace_back(opt::cache_min_lifetime{
+                    std::chrono::milliseconds{config->cache_min_lifetime_ms}});
 
         if (config->cache_min_size > 0)
             cpp_opts.emplace_back(opt::cache_min_size{config->cache_min_size});
@@ -1531,12 +1525,10 @@ LIBSESSION_C_API bool session_network_init(
             cpp_opts.emplace_back(opt::cache_min_swarm_size{config->cache_min_swarm_size});
 
         // A `0` value is valid for these options
-        cpp_opts.emplace_back(
-                opt::cache_num_nodes_to_use_for_refresh{
-                        config->cache_num_nodes_to_use_for_refresh});
-        cpp_opts.emplace_back(
-                opt::cache_min_num_refresh_presence_to_include_node{
-                        config->cache_min_num_refresh_presence_to_include_node});
+        cpp_opts.emplace_back(opt::cache_num_nodes_to_use_for_refresh{
+                config->cache_num_nodes_to_use_for_refresh});
+        cpp_opts.emplace_back(opt::cache_min_num_refresh_presence_to_include_node{
+                config->cache_min_num_refresh_presence_to_include_node});
 
         if (config->cache_node_strike_threshold > 0)
             cpp_opts.emplace_back(
@@ -1550,25 +1542,20 @@ LIBSESSION_C_API bool session_network_init(
                     cpp_opts.emplace_back(opt::path_length{config->path_length});
 
                 if (config->onionreq_path_strike_threshold > 0)
-                    cpp_opts.emplace_back(
-                            opt::onionreq_path_strike_threshold{
-                                    config->onionreq_path_strike_threshold});
+                    cpp_opts.emplace_back(opt::onionreq_path_strike_threshold{
+                            config->onionreq_path_strike_threshold});
 
                 if (config->onionreq_path_build_retry_limit > 0)
-                    cpp_opts.emplace_back(
-                            opt::onionreq_path_build_retry_limit{
-                                    config->onionreq_path_build_retry_limit});
+                    cpp_opts.emplace_back(opt::onionreq_path_build_retry_limit{
+                            config->onionreq_path_build_retry_limit});
 
                 if (config->onionreq_min_path_count_standard > 0)
-                    cpp_opts.emplace_back(
-                            opt::onionreq_min_path_count{
-                                    PathCategory::standard,
-                                    config->onionreq_min_path_count_standard});
+                    cpp_opts.emplace_back(opt::onionreq_min_path_count{
+                            PathCategory::standard, config->onionreq_min_path_count_standard});
 
                 if (config->onionreq_min_path_count_file > 0)
-                    cpp_opts.emplace_back(
-                            opt::onionreq_min_path_count{
-                                    PathCategory::file, config->onionreq_min_path_count_file});
+                    cpp_opts.emplace_back(opt::onionreq_min_path_count{
+                            PathCategory::file, config->onionreq_min_path_count_file});
 
                 if (config->onionreq_single_path_mode)
                     cpp_opts.emplace_back(opt::onionreq_single_path_mode{});
@@ -1582,9 +1569,8 @@ LIBSESSION_C_API bool session_network_init(
                                     config->onionreq_path_rotation_frequency_minutes}});
 
                 if (config->onionreq_edge_node_cache_duration_days > 0)
-                    cpp_opts.emplace_back(
-                            opt::onionreq_edge_node_cache_duration{std::chrono::days{
-                                    config->onionreq_edge_node_cache_duration_days}});
+                    cpp_opts.emplace_back(opt::onionreq_edge_node_cache_duration{
+                            std::chrono::days{config->onionreq_edge_node_cache_duration_days}});
                 break;
 
             case SESSION_NETWORK_ROUTER_SESSION_ROUTER:
@@ -1600,14 +1586,12 @@ LIBSESSION_C_API bool session_network_init(
         switch (config->transport) {
             case SESSION_NETWORK_TRANSPORT_QUIC:
                 if (config->quic_handshake_timeout_seconds > 0)
-                    cpp_opts.emplace_back(
-                            opt::quic_handshake_timeout{
-                                    std::chrono::seconds{config->quic_handshake_timeout_seconds}});
+                    cpp_opts.emplace_back(opt::quic_handshake_timeout{
+                            std::chrono::seconds{config->quic_handshake_timeout_seconds}});
 
                 if (config->quic_keep_alive_seconds > 0)
-                    cpp_opts.emplace_back(
-                            opt::quic_keep_alive{
-                                    std::chrono::seconds{config->quic_keep_alive_seconds}});
+                    cpp_opts.emplace_back(opt::quic_keep_alive{
+                            std::chrono::seconds{config->quic_keep_alive_seconds}});
 
                 if (config->quic_max_udp_payload > 0)
                     cpp_opts.emplace_back(opt::quic_max_udp_payload{config->quic_max_udp_payload});

--- a/tests/live/test_attachment_send.cpp
+++ b/tests/live/test_attachment_send.cpp
@@ -120,8 +120,8 @@ TEST_CASE(
     CHECK(ptr.contenttype() == "application/octet-stream");
 
     // The file's own size, exactly -- not the encrypted size the file server reports back, which is
-    // larger and is what every other client would misread.  Pinned to the byte rather than to `> 0`,
-    // which is what let the two be confused in the first place.
+    // larger and is what every other client would misread.  Pinned to the byte rather than to `>
+    // 0`, which is what let the two be confused in the first place.
     CHECK(ptr.size() == contents.size());
 
     // The url has to be one the download path can actually use, rather than merely non-empty.

--- a/tests/test_attachment_encrypt.cpp
+++ b/tests/test_attachment_encrypt.cpp
@@ -746,8 +746,9 @@ TEST_CASE("Display picture decryption -- the legacy GCM scheme", "[attachments][
     CHECK_THROWS(attachment::legacy_display_pic_decrypt(blob.subspan(0, 27), key));
 }
 
-TEST_CASE("legacy attachment decryption holds the sender to the size they claimed",
-          "[attachments][legacy][size]") {
+TEST_CASE(
+        "legacy attachment decryption holds the sender to the size they claimed",
+        "[attachments][legacy][size]") {
     // Over-reporting has always failed: the claim exceeds what came out.
     CHECK_THROWS(attachment::legacy_decrypt(
             LEGACY_BLOB, legacy_key(), legacy_digest(), LEGACY_PLAINTEXT.size() + 1));

--- a/tests/test_backend_session_file_server.cpp
+++ b/tests/test_backend_session_file_server.cpp
@@ -47,10 +47,8 @@ TEST_CASE("Download url parsing", "[backend][session_file_server]") {
     CHECK_FALSE(parsed_download_url->wants_stream_decryption);
 
     // Ignores the pubkey if it matches the default one
-    parsed_download_url = file_server::parse_download_url(
-            fmt::format(
-                    "https://example.com/file/abc123#p={}"sv,
-                    file_server::DEFAULT_CONFIG.pubkey_hex));
+    parsed_download_url = file_server::parse_download_url(fmt::format(
+            "https://example.com/file/abc123#p={}"sv, file_server::DEFAULT_CONFIG.pubkey_hex));
     REQUIRE(parsed_download_url.has_value());
     CHECK(parsed_download_url->scheme == "https"sv);
     CHECK(parsed_download_url->host == "example.com"sv);

--- a/tests/test_client/attachments.cpp
+++ b/tests/test_client/attachments.cpp
@@ -162,7 +162,8 @@ TEST_CASE("Client: a message reports the attachments it carries", "[client][send
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: saving an attachment fetches, decrypts and reports it", "[client][attachments]") {
+TEST_CASE(
+        "Client: saving an attachment fetches, decrypts and reports it", "[client][attachments]") {
     TempClient c;
     SenderKeys peer;
     auto* net = attach_mock_network(c->core);
@@ -177,7 +178,14 @@ TEST_CASE("Client: saving an attachment fetches, decrypts and reports it", "[cli
     auto seed = random::random(32);
     auto [ciphertext, key] = attachment::encrypt(seed, plaintext, attachment::Domain::ATTACHMENT);
 
-    deliver(*c, peer, "", from_epoch_ms(1000), "h1", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            from_epoch_ms(1000),
+            "h1",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& data) {
                 auto* a = data.add_attachments();
                 a->set_id(1);
@@ -201,7 +209,9 @@ TEST_CASE("Client: saving an attachment fetches, decrypts and reports it", "[cli
     std::promise<std::optional<std::string>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            msg_id, 0, dest,
+            msg_id,
+            0,
+            dest,
             [&](const AttachmentProgress& p) { reports.push_back(p); },
             [&](std::optional<std::string> err, std::filesystem::path) {
                 done.set_value(std::move(err));
@@ -256,8 +266,9 @@ TEST_CASE("Client: saving an attachment fetches, decrypts and reports it", "[cli
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: a save can be kept to ourselves, and a bad one writes nothing",
-          "[client][attachments]") {
+TEST_CASE(
+        "Client: a save can be kept to ourselves, and a bad one writes nothing",
+        "[client][attachments]") {
     TempClient c;
     SenderKeys peer;
     auto* net = attach_mock_network(c->core);
@@ -287,7 +298,10 @@ TEST_CASE("Client: a save can be kept to ourselves, and a bad one writes nothing
         auto done = std::make_shared<std::promise<std::optional<std::string>>>();
         auto waiter = done->get_future();
         c->Client::save_attachment(
-                msg_id, 0, dest, nullptr,
+                msg_id,
+                0,
+                dest,
+                nullptr,
                 [done](std::optional<std::string> err, std::filesystem::path) {
                     done->set_value(std::move(err));
                 },
@@ -389,7 +403,10 @@ TEST_CASE("Client: an attachment we sent can be saved back", "[client][attachmen
     std::promise<std::optional<std::string>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            msg->id, 0, dest, nullptr,
+            msg->id,
+            0,
+            dest,
+            nullptr,
             [&done](std::optional<std::string> err, std::filesystem::path) {
                 done.set_value(std::move(err));
             });
@@ -414,8 +431,9 @@ TEST_CASE("Client: an attachment we sent can be saved back", "[client][attachmen
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: a save does not destroy files it was not asked to touch",
-          "[client][attachments]") {
+TEST_CASE(
+        "Client: a save does not destroy files it was not asked to touch",
+        "[client][attachments]") {
     TempClient c;
     auto* net = attach_mock_network(c->core);
 
@@ -454,7 +472,10 @@ TEST_CASE("Client: a save does not destroy files it was not asked to touch",
     std::promise<std::pair<std::optional<std::string>, std::filesystem::path>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            id, 0, dest, nullptr,
+            id,
+            0,
+            dest,
+            nullptr,
             [&done](std::optional<std::string> err, std::filesystem::path where) {
                 done.set_value({std::move(err), std::move(where)});
             });
@@ -474,8 +495,8 @@ TEST_CASE("Client: a save does not destroy files it was not asked to touch",
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: an approved replacement is not renamed out of the way",
-          "[client][attachments]") {
+TEST_CASE(
+        "Client: an approved replacement is not renamed out of the way", "[client][attachments]") {
     TempClient c;
     auto* net = attach_mock_network(c->core);
 
@@ -506,7 +527,10 @@ TEST_CASE("Client: an approved replacement is not renamed out of the way",
     std::promise<std::filesystem::path> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            id, 0, dest, nullptr,
+            id,
+            0,
+            dest,
+            nullptr,
             [&done](std::optional<std::string>, std::filesystem::path where) {
                 done.set_value(std::move(where));
             },
@@ -525,8 +549,9 @@ TEST_CASE("Client: an approved replacement is not renamed out of the way",
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: saving what we sent someone else does not claim they saved it",
-          "[client][attachments]") {
+TEST_CASE(
+        "Client: saving what we sent someone else does not claim they saved it",
+        "[client][attachments]") {
     TempClient c;
     auto* net = attach_mock_network(c->core);
 
@@ -553,8 +578,7 @@ TEST_CASE("Client: saving what we sent someone else does not claim they saved it
     std::promise<std::optional<std::string>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            id, 0, dest, nullptr,
-            [&done](std::optional<std::string> err, std::filesystem::path) {
+            id, 0, dest, nullptr, [&done](std::optional<std::string> err, std::filesystem::path) {
                 done.set_value(std::move(err));
             });
     sync(*c);
@@ -601,7 +625,8 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
     auto sent = c->message(id, wait);
     REQUIRE(sent.has_value());
     REQUIRE(sent->attachments.size() == 2);
-    // Nobody has said anything yet, and an upload reaching the file server is not someone saving it.
+    // Nobody has said anything yet, and an upload reaching the file server is not someone saving
+    // it.
     CHECK_FALSE(sent->attachments[0].saved_at.has_value());
     CHECK_FALSE(sent->attachments[1].saved_at.has_value());
 
@@ -630,11 +655,13 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
     };
 
     auto saved_at = from_epoch_ms(9'000'000);
-    notify([&](auto* note) {
-        note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
-        note->set_msgid(msgid);
-        note->set_attindex(1);
-    }, saved_at);
+    notify(
+            [&](auto* note) {
+                note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
+                note->set_msgid(msgid);
+                note->set_attindex(1);
+            },
+            saved_at);
 
     auto after = c->message(id, wait);
     REQUIRE(after.has_value());
@@ -646,11 +673,13 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
 
     // -1 is "all of them, together", which is what saving from a gallery view reports.
     auto all_at = from_epoch_ms(9'500'000);
-    notify([&](auto* note) {
-        note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
-        note->set_msgid(msgid);
-        note->set_attindex(-1);
-    }, all_at);
+    notify(
+            [&](auto* note) {
+                note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
+                note->set_msgid(msgid);
+                note->set_attindex(-1);
+            },
+            all_at);
 
     auto all = c->message(id, wait);
     REQUIRE(all->attachments[0].saved_at == all_at);
@@ -661,11 +690,13 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
     // A notification naming a message we do not have changes nothing, and neither does one that
     // names no message at all -- which is every notification the other clients send today, since
     // their `timestamp` field means something different in each of them.
-    notify([&](auto* note) {
-        note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
-        note->set_msgid(msgid + 1);
-        note->set_attindex(0);
-    }, from_epoch_ms(9'900'000));
+    notify(
+            [&](auto* note) {
+                note->set_msgtimestamp(static_cast<uint64_t>(epoch_ms(sent->timestamp)));
+                note->set_msgid(msgid + 1);
+                note->set_attindex(0);
+            },
+            from_epoch_ms(9'900'000));
     notify([&](auto* note) { note->set_timestamp(12345); }, from_epoch_ms(9'900'000));
 
     auto unchanged = c->message(id, wait);
@@ -705,7 +736,14 @@ TEST_CASE("Client: a legacy attachment is saved", "[client][attachments][legacy]
 
     // No `d` fragment on the url, a 64-byte key and a digest: that combination is what tells the
     // save which of the two schemes to use, and nothing else does.
-    deliver(*c, peer, "", from_epoch_ms(3000), "legacy_hash", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            from_epoch_ms(3000),
+            "legacy_hash",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& data) {
                 auto* a = data.add_attachments();
                 a->set_id(9);
@@ -713,8 +751,7 @@ TEST_CASE("Client: a legacy attachment is saved", "[client][attachments][legacy]
                 a->set_key(std::string{
                         reinterpret_cast<const char*>(LEGACY_KEY.data()), LEGACY_KEY.size()});
                 a->set_digest(std::string{
-                        reinterpret_cast<const char*>(LEGACY_DIGEST.data()),
-                        LEGACY_DIGEST.size()});
+                        reinterpret_cast<const char*>(LEGACY_DIGEST.data()), LEGACY_DIGEST.size()});
                 a->set_size(LEGACY_TEXT.size());
                 a->set_filename("legacy.txt");
             },
@@ -732,7 +769,10 @@ TEST_CASE("Client: a legacy attachment is saved", "[client][attachments][legacy]
     std::promise<std::optional<std::string>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            msgs[0].id, 0, dest, nullptr,
+            msgs[0].id,
+            0,
+            dest,
+            nullptr,
             [&done](std::optional<std::string> err, std::filesystem::path) {
                 done.set_value(std::move(err));
             });
@@ -795,7 +835,8 @@ TEST_CASE(
             {.body = "here you go", .attachments = {OutgoingAttachment{.path = file}}},
             [&](size_t idx, int64_t sent, int64_t total, std::optional<int> result) {
                 reports.emplace_back(idx, sent, total, result);
-            }, wait);
+            },
+            wait);
     sync(*c);
 
     auto msg = c->message(id, wait);
@@ -833,9 +874,8 @@ TEST_CASE(
     auto id = c->send_message(
             ConversationId::dm(me),
             {.body = "here you go", .attachments = {OutgoingAttachment{.path = file}}},
-            [&](size_t, int64_t, int64_t, std::optional<int> result) {
-                results.push_back(result);
-            }, wait);
+            [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
+            wait);
     sync(*c);
 
     // With no network the upload cannot start, so the one report is its failure -- which is the
@@ -872,9 +912,7 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     std::vector<std::optional<int>> results;
     CHECK(c->retry_send(
             id,
-            [&](size_t, int64_t, int64_t, std::optional<int> result) {
-                results.push_back(result);
-            },
+            [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
             wait));
     sync(*c);
     REQUIRE(results.size() == 1);
@@ -887,9 +925,7 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     results.clear();
     CHECK(c->retry_send(
             id,
-            [&](size_t, int64_t, int64_t, std::optional<int> result) {
-                results.push_back(result);
-            },
+            [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
             wait));
     sync(*c);
     REQUIRE(results.size() == 1);
@@ -900,15 +936,15 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     CHECK_FALSE(c->retry_send(id, wait));
 }
 
-TEST_CASE("Client: a stream attachment must be the size its sender claimed",
-          "[client][attachments][size]") {
+TEST_CASE(
+        "Client: a stream attachment must be the size its sender claimed",
+        "[client][attachments][size]") {
     // The pointer's size is exact -- the file server is told the byte count up front and refuses
     // anything else -- so a file that decrypts to a different length is not a file we asked for.
     // Nothing else catches this for a stream attachment: the format strips its own padding and
     // never consults the pointer, so before this the claim was simply ignored.
     // One short, one long: over-reporting and under-reporting are both lies.
     int64_t claimed = GENERATE(8999, 9001);
-
 
     TempClient c;
     SenderKeys peer;
@@ -919,7 +955,14 @@ TEST_CASE("Client: a stream attachment must be the size its sender claimed",
     auto seed = random::random(32);
     auto [ciphertext, key] = attachment::encrypt(seed, plaintext, attachment::Domain::ATTACHMENT);
 
-    deliver(*c, peer, "", from_epoch_ms(1000), "h1", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            from_epoch_ms(1000),
+            "h1",
+            "",
+            std::nullopt,
             [&, claimed](SessionProtos::DataMessage& data) {
                 auto* a = data.add_attachments();
                 a->set_id(1);
@@ -961,7 +1004,8 @@ TEST_CASE("Client: a stream attachment must be the size its sender claimed",
     std::filesystem::remove_all(dir);
 }
 
-TEST_CASE("Client: two askers for one attachment share one download", "[client][attachments][join]") {
+TEST_CASE(
+        "Client: two askers for one attachment share one download", "[client][attachments][join]") {
     // A conversation opening while its attachments are being fetched asks for bytes that are not in
     // the cache yet.  Without joining, that starts a second download of the same file: the cache is
     // still empty, so a display sees a miss and fetches it again.
@@ -977,7 +1021,14 @@ TEST_CASE("Client: two askers for one attachment share one download", "[client][
     auto [ciphertext, key] = attachment::encrypt(seed, plaintext, attachment::Domain::ATTACHMENT);
     net->served["shared"] = ciphertext;
 
-    deliver(*c, peer, "", from_epoch_ms(1000), "h1", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            from_epoch_ms(1000),
+            "h1",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& data) {
                 auto* a = data.add_attachments();
                 a->set_id(1);
@@ -994,7 +1045,8 @@ TEST_CASE("Client: two askers for one attachment share one download", "[client][
     std::vector<std::vector<AttachmentProgress>> seen(2);
     for (int i = 0; i < 2; i++)
         c->attachment_data(
-                msg_id, 0,
+                msg_id,
+                0,
                 [&, i](const AttachmentProgress& p) { seen[i].push_back(p); },
                 [&, i](std::optional<std::string> err, std::vector<std::byte> d) {
                     REQUIRE_FALSE(err.has_value());
@@ -1025,11 +1077,11 @@ TEST_CASE("Client: two askers for one attachment share one download", "[client][
     // And having finished, a third ask is served from the cache with no download at all.
     net->downloads.clear();
     std::optional<std::vector<std::byte>> third;
-    c->attachment_data(msg_id, 0, nullptr,
-                       [&](std::optional<std::string> err, std::vector<std::byte> d) {
-                           REQUIRE_FALSE(err.has_value());
-                           third = std::move(d);
-                       });
+    c->attachment_data(
+            msg_id, 0, nullptr, [&](std::optional<std::string> err, std::vector<std::byte> d) {
+                REQUIRE_FALSE(err.has_value());
+                third = std::move(d);
+            });
     sync(*c);
     CHECK(net->downloads.empty());
     REQUIRE(third);
@@ -1057,7 +1109,14 @@ TEST_CASE("Client: saving joins a fetch already under way", "[client][attachment
     auto [ciphertext, key] = attachment::encrypt(seed, plaintext, attachment::Domain::ATTACHMENT);
     net->served["both"] = ciphertext;
 
-    deliver(*c, peer, "", from_epoch_ms(1000), "h1", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            from_epoch_ms(1000),
+            "h1",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& data) {
                 auto* a = data.add_attachments();
                 a->set_id(1);
@@ -1072,11 +1131,11 @@ TEST_CASE("Client: saving joins a fetch already under way", "[client][attachment
 
     // A display asks first, so the file is being accumulated.
     std::optional<std::vector<std::byte>> shown;
-    c->attachment_data(msg_id, 0, nullptr,
-                       [&](std::optional<std::string> err, std::vector<std::byte> d) {
-                           REQUIRE_FALSE(err.has_value());
-                           shown = std::move(d);
-                       });
+    c->attachment_data(
+            msg_id, 0, nullptr, [&](std::optional<std::string> err, std::vector<std::byte> d) {
+                REQUIRE_FALSE(err.has_value());
+                shown = std::move(d);
+            });
     sync(*c);
     REQUIRE(net->downloads.size() == 1);
 
@@ -1086,7 +1145,9 @@ TEST_CASE("Client: saving joins a fetch already under way", "[client][attachment
     std::promise<std::optional<std::string>> done;
     auto waiter = done.get_future();
     c->Client::save_attachment(
-            msg_id, 0, dest,
+            msg_id,
+            0,
+            dest,
             [&](const AttachmentProgress& p) { saw.push_back(p); },
             [&](std::optional<std::string> err, std::filesystem::path) {
                 done.set_value(std::move(err));
@@ -1143,7 +1204,13 @@ TEST_CASE("Client: a conversation set to auto-download fetches on arrival", "[cl
     net->served["doc"] = doc_ct;
 
     auto arrive = [&](std::string hash, bool with_doc) {
-        deliver(*c, peer, "", from_epoch_ms(1000), hash, "", std::nullopt,
+        deliver(*c,
+                peer,
+                "",
+                from_epoch_ms(1000),
+                hash,
+                "",
+                std::nullopt,
                 [&](SessionProtos::DataMessage& data) {
                     auto* a = data.add_attachments();
                     a->set_id(1);
@@ -1228,9 +1295,10 @@ TEST_CASE("Client: a conversation set to auto-download fetches on arrival", "[cl
         CHECK(progress.back().second.result == 0);
 
         // In the cache, so opening the conversation costs nothing...
-        CHECK(std::filesystem::exists(
-                cache::path_for(dir.path, cache::ATTACHMENT_DIR,
-                                network::file_server::generate_download_url("img", {}, true))));
+        CHECK(std::filesystem::exists(cache::path_for(
+                dir.path,
+                cache::ATTACHMENT_DIR,
+                network::file_server::generate_download_url("img", {}, true))));
 
         // ...and the sender is *not* told, because nobody has saved anything.  That notification
         // belongs to a save, whether or not the bytes came from the cache.
@@ -1269,13 +1337,18 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
         auto url = network::file_server::generate_download_url(file_id, {}, true);
         urls.push_back(url);
 
-        deliver(*c, peer, "", from_epoch_ms(1000 + i), "h{}"_format(i), "", std::nullopt,
+        deliver(*c,
+                peer,
+                "",
+                from_epoch_ms(1000 + i),
+                "h{}"_format(i),
+                "",
+                std::nullopt,
                 [&, url](SessionProtos::DataMessage& d) {
                     auto* a = d.add_attachments();
                     a->set_id(static_cast<uint64_t>(i + 1));
                     a->set_url(url);
-                    a->set_key(std::string{
-                            reinterpret_cast<const char*>(key.data()), key.size()});
+                    a->set_key(std::string{reinterpret_cast<const char*>(key.data()), key.size()});
                     a->set_size(data.size());
                     a->set_contenttype("image/png");
                 });
@@ -1298,7 +1371,8 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
     sync(*c);
 
     // Now a limit that only two of the three fit under.
-    auto one = std::filesystem::file_size(cache::path_for(dir.path, cache::ATTACHMENT_DIR, urls[0]));
+    auto one =
+            std::filesystem::file_size(cache::path_for(dir.path, cache::ATTACHMENT_DIR, urls[0]));
     c->set_attachment_cache_limit(static_cast<int64_t>(one * 2 + one / 2), wait);
 
     // Nothing happens until something is added, which is the only moment the total can grow.
@@ -1311,7 +1385,13 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
     auto [more_ct, more_key] = attachment::encrypt(seed, more, attachment::Domain::ATTACHMENT);
     net->served["f3"] = more_ct;
     auto more_url = network::file_server::generate_download_url("f3", {}, true);
-    deliver(*c, peer, "", from_epoch_ms(2000), "h3", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "",
+            from_epoch_ms(2000),
+            "h3",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& d) {
                 auto* a = d.add_attachments();
                 a->set_id(9);
@@ -1337,8 +1417,7 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
     auto rows = c->core.database().conn().prepared_get<int64_t>(
             "SELECT count(*) FROM attachment_cache");
     size_t on_disk = 0;
-    for (const auto& e :
-         std::filesystem::directory_iterator{dir.path / cache::ATTACHMENT_DIR})
+    for (const auto& e : std::filesystem::directory_iterator{dir.path / cache::ATTACHMENT_DIR})
         if (!e.path().filename().string().ends_with(cache::PARTIAL_SUFFIX))
             on_disk++;
     CHECK(static_cast<size_t>(rows) == on_disk);
@@ -1363,13 +1442,18 @@ TEST_CASE("Client: the sweep reconciles the cache with what the database says", 
     net->served["real"] = ct;
     auto url = network::file_server::generate_download_url("real", {}, true);
 
-    deliver(*c, peer, "", from_epoch_ms(1000), "hh", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "",
+            from_epoch_ms(1000),
+            "hh",
+            "",
+            std::nullopt,
             [&](SessionProtos::DataMessage& d) {
                 auto* a = d.add_attachments();
                 a->set_id(1);
                 a->set_url(url);
-                a->set_key(
-                        std::string{reinterpret_cast<const char*>(key.data()), key.size()});
+                a->set_key(std::string{reinterpret_cast<const char*>(key.data()), key.size()});
                 a->set_size(data.size());
                 a->set_contenttype("image/png");
             });
@@ -1409,9 +1493,10 @@ TEST_CASE("Client: the sweep reconciles the cache with what the database says", 
     c->set_cache_dir(dir.path);
 
     // Reopened *again* rather than waited on, because destruction is what a sweep is guaranteed
-    // against: the destructor joins the sweeper, and the sweeper does not finish until the reconcile
-    // it posted has run.  A `sync` here would only prove the loop was idle, which it is well before
-    // the listing is done.  This one is given no cache directory, so it does not sweep in turn.
+    // against: the destructor joins the sweeper, and the sweeper does not finish until the
+    // reconcile it posted has run.  A `sync` here would only prove the loop was idle, which it is
+    // well before the listing is done.  This one is given no cache directory, so it does not sweep
+    // in turn.
     c.reopen();
 
     CHECK(std::filesystem::exists(dir.path / cache::ATTACHMENT_DIR / real_name));

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -62,8 +62,7 @@ struct TempClient {
     explicit TempClient(callbacks cbs, Opts&&... opts) :
             path{std::filesystem::temp_directory_path() /
                  fmt::format("{}.db", random::unique_id("test_client", 7))},
-            client{std::make_unique<Client>(
-                    path, std::move(cbs), std::forward<Opts>(opts)...)} {}
+            client{std::make_unique<Client>(path, std::move(cbs), std::forward<Opts>(opts)...)} {}
 
     template <core::CoreOption... Opts>
     void reopen(Opts&&... opts) {

--- a/tests/test_client/configs.cpp
+++ b/tests/test_client/configs.cpp
@@ -59,9 +59,9 @@ TEST_CASE("Client: re-deriving a contact changes nothing", "[client][configs]") 
     merge_contacts(*c.client, pushed);
 
     // The property that makes the mapping trustworthy: applying a config to the tables and then
-    // deriving a config back from those tables is the identity.  Anything lost, rounded or defaulted
-    // on the way through shows up here as a config that went dirty -- and a mapping that dirties on
-    // every pass would push a pointless update after every merge, forever.
+    // deriving a config back from those tables is the identity.  Anything lost, rounded or
+    // defaulted on the way through shows up here as a config that went dirty -- and a mapping that
+    // dirties on every pass would push a pointless update after every merge, forever.
     auto& contacts = c->core.configs.contacts();
     REQUIRE_FALSE(contacts.needs_push());
     TestHelper::sync_contact(*c.client, id);
@@ -78,8 +78,10 @@ TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][con
     auto them = "05" + std::string(64, 'c');
     auto id = dm_from_hex(them);
 
-    auto pushed = contacts_from_another_device(
-            *c.client, them, [](auto& e) { e.set_name("Anakin"); e.approved = true; });
+    auto pushed = contacts_from_another_device(*c.client, them, [](auto& e) {
+        e.set_name("Anakin");
+        e.approved = true;
+    });
     merge_contacts(*c.client, pushed);
     REQUIRE(c->conversation(id, wait));
 
@@ -100,24 +102,27 @@ TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][con
 
     // Conversation and history both gone, and reported.
     CHECK_FALSE(c->conversation(id, wait));
-    CHECK(conn.prepared_get<int64_t>(
-                  "SELECT count(*) FROM messages WHERE sender = ?", account) == 0);
+    CHECK(conn.prepared_get<int64_t>("SELECT count(*) FROM messages WHERE sender = ?", account) ==
+          0);
     CHECK(std::ranges::find(gone, id) != gone.end());
 
     // But not the account: we may have seen them in a group, and their profile renders that.
     CHECK(conn.prepared_get<int64_t>(
                   "SELECT count(*) FROM accounts WHERE session_id = ?", id.session_id()) == 1);
-    CHECK(conn.prepared_get<int64_t>(
-                  "SELECT count(*) FROM contacts WHERE account = ?", account) == 0);
+    CHECK(conn.prepared_get<int64_t>("SELECT count(*) FROM contacts WHERE account = ?", account) ==
+          0);
 }
 
-TEST_CASE("Client: a contact whose dump was lost is published, not destroyed", "[client][configs]") {
+TEST_CASE(
+        "Client: a contact whose dump was lost is published, not destroyed", "[client][configs]") {
     TempClient c;
     auto them = "05" + std::string(64, 'e');
     auto id = dm_from_hex(them);
 
-    auto pushed = contacts_from_another_device(
-            *c.client, them, [](auto& e) { e.set_name("Rey"); e.approved = true; });
+    auto pushed = contacts_from_another_device(*c.client, them, [](auto& e) {
+        e.set_name("Rey");
+        e.approved = true;
+    });
     merge_contacts(*c.client, pushed);
     REQUIRE(c->conversation(id, wait));
 
@@ -520,7 +525,8 @@ TEST_CASE("Client: the save-notification preference follows the account", "[clie
     CHECK(c->notify_media_saved(wait));
 }
 
-TEST_CASE("Client: a conversation reports the picture it has been told about", "[client][configs]") {
+TEST_CASE(
+        "Client: a conversation reports the picture it has been told about", "[client][configs]") {
     TempClient c;
     auto them = "05" + std::string(64, 'b');
     auto id = dm_from_hex(them);

--- a/tests/test_client/conversation_api.cpp
+++ b/tests/test_client/conversation_api.cpp
@@ -105,8 +105,9 @@ TEST_CASE("Client: a conversation knows which kind it is", "[client][convos]") {
     CHECK(convo->unread() == 0);
 }
 
-TEST_CASE("Client: a handler-form operation outlives the conversation it came from",
-          "[client][convos]") {
+TEST_CASE(
+        "Client: a handler-form operation outlives the conversation it came from",
+        "[client][convos]") {
     TempClient c;
     SenderKeys them;
     auto id = ConversationId::dm(them.session_id);
@@ -156,7 +157,6 @@ TEST_CASE("Client: every conversation kind starts with its base", "[client][conv
     CHECK(static_cast<const void*>(&group) == static_cast<const Conversation*>(&group));
     CHECK(static_cast<const void*>(&community) == static_cast<const Conversation*>(&community));
 }
-
 
 TEST_CASE("Client: auto-download is per conversation and stays here", "[client][convos]") {
     TempClient c;

--- a/tests/test_client/download_cache.cpp
+++ b/tests/test_client/download_cache.cpp
@@ -1,8 +1,8 @@
-#include <session/random.hpp>
+#include "../../src/client/download_cache.hpp"
 
 #include <fstream>
+#include <session/random.hpp>
 
-#include "../../src/client/download_cache.hpp"
 #include "common.hpp"
 
 namespace cache = session::client::cache;
@@ -36,8 +36,7 @@ TEST_CASE("Cache: a url names one file, whatever is hung off it", "[client][cach
     auto base = cache::path_for(dir.path, cache::PROFILE_DIR, "http://fs.example/file/1234");
     auto fragment = cache::path_for(
             dir.path, cache::PROFILE_DIR, "http://fs.example/file/1234#pubkey=abcdef");
-    auto query =
-            cache::path_for(dir.path, cache::PROFILE_DIR, "http://fs.example/file/1234?v=2");
+    auto query = cache::path_for(dir.path, cache::PROFILE_DIR, "http://fs.example/file/1234?v=2");
 
     // The bytes at the base url are the bytes; a fragment says how to reach and unpack them, and a
     // query string is not part of which file this is.
@@ -128,8 +127,7 @@ TEST_CASE("Cache: listing offers up what a sweep may consider", "[client][cache]
 
     // Two finished files and not the third: what is offered up is only what a sweep may act on.
     CHECK(names.size() == 2);
-    CHECK(names.contains(
-            cache::path_for(dir.path, cache::PROFILE_DIR, kept).filename().string()));
+    CHECK(names.contains(cache::path_for(dir.path, cache::PROFILE_DIR, kept).filename().string()));
     CHECK_FALSE(names.contains(partial.filename().string()));
 
     // The referencing url carries a fragment, as a stored one may, and still names the same file --

--- a/tests/test_client/interop_and_threading.cpp
+++ b/tests/test_client/interop_and_threading.cpp
@@ -13,10 +13,11 @@ TEST_CASE("Client: an asynchronous call reports that it succeeded", "[client][ca
     // class means choosing it for everything.
     std::optional<std::string> reported_error = "not called";
     std::vector<AnyConversation> got;
-    c->Client::conversations([&](std::optional<std::string> error, std::vector<AnyConversation> cs) {
-        reported_error = std::move(error);
-        got = std::move(cs);
-    });
+    c->Client::conversations(
+            [&](std::optional<std::string> error, std::vector<AnyConversation> cs) {
+                reported_error = std::move(error);
+                got = std::move(cs);
+            });
     sync(*c);
 
     // Called exactly once, and saying it worked rather than leaving the caller to assume so.

--- a/tests/test_client/profile_pictures.cpp
+++ b/tests/test_client/profile_pictures.cpp
@@ -1,4 +1,5 @@
 #include <nettle/gcm.h>
+
 #include <session/attachments.hpp>
 #include <session/network/backends/session_file_server.hpp>
 #include <session/random.hpp>
@@ -46,7 +47,8 @@ void set_picture(
 
 }  // namespace
 
-TEST_CASE("Client: a stream-encrypted picture round-trips through the cache", "[client][pictures]") {
+TEST_CASE(
+        "Client: a stream-encrypted picture round-trips through the cache", "[client][pictures]") {
     TempCacheDir dir;
     TempClient c;
     auto* net = attach_mock_network(c->core);
@@ -57,8 +59,7 @@ TEST_CASE("Client: a stream-encrypted picture round-trips through the cache", "[
 
     // As a current client uploads one: the stream scheme, with the url saying so.
     auto seed = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"_hex_b;
-    auto [encrypted, key] =
-            attachment::encrypt(seed, image, attachment::Domain::PROFILE_PIC);
+    auto [encrypted, key] = attachment::encrypt(seed, image, attachment::Domain::PROFILE_PIC);
     net->served["pic1"] = encrypted;
     auto url = network::file_server::generate_download_url("pic1", {}, true);
 
@@ -151,8 +152,9 @@ TEST_CASE("Client: a picture from before the stream scheme still opens", "[clien
     CHECK(*got == image);
 }
 
-TEST_CASE("Client: a picture that will not decrypt is an error, not an absence",
-          "[client][pictures]") {
+TEST_CASE(
+        "Client: a picture that will not decrypt is an error, not an absence",
+        "[client][pictures]") {
     TempCacheDir dir;
     TempClient c;
     auto* net = attach_mock_network(c->core);

--- a/tests/test_client/receiving.cpp
+++ b/tests/test_client/receiving.cpp
@@ -160,8 +160,7 @@ TEST_CASE("Client: redelivery of the same swarm hash is ignored", "[client][rece
     CHECK(c->conversation(convo, wait)->messages(wait).size() == 2);
 }
 
-TEST_CASE(
-        "Client: the same message under a different swarm hash is deduped", "[client][receive]") {
+TEST_CASE("Client: the same message under a different swarm hash is deduped", "[client][receive]") {
     TempClient c;
     SenderKeys sender;
     auto convo = ConversationId::dm(sender.session_id);
@@ -169,15 +168,39 @@ TEST_CASE(
     // One message stored twice -- a sender who retried a store that had actually succeeded, say --
     // lands under two swarm hashes.  The swarm hash cannot recognise that; the msgid can, being the
     // one identifier every copy of a message carries.
-    deliver(*c, sender, "said once", from_epoch_ms(5000), "first_hash", "", std::nullopt, nullptr, 7);
-    deliver(*c, sender, "said once", from_epoch_ms(5000), "second_hash", "", std::nullopt, nullptr, 7);
+    deliver(*c,
+            sender,
+            "said once",
+            from_epoch_ms(5000),
+            "first_hash",
+            "",
+            std::nullopt,
+            nullptr,
+            7);
+    deliver(*c,
+            sender,
+            "said once",
+            from_epoch_ms(5000),
+            "second_hash",
+            "",
+            std::nullopt,
+            nullptr,
+            7);
 
     CHECK(c->conversation(convo, wait)->messages(wait).size() == 1);
     CHECK(c->conversation(convo, wait)->unread() == 1);
 
     // Same millisecond, different message: the case the timestamp alone cannot tell apart, and the
     // whole reason the id exists.  Identical body, so nothing but the id distinguishes them.
-    deliver(*c, sender, "said once", from_epoch_ms(5000), "third_hash", "", std::nullopt, nullptr, 8);
+    deliver(*c,
+            sender,
+            "said once",
+            from_epoch_ms(5000),
+            "third_hash",
+            "",
+            std::nullopt,
+            nullptr,
+            8);
     CHECK(c->conversation(convo, wait)->messages(wait).size() == 2);
 
     // A sender too old to set one has no identity beyond its timestamp, so two arrivals under
@@ -304,7 +327,8 @@ TEST_CASE("Client: unread counting and the read watermark", "[client][unread]") 
     // Even one that arrives late, bearing a timestamp older than what we already read to.
     c->conversation(convo, wait)->mark_read(wait);
     deliver(*c, sender, "late", from_epoch_ms(3500), "h5");
-    CHECK(c->conversation(convo, wait)->unread() == 0);  // known limitation of a timestamp watermark
+    CHECK(c->conversation(convo, wait)->unread() ==
+          0);  // known limitation of a timestamp watermark
 
     // Marking read on a conversation with nothing to read is a no-op, not an error.
     auto empty = ConversationId::dm(
@@ -471,7 +495,8 @@ TEST_CASE("Client: a message can be shown as it was on the wire", "[client][mess
     SenderKeys sender;
     auto convo = ConversationId::dm(sender.session_id);
 
-    deliver(*c,
+    deliver(
+            *c,
             sender,
             "hello there",
             from_epoch_ms(5000),
@@ -517,7 +542,8 @@ TEST_CASE("Client: a message can be shown as it was on the wire", "[client][mess
     CHECK_FALSE(c->message_debug(msgs[0].id + 1000, wait).has_value());
 }
 
-TEST_CASE("Client: deleting a message empties it but keeps its place", "[client][messages][delete]") {
+TEST_CASE(
+        "Client: deleting a message empties it but keeps its place", "[client][messages][delete]") {
     TempClient c;
     SenderKeys sender;
     auto convo = ConversationId::dm(sender.session_id);
@@ -655,8 +681,11 @@ TEST_CASE("Client: an unsend request from the author deletes the message", "[cli
     SenderKeys sender;
     auto convo = ConversationId::dm(sender.session_id);
 
-    auto unsend = [&](const SenderKeys& from, const b33& author, int64_t ts,
-                      std::optional<int64_t> msgid, std::string hash) {
+    auto unsend = [&](const SenderKeys& from,
+                      const b33& author,
+                      int64_t ts,
+                      std::optional<int64_t> msgid,
+                      std::string hash) {
         SessionProtos::Content content;
         content.set_sigtimestamp(9000);
         auto* req = content.mutable_unsendrequest();
@@ -744,8 +773,7 @@ TEST_CASE("Client: a sender's picture arrives with their message", "[client][rec
             if (stamp)
                 p->set_lastupdateseconds(*stamp);
             if (k)
-                d.set_profilekey(std::string{
-                        reinterpret_cast<const char*>(k->data()), k->size()});
+                d.set_profilekey(std::string{reinterpret_cast<const char*>(k->data()), k->size()});
         };
     };
 

--- a/tests/test_client/replies.cpp
+++ b/tests/test_client/replies.cpp
@@ -22,7 +22,13 @@ TEST_CASE("Client: a reply names what it answers", "[client][replies]") {
 
     auto first = from_epoch_ms(1000);
     deliver(*c, peer, "the original", first, "h1", "", std::nullopt, nullptr, 7777);
-    deliver(*c, peer, "the answer", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "the answer",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
@@ -43,14 +49,20 @@ TEST_CASE("Client: a reply names what it answers", "[client][replies]") {
     CHECK_FALSE(original.reply.has_value());
 }
 
-TEST_CASE("Client: a reply to a message we do not have still names its author",
-          "[client][replies]") {
+TEST_CASE(
+        "Client: a reply to a message we do not have still names its author", "[client][replies]") {
     TempClient c;
     SenderKeys peer;
 
     auto missing = from_epoch_ms(500);
-    deliver(*c, peer, "answering something we never got", from_epoch_ms(2000), "h1", "",
-            std::nullopt, quoting(peer.session_id, missing, 4242));
+    deliver(*c,
+            peer,
+            "answering something we never got",
+            from_epoch_ms(2000),
+            "h1",
+            "",
+            std::nullopt,
+            quoting(peer.session_id, missing, 4242));
     sync(*c);
 
     auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
@@ -71,7 +83,13 @@ TEST_CASE("Client: a reply resolves once its target arrives", "[client][replies]
     // Out of order: the answer first.  This is the case that makes resolving-on-read necessary
     // rather than merely tidy -- resolved once at receipt, this reference would stay empty forever.
     auto first = from_epoch_ms(1000);
-    deliver(*c, peer, "the answer", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "the answer",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
@@ -99,7 +117,13 @@ TEST_CASE("Client: msgid disambiguates a same-millisecond target", "[client][rep
     auto same = from_epoch_ms(1000);
     deliver(*c, peer, "first", same, "h1", "", std::nullopt, nullptr, 111);
     deliver(*c, peer, "second", same, "h2", "", std::nullopt, nullptr, 222);
-    deliver(*c, peer, "answering the second", from_epoch_ms(2000), "h3", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "answering the second",
+            from_epoch_ms(2000),
+            "h3",
+            "",
+            std::nullopt,
             quoting(peer.session_id, same, 222));
     sync(*c);
 
@@ -127,7 +151,13 @@ TEST_CASE("Client: an ambiguous target resolves stably", "[client][replies]") {
     auto same = from_epoch_ms(1000);
     deliver(*c, peer, "first", same, "h1", "", std::nullopt, nullptr, 111);
     deliver(*c, peer, "second", same, "h2", "", std::nullopt, nullptr, 222);
-    deliver(*c, peer, "answering one of them", from_epoch_ms(2000), "h3", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "answering one of them",
+            from_epoch_ms(2000),
+            "h3",
+            "",
+            std::nullopt,
             quoting(peer.session_id, same));
     sync(*c);
 
@@ -150,7 +180,13 @@ TEST_CASE("Client: a quote with an unusable author is dropped", "[client][replie
 
     auto target = from_epoch_ms(1000);
     deliver(*c, peer, "the original", target, "h0", "", std::nullopt, nullptr, 999);
-    deliver(*c, peer, "body survives", from_epoch_ms(2000), "h1", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "body survives",
+            from_epoch_ms(2000),
+            "h1",
+            "",
+            std::nullopt,
             [](SessionProtos::DataMessage& d) {
                 auto* q = d.mutable_quote();
                 q->set_msgtimestamp(1000);
@@ -158,7 +194,13 @@ TEST_CASE("Client: a quote with an unusable author is dropped", "[client][replie
             });
     // A well-formed one alongside it, so that "no reply" here means the bad reference was rejected
     // rather than that nothing writes references at all.
-    deliver(*c, peer, "a good reply", from_epoch_ms(3000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "a good reply",
+            from_epoch_ms(3000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, target, 999));
     sync(*c);
 
@@ -183,7 +225,13 @@ TEST_CASE("Client: a reply is re-reported when its target arrives", "[client][re
     auto convo = ConversationId::dm(peer.session_id);
 
     auto target_ts = from_epoch_ms(1000);
-    deliver(*c, peer, "the answer", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "the answer",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, target_ts, 7777));
     sync(*c);
 
@@ -197,9 +245,8 @@ TEST_CASE("Client: a reply is re-reported when its target arrives", "[client][re
     deliver(*c, peer, "the original", target_ts, "h1", "", std::nullopt, nullptr, 7777);
     sync(*c);
 
-    auto reported = std::ranges::find_if(rec.msg_updated, [&](const auto& p) {
-        return p.second.id == reply_id;
-    });
+    auto reported = std::ranges::find_if(
+            rec.msg_updated, [&](const auto& p) { return p.second.id == reply_id; });
     REQUIRE(reported != rec.msg_updated.end());
     REQUIRE(reported->second.reply);
     CHECK(reported->second.reply->message_id.has_value());
@@ -213,7 +260,13 @@ TEST_CASE("Client: deleting a target re-reports the replies to it", "[client][re
 
     auto target_ts = from_epoch_ms(1000);
     deliver(*c, peer, "the original", target_ts, "h1", "", std::nullopt, nullptr, 7777);
-    deliver(*c, peer, "the answer", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "the answer",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, target_ts, 7777));
     sync(*c);
 
@@ -228,12 +281,10 @@ TEST_CASE("Client: deleting a target re-reports the replies to it", "[client][re
 
     // The target itself is reported, and so is the reply that points at it: what it should draw
     // has changed even though its own row has not.
-    CHECK(std::ranges::any_of(rec.msg_updated, [&](const auto& p) {
-        return p.second.id == target_id;
-    }));
-    CHECK(std::ranges::any_of(rec.msg_updated, [&](const auto& p) {
-        return p.second.id == reply_id;
-    }));
+    CHECK(std::ranges::any_of(
+            rec.msg_updated, [&](const auto& p) { return p.second.id == target_id; }));
+    CHECK(std::ranges::any_of(
+            rec.msg_updated, [&](const auto& p) { return p.second.id == reply_id; }));
 }
 
 TEST_CASE("Client: a reply carries the message it answers", "[client][replies]") {
@@ -243,7 +294,13 @@ TEST_CASE("Client: a reply carries the message it answers", "[client][replies]")
 
     auto first = from_epoch_ms(1000);
     deliver(*c, peer, "what was said", first, "h1", "", std::nullopt, nullptr, 7777);
-    deliver(*c, peer, "the answer", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "the answer",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
@@ -268,7 +325,14 @@ TEST_CASE("Client: a quoted attachment-only message arrives whole", "[client][re
 
     // No body at all: exactly the case a body-only summary could not draw.
     auto first = from_epoch_ms(1000);
-    deliver(*c, peer, "", first, "h1", "", std::nullopt,
+    deliver(
+            *c,
+            peer,
+            "",
+            first,
+            "h1",
+            "",
+            std::nullopt,
             [](SessionProtos::DataMessage& d) {
                 auto* a = d.add_attachments();
                 a->set_id(1);
@@ -278,7 +342,13 @@ TEST_CASE("Client: a quoted attachment-only message arrives whole", "[client][re
                 a->set_filename("photo.png");
             },
             7777);
-    deliver(*c, peer, "nice one", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "nice one",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
@@ -305,7 +375,13 @@ TEST_CASE("Client: reply loading stops one level down", "[client][replies]") {
     auto b_ts = from_epoch_ms(2000);
     deliver(*c, peer, "A", a_ts, "h1", "", std::nullopt, nullptr, 111);
     deliver(*c, peer, "B", b_ts, "h2", "", std::nullopt, quoting(peer.session_id, a_ts, 111), 222);
-    deliver(*c, peer, "C", from_epoch_ms(3000), "h3", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "C",
+            from_epoch_ms(3000),
+            "h3",
+            "",
+            std::nullopt,
             quoting(peer.session_id, b_ts, 222));
     sync(*c);
 
@@ -334,9 +410,21 @@ TEST_CASE("Client: several replies to one message share one copy", "[client][rep
 
     auto first = from_epoch_ms(1000);
     deliver(*c, peer, "the original", first, "h1", "", std::nullopt, nullptr, 7777);
-    deliver(*c, peer, "answer one", from_epoch_ms(2000), "h2", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "answer one",
+            from_epoch_ms(2000),
+            "h2",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
-    deliver(*c, peer, "answer two", from_epoch_ms(3000), "h3", "", std::nullopt,
+    deliver(*c,
+            peer,
+            "answer two",
+            from_epoch_ms(3000),
+            "h3",
+            "",
+            std::nullopt,
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
@@ -362,12 +450,25 @@ TEST_CASE("Client: many distinct reply targets load correctly", "[client][replie
     for (int i = 0; i < n; i++) {
         auto ts = from_epoch_ms(1000 + i);
         stamps.push_back(ts);
-        deliver(*c, peer, "original {}"_format(i), ts, "o{}"_format(i), "", std::nullopt, nullptr,
+        deliver(*c,
+                peer,
+                "original {}"_format(i),
+                ts,
+                "o{}"_format(i),
+                "",
+                std::nullopt,
+                nullptr,
                 100 + i);
     }
     for (int i = 0; i < n; i++)
-        deliver(*c, peer, "answer {}"_format(i), from_epoch_ms(5000 + i), "a{}"_format(i), "",
-                std::nullopt, quoting(peer.session_id, stamps[i], 100 + i));
+        deliver(*c,
+                peer,
+                "answer {}"_format(i),
+                from_epoch_ms(5000 + i),
+                "a{}"_format(i),
+                "",
+                std::nullopt,
+                quoting(peer.session_id, stamps[i], 100 + i));
     sync(*c);
 
     auto msgs = c->conversation(convo, wait)->messages(wait);

--- a/tests/test_client/requests.cpp
+++ b/tests/test_client/requests.cpp
@@ -140,4 +140,3 @@ TEST_CASE("Client: a blocked account's messages are refused", "[client][requests
     deliver(*c, sender, "still there?", from_epoch_ms(7000), "h3");
     CHECK(c->conversation(id, wait)->messages(wait).size() == 2);
 }
-

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -152,12 +152,11 @@ TEST_CASE(
                 std::nullopt));
     std::vector<core::SwarmMessage> batch;
     for (int i = 0; i < 5; i++)
-        batch.push_back(
-                core::SwarmMessage{
-                        wire[i],
-                        "b{}"_format(i),
-                        from_epoch_ms(1000 + i),
-                        from_epoch_ms(1'000'000'000'000)});
+        batch.push_back(core::SwarmMessage{
+                wire[i],
+                "b{}"_format(i),
+                from_epoch_ms(1000 + i),
+                from_epoch_ms(1'000'000'000'000)});
 
     c->core.loop().call_get([&] {
         c->core.receive_messages(batch, config::Namespace::Default, true);

--- a/tests/test_client/volatile.cpp
+++ b/tests/test_client/volatile.cpp
@@ -123,4 +123,3 @@ TEST_CASE("Client: read state for a conversation we do not have is ignored", "[c
     CHECK_FALSE(c->conversation(id, wait));
     CHECK(c->conversations(wait).empty());
 }
-

--- a/tests/test_core_configs.cpp
+++ b/tests/test_core_configs.cpp
@@ -146,7 +146,8 @@ TEST_CASE("Configs: a namespace names exactly one config", "[core][configs]") {
     CHECK(c->configs.for_namespace(config::Namespace::UserProfile) ==
           base(c->configs.user_profile()));
     CHECK(c->configs.for_namespace(config::Namespace::Contacts) == base(c->configs.contacts()));
-    CHECK(c->configs.for_namespace(config::Namespace::UserGroups) == base(c->configs.user_groups()));
+    CHECK(c->configs.for_namespace(config::Namespace::UserGroups) ==
+          base(c->configs.user_groups()));
     CHECK(c->configs.for_namespace(config::Namespace::ConvoInfoVolatile) ==
           base(c->configs.convo_info_volatile()));
 
@@ -307,8 +308,7 @@ TEST_CASE("Configs: one batch reports everything it changed, once", "[core][conf
     REQUIRE(w.reported.size() == 1);
     auto changed = w.reported[0];
     std::ranges::sort(changed);
-    CHECK(changed ==
-          std::vector{config::Namespace::UserProfile, config::Namespace::Contacts});
+    CHECK(changed == std::vector{config::Namespace::UserProfile, config::Namespace::Contacts});
 }
 
 TEST_CASE("Configs: a conflicting merge at our own seqno is reported", "[core][configs][notify]") {

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -3,16 +3,15 @@
 #include <fmt/format.h>
 #include <oxenc/base64.h>
 
+#include <filesystem>
 #include <fstream>
 #include <map>
-#include <session/attachments.hpp>
-#include <session/network/backends/session_file_server.hpp>
-
-#include <filesystem>
 #include <nlohmann/json.hpp>
+#include <session/attachments.hpp>
 #include <session/core.hpp>
-#include <session/format.hpp>
 #include <session/core/devices.hpp>
+#include <session/format.hpp>
+#include <session/network/backends/session_file_server.hpp>
 #include <session/network/key_types.hpp>
 #include <session/network/routing/network_router.hpp>
 #include <session/network/session_network.hpp>
@@ -77,8 +76,7 @@ class MockNetwork : public network::Network {
     std::map<std::string, std::vector<std::byte>> served;
     int next_file_id = 1000;
 
-    void upload_file(
-            network::FileUploadRequest request, std::span<const std::byte> seed) override {
+    void upload_file(network::FileUploadRequest request, std::span<const std::byte> seed) override {
         // Encrypted the same way the routers do it, so what a save reads back is what a real
         // upload would have left on the server: same scheme, same padding, same key derivation.
         std::vector<std::byte> plain;
@@ -93,8 +91,7 @@ class MockNetwork : public network::Network {
         auto id = std::to_string(next_file_id++);
         served.emplace(id, std::move(ciphertext));
 
-        network::file_metadata meta{
-                id, static_cast<int64_t>(served.at(id).size()), {}, {}};
+        network::file_metadata meta{id, static_cast<int64_t>(served.at(id).size()), {}, {}};
         if (request.on_progress)
             request.on_progress(meta.size, meta.size);
         if (request.on_complete)
@@ -116,8 +113,7 @@ inline size_t serve_downloads(
         MockNetwork& net, std::span<const std::byte> data, size_t chunk = 4096) {
     auto pending = std::exchange(net.downloads, {});
     for (auto& r : pending) {
-        network::file_metadata meta{
-                "served", static_cast<int64_t>(data.size()), {}, {}};
+        network::file_metadata meta{"served", static_cast<int64_t>(data.size()), {}, {}};
         for (size_t at = 0; at < data.size(); at += chunk)
             r.on_data(meta, data.subspan(at, std::min(chunk, data.size() - at)));
         r.on_complete(meta, false);
@@ -139,8 +135,7 @@ inline size_t serve_downloads(MockNetwork& net, size_t chunk = 4096) {
         }
 
         std::span<const std::byte> data{found->second};
-        network::file_metadata meta{
-                info->file_id, static_cast<int64_t>(data.size()), {}, {}};
+        network::file_metadata meta{info->file_id, static_cast<int64_t>(data.size()), {}, {}};
         for (size_t at = 0; at < data.size(); at += chunk)
             r.on_data(meta, data.subspan(at, std::min(chunk, data.size() - at)));
         r.on_complete(meta, false);
@@ -290,8 +285,7 @@ class FakeRouter : public network::IRouter {
     // Destination pubkey -> how that node answers.  Anything not named here answers as unreachable,
     // which makes "only this node works" the short thing to write.
     std::map<network::ed25519_pubkey, Reply> replies;
-    Reply default_reply{
-            false, false, network::ERROR_INVALID_DESTINATION, "Node is not reachable"};
+    Reply default_reply{false, false, network::ERROR_INVALID_DESTINATION, "Node is not reachable"};
 
     // Every destination tried, in order.  The point of most assertions.
     std::vector<network::ed25519_pubkey> tried;
@@ -386,7 +380,8 @@ class TestHelper {
     }
 
     // The cursor a retrieve from this namespace+node would send: the newest hash that node handed
-    // us and still holds.  Derived rather than stored, so this asks the same question the poll does.
+    // us and still holds.  Derived rather than stored, so this asks the same question the poll
+    // does.
     static std::optional<std::string> namespace_last_hash(
             core::Core& core, int16_t ns, const network::ed25519_pubkey& sn_pubkey) {
         return core.db.conn().prepared_maybe_get<std::string>(
@@ -455,8 +450,7 @@ SELECT h.hash FROM swarm_hashes h JOIN swarm_nodes n ON n.id = h.node
     // tests to detect that a poll completed and delivered at least one message.
     static bool has_any_namespace_sync(core::Core& core, config::Namespace ns) {
         auto count = core.db.conn().prepared_get<int64_t>(
-                "SELECT COUNT(*) FROM swarm_hashes WHERE namespace = ?",
-                static_cast<int16_t>(ns));
+                "SELECT COUNT(*) FROM swarm_hashes WHERE namespace = ?", static_cast<int16_t>(ns));
         return count > 0;
     }
 

--- a/tests/test_poll.cpp
+++ b/tests/test_poll.cpp
@@ -309,7 +309,8 @@ TEST_CASE("Poll: a truncated namespace is continued before it is reported final"
     CHECK(namespaces_in(second) == std::vector<int16_t>{21});
     CHECK(params_for(second, 21)["last_hash"] == "hash1");
 
-    // Nothing left behind it: an empty answer is still an answer, and is what makes the batch final.
+    // Nothing left behind it: an empty answer is still an answer, and is what makes the batch
+    // final.
     auto reply2 = mock_net->sent_requests[1].callback;
     reply2(true, false, 200, {}, make_empty_response(second).dump());
 

--- a/tests/test_swarm_retry.cpp
+++ b/tests/test_swarm_retry.cpp
@@ -49,12 +49,7 @@ struct ScriptedNetwork {
 
     /// A request addressed to the swarm, starting at whichever member the caller would have picked.
     Request to(const service_node& first, std::optional<std::chrono::milliseconds> overall = 60s) {
-        Request req{
-                first,
-                "store",
-                std::vector<std::byte>{},
-                RequestCategory::standard_small,
-                10s};
+        Request req{first, "store", std::vector<std::byte>{}, RequestCategory::standard_small, 10s};
         req.swarm_pubkey = swarm_pubkey;
         req.overall_timeout = overall;
         return req;


### PR DESCRIPTION
The lint pipeline has been failing on `client` for a while, on code that predates any one branch,
so every PR opened against it inherits a red build it did not cause. This is `./utils/format.sh`
and nothing else.

Mechanical, and checked as such: outside the reordering `SortIncludes` does, not a token changed in
any of the 40 files, and no include was added or removed. `jsonnetfmt` leaves `.drone.jsonnet` alone
already.

Reviewing with whitespace hidden should show nothing but the include reordering.