### PR TITLE
Say where a conversation belongs when it is added, changed or removed

### DIFF
--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1237,8 +1237,19 @@ class Client {
     void _flush_pending();
     // Reports one list, if a row in it changed and the subscriber asked for it.  The rows are the
     // expensive part, so nothing is read for a handler that is not there.
+    // Which list each conversation was last *reported* in.  The subscriber's belief rather than
+    // the database's state, which is the point: it is what the subscriber has to take the row out
+    // of before putting it where it now belongs.
+    //
+    // Keyed by ConversationId and not by row id, because a removal is reported *after* the row is
+    // deleted -- `_delete_contact` commits the DELETE first -- so there is nothing left to look a
+    // row id up from, and an entry keyed that way could never be erased.
+    std::unordered_map<ConversationId, ConversationList> _placed;
+    // Where a conversation was and where it belongs now, and records the latter.
+    ListPlacement _place(const AnyConversation& convo);
     void _report_list(
             bool changed,
+            ConversationList list_kind,
             std::vector<AnyConversation> (Client::*rows)(),
             std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced);
     // Reports both lists, given for each whether a row in it changed.  Called by `_flush_pending`,

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1275,13 +1275,17 @@ class Client {
     // wanting only the order gets the id-only query, which is the cheaper of the two and the one
     // that runs on every message.
     void _report_list(
+            bool changed,
+            bool moved,
             std::vector<ConversationId>& reported,
             std::vector<AnyConversation> (Client::*rows)(),
             std::vector<ConversationId> (Client::*ids)(),
             std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
             std::function<void(std::vector<ConversationId>)> callbacks::* reordered);
-    // Reports whichever of the two lists is asked for.  Called by `_flush_pending`.
-    void _emit_order_updated(bool conversations, bool requests);
+    // Reports both lists, given for each whether a row in it changed and whether one moved.
+    // Called by `_flush_pending`, once per batch.
+    void _report_lists(
+            bool convos_changed, bool convos_moved, bool requests_changed, bool requests_moved);
 
   public:
     /// The account state this Client is built on: keys, device group, configs, polling.  A

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1284,7 +1284,7 @@ class Client {
             std::vector<ConversationId>& reported,
             std::vector<AnyConversation> (Client::*rows)(),
             std::vector<ConversationId> (Client::*ids)(),
-            std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
+            std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced,
             std::function<void(std::vector<ConversationId>)> callbacks::* reordered);
     // Reports both lists, given for each whether a row in it changed and whether one moved.
     // Called by `_flush_pending`, once per batch.

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1229,8 +1229,46 @@ class Client {
     // dirtied them is finished.
     std::vector<ConversationId> _dirty;
     bool _flush_scheduled = false;
+    // The conversations in this batch whose *place* changed and not merely their contents, so that
+    // `_flush_pending` reports the order once for the batch instead of once per message.
+    //
+    // The ids rather than a flag, because which list to report is a property of the row that moved:
+    // the two lists are strict complements, so a message can only have moved a row within the one
+    // it already sits in, and reporting both would say one true thing and one false one.
+    // `_flush_pending` reads the list off the conversation it has already fetched to emit
+    // `conversation_updated`, so knowing which costs no extra query.
+    std::vector<ConversationId> _dirty_order;
     void _touch(const ConversationId& id);
+    // `_touch`, for a change that moves the row: `last_activity` and `priority` are what both lists
+    // are ordered by, so a subscriber told only that the row changed would not know it had moved.
+    // Named rather than a flag on `_touch` because the two readings are not obvious from a bool at
+    // a call site, and most callers are the plain one -- a nickname or a read receipt changes the
+    // row and leaves it exactly where it was.
+    void _touch_reordered(const ConversationId& id);
     void _flush_pending();
+
+    // The ids, in order, as each list was last reported to the subscriber -- by an order event or
+    // by a replacement, since both tell it the same thing about position.
+    //
+    // Kept so that an order event can be suppressed when the order has not actually changed, which
+    // is the common case and the point of the whole exercise: a message into the conversation
+    // already at the top of its list leaves every row exactly where it was.  Without this, the hot
+    // path reports an unchanged order on every incoming message.
+    //
+    // The cost is one id per conversation per list, against a query and a callback per message
+    // saved.  Only the ids, and only the two lists, which is why this is worth holding when the
+    // rows themselves would not be.
+    std::vector<ConversationId> _reported_order;
+    std::vector<ConversationId> _reported_request_order;
+    // The ordered ids of one list: the `_conversations` and `_message_requests` queries with
+    // everything but the identity columns taken out.  Same filter and same ORDER BY -- they have to
+    // agree, or a client applying an order event would arrange rows differently from a client that
+    // had just been handed a replacement.
+    std::vector<ConversationId> _conversation_order();
+    std::vector<ConversationId> _message_request_order();
+    // Reports whichever of the two lists is asked for, if its order has changed since it was last
+    // reported, and records what it sent.  Called by `_flush_pending`.
+    void _emit_order_updated(bool conversations, bool requests);
 
   public:
     /// The account state this Client is built on: keys, device group, configs, polling.  A

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1233,63 +1233,17 @@ class Client {
     // dirtied them is finished.
     std::vector<ConversationId> _dirty;
     bool _flush_scheduled = false;
-    // The conversations in this batch whose *place* changed and not merely their contents, so that
-    // `_flush_pending` reports the order once for the batch instead of once per message.
-    //
-    // The ids rather than a flag, because which list to report is a property of the row that moved:
-    // the two lists are strict complements, so a message can only have moved a row within the one
-    // it already sits in, and reporting both would say one true thing and one false one.
-    // `_flush_pending` reads the list off the conversation it has already fetched to emit
-    // `conversation_updated`, so knowing which costs no extra query.
-    std::vector<ConversationId> _dirty_order;
     void _touch(const ConversationId& id);
-    // `_touch`, for a change that moves the row: `last_activity` and `priority` are what both lists
-    // are ordered by, so a subscriber told only that the row changed would not know it had moved.
-    // Named rather than a flag on `_touch` because the two readings are not obvious from a bool at
-    // a call site, and most callers are the plain one -- a nickname or a read receipt changes the
-    // row and leaves it exactly where it was.
-    void _touch_reordered(const ConversationId& id);
     void _flush_pending();
-
-    // The ids, in order, as each list was last reported to the subscriber -- by an order event or
-    // by a replacement, since both tell it the same thing about position.
-    //
-    // Kept so that an order event can be suppressed when the order has not actually changed, which
-    // is the common case and the point of the whole exercise: a message into the conversation
-    // already at the top of its list leaves every row exactly where it was.  Without this, the hot
-    // path reports an unchanged order on every incoming message.
-    //
-    // The cost is one id per conversation per list, against a query and a callback per message
-    // saved.  Only the ids, and only the two lists, which is why this is worth holding when the
-    // rows themselves would not be.
-    std::vector<ConversationId> _reported_order;
-    std::vector<ConversationId> _reported_request_order;
-    // The ordered ids of one list: the `_conversations` and `_message_requests` queries with
-    // everything but the identity columns taken out.  Same filter and same ORDER BY -- they have to
-    // agree, or a client applying an order event would arrange rows differently from a client that
-    // had just been handed a replacement.
-    std::vector<ConversationId> _conversation_order();
-    std::vector<ConversationId> _message_request_order();
-    // Reports one list whose order may have moved, through whichever of its two handlers the
-    // subscriber registered, and records the order it reported.
-    //
-    // Which query runs is decided by that registration.  A replacement carries the rows and the
-    // order is already in them, so a subscriber wanting one is served by the row query alone;
-    // asking for the ids as well would be a second query for something already held.  A subscriber
-    // wanting only the order gets the id-only query, which is the cheaper of the two and the one
-    // that runs on every message.
+    // Reports one list, if a row in it changed and the subscriber asked for it.  The rows are the
+    // expensive part, so nothing is read for a handler that is not there.
     void _report_list(
             bool changed,
-            bool moved,
-            std::vector<ConversationId>& reported,
             std::vector<AnyConversation> (Client::*rows)(),
-            std::vector<ConversationId> (Client::*ids)(),
-            std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced,
-            std::function<void(std::vector<ConversationId>)> callbacks::* reordered);
-    // Reports both lists, given for each whether a row in it changed and whether one moved.
-    // Called by `_flush_pending`, once per batch.
-    void _report_lists(
-            bool convos_changed, bool convos_moved, bool requests_changed, bool requests_moved);
+            std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced);
+    // Reports both lists, given for each whether a row in it changed.  Called by `_flush_pending`,
+    // once per batch.
+    void _report_lists(bool convos_changed, bool requests_changed);
 
   public:
     /// The account state this Client is built on: keys, device group, configs, polling.  A

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1208,7 +1208,7 @@ class Client {
     // through whichever handlers the subscriber registered.  A replacement carries the order, so
     // this cannot send one without also considering the order event, or a subscriber holding only
     // that handler hears nothing.
-    void _report_lists_replaced();
+    void _report_lists_replaced(bool convos, bool requests);
     void _emit_history_replaced(const ConversationId& id);
     // Reports a message, and then reports every message that replies to it.
     //

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1204,7 +1204,11 @@ class Client {
 
     void _emit_conversation_added(const ConversationId& id);
     void _emit_conversation_removed(const ConversationId& id);
-    void _emit_lists_replaced();
+    // Reports both lists as wholly changed -- a row added, removed, or moved to a new position --
+    // through whichever handlers the subscriber registered.  A replacement carries the order, so
+    // this cannot send one without also considering the order event, or a subscriber holding only
+    // that handler hears nothing.
+    void _report_lists_replaced();
     void _emit_history_replaced(const ConversationId& id);
     // Reports a message, and then reports every message that replies to it.
     //

--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -1266,8 +1266,21 @@ class Client {
     // had just been handed a replacement.
     std::vector<ConversationId> _conversation_order();
     std::vector<ConversationId> _message_request_order();
-    // Reports whichever of the two lists is asked for, if its order has changed since it was last
-    // reported, and records what it sent.  Called by `_flush_pending`.
+    // Reports one list whose order may have moved, through whichever of its two handlers the
+    // subscriber registered, and records the order it reported.
+    //
+    // Which query runs is decided by that registration.  A replacement carries the rows and the
+    // order is already in them, so a subscriber wanting one is served by the row query alone;
+    // asking for the ids as well would be a second query for something already held.  A subscriber
+    // wanting only the order gets the id-only query, which is the cheaper of the two and the one
+    // that runs on every message.
+    void _report_list(
+            std::vector<ConversationId>& reported,
+            std::vector<AnyConversation> (Client::*rows)(),
+            std::vector<ConversationId> (Client::*ids)(),
+            std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
+            std::function<void(std::vector<ConversationId>)> callbacks::* reordered);
+    // Reports whichever of the two lists is asked for.  Called by `_flush_pending`.
     void _emit_order_updated(bool conversations, bool requests);
 
   public:

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -39,9 +39,14 @@ namespace session::client {
 /// is not a template on its argument — it is a promise by the caller that the object is spent
 /// afterwards.
 ///
-/// The conversation list an application maintains from these is expected to be *complete*: ordering
-/// is a comparison against every other conversation, so a partial list cannot be sorted.  Showing
-/// only part of it is fine, holding only part of it is not.
+/// The conversation list an application maintains from these is expected to be *complete*: the
+/// order is given as a whole list, so a partial one cannot be placed in it.  Showing only part of
+/// it is fine, holding only part of it is not.
+///
+/// The order itself is **ours, not the application's**.  Every handler that carries a list carries
+/// it already ordered, and `conversation_order_updated` reports a change to that order without
+/// re-sending the rows — so an application never has to sort, and should not, because the two
+/// lists are not sorted the same way and a comparator copied from one gets the other wrong.
 struct callbacks {
     /// A conversation now exists that did not before.
     std::function<void(AnyConversation&&)> conversation_added;
@@ -70,6 +75,42 @@ struct callbacks {
     /// are shared between them — a request is a conversation in every respect except which list it
     /// belongs to — and `Conversation::request` is what says which one a given handler is about.
     std::function<void(std::vector<AnyConversation>&&)> request_list_replaced;
+
+    /// One list's order changed, carrying that list's conversation ids in their new order and
+    /// nothing else.
+    ///
+    /// This is the cheap counterpart to the two `_list_replaced` handlers above.  What moves a
+    /// conversation is `last_activity` and `priority`, and by far the most common thing that moves
+    /// one is a message arriving — which also changes the row, so `conversation_updated` already
+    /// carries the new snippet and unread count.  Sending the whole list again to say the row is
+    /// now first would send every field of every other row to describe a change to one, and would
+    /// send that row's snippet twice.
+    ///
+    /// So the division is: **`conversation_updated` says what a row now contains,
+    /// `conversation_order_updated` says where the rows now are.**  A subscriber applying both has
+    /// the same state a replacement would have given it.
+    ///
+    /// Only fired when the order actually differs from what was last reported, which is what makes
+    /// it cheap in the common case: a message into the conversation already at the top of the list
+    /// leaves it at the top, and nothing is sent at all.
+    ///
+    /// Ordering guarantee, which a subscriber is entitled to rely on: any `conversation_added`,
+    /// `conversation_updated` or `conversation_removed` for the rows involved is delivered
+    /// **before** this, so the ids here always name conversations the subscriber has already been
+    /// told about.  An id in here that the subscriber does not hold — or one it holds that is
+    /// absent — therefore means a notification was missed, and is worth treating as a reason to
+    /// re-read the list rather than as a state to reconcile.
+    std::function<void(std::vector<ConversationId>)> conversation_order_updated;
+
+    /// The same, for the message request list, and separate for the same reason
+    /// `request_list_replaced` is: the two lists are disjoint and are not even ordered the same way
+    /// — conversations by `priority DESC, last_activity DESC, id` and requests by
+    /// `last_activity DESC, id`, with no priority term, because a request cannot be pinned.
+    ///
+    /// A conversation only ever sits in one of the two, so a message arriving fires exactly one of
+    /// these.  Approval moves a row between the lists, which is a change of membership rather than
+    /// of order, and is still reported as a replacement of both.
+    std::function<void(std::vector<ConversationId>)> request_order_updated;
 
     /// A message was added, whether received or sent from here.
     std::function<void(ConversationId&&, Message&&)> message_added;

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -44,9 +44,8 @@ namespace session::client {
 /// it is fine, holding only part of it is not.
 ///
 /// The order itself is **ours, not the application's**.  Every handler that carries a list carries
-/// it already ordered, and `conversation_order_updated` reports a change to that order without
-/// re-sending the rows — so an application never has to sort, and should not, because the two
-/// lists are not sorted the same way and a comparator copied from one gets the other wrong.
+/// it already ordered, so an application never has to sort, and should not: the two lists are not
+/// sorted the same way and a comparator copied from one gets the other wrong.
 struct callbacks {
     /// A conversation now exists that did not before.
     std::function<void(AnyConversation&&)> conversation_added;
@@ -76,41 +75,6 @@ struct callbacks {
     /// belongs to — and `Conversation::request` is what says which one a given handler is about.
     std::function<void(std::vector<AnyConversation>&&)> request_list_replaced;
 
-    /// One list's order changed, carrying that list's conversation ids in their new order and
-    /// nothing else.
-    ///
-    /// This is the cheap counterpart to the two `_list_replaced` handlers above.  What moves a
-    /// conversation is `last_activity` and `priority`, and by far the most common thing that moves
-    /// one is a message arriving — which also changes the row, so `conversation_updated` already
-    /// carries the new snippet and unread count.  Sending the whole list again to say the row is
-    /// now first would send every field of every other row to describe a change to one, and would
-    /// send that row's snippet twice.
-    ///
-    /// So the division is: **`conversation_updated` says what a row now contains,
-    /// `conversation_order_updated` says where the rows now are.**  A subscriber applying both has
-    /// the same state a replacement would have given it.
-    ///
-    /// Only fired when the order actually differs from what was last reported, which is what makes
-    /// it cheap in the common case: a message into the conversation already at the top of the list
-    /// leaves it at the top, and nothing is sent at all.
-    ///
-    /// Ordering guarantee, which a subscriber is entitled to rely on: any `conversation_added`,
-    /// `conversation_updated` or `conversation_removed` for the rows involved is delivered
-    /// **before** this, so the ids here always name conversations the subscriber has already been
-    /// told about.  An id in here that the subscriber does not hold — or one it holds that is
-    /// absent — therefore means a notification was missed, and is worth treating as a reason to
-    /// re-read the list rather than as a state to reconcile.
-    std::function<void(std::vector<ConversationId>)> conversation_order_updated;
-
-    /// The same, for the message request list, and separate for the same reason
-    /// `request_list_replaced` is: the two lists are disjoint and are not even ordered the same way
-    /// — conversations by `priority DESC, last_activity DESC, id` and requests by
-    /// `last_activity DESC, id`, with no priority term, because a request cannot be pinned.
-    ///
-    /// A conversation only ever sits in one of the two, so a message arriving fires exactly one of
-    /// these.  Approval moves a row between the lists, which is a change of membership rather than
-    /// of order, and is still reported as a replacement of both.
-    std::function<void(std::vector<ConversationId>)> request_order_updated;
 
     /// A message was added, whether received or sent from here.
     std::function<void(ConversationId&&, Message&&)> message_added;

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -11,6 +11,41 @@
 #include <vector>
 
 namespace session::client {
+/// Which of the two lists a conversation sits in.
+///
+/// `none` is a real answer rather than a missing one: a hidden conversation is in neither list, and
+/// so is one the subscriber has not been shown.
+enum class ConversationList {
+    none,
+    conversations,
+    requests,
+};
+
+/// Where a conversation was, and where it belongs now.
+///
+/// Enough to apply on its own, and it reads as the two steps it is:
+///
+///     if (p.from != ConversationList::none) remove(p.from, convo.id());
+///     if (p.to   != ConversationList::none) insert(p.to, std::move(convo), p.after);
+///
+/// `from` is the list the subscriber was last *told* this row was in, which is what it is holding
+/// rather than what the database now says. It saves searching the list the row did not come from;
+/// it does not save finding the row, which is a lookup by id either way.
+///
+/// The two lists are ordered differently -- conversations by `priority DESC, last_activity DESC,
+/// id` and requests by `last_activity DESC, id`, with no priority term -- so which list a position
+/// is in is part of the position rather than a detail.
+struct ListPlacement {
+    /// Where the subscriber is holding this row, so it knows which list to take it out of.
+    /// `none` when it is holding it nowhere: a row it has not been shown, or one that was hidden.
+    ConversationList from = ConversationList::none;
+    /// Where it belongs now.  `none` means neither list, which is what hiding does -- then it is
+    /// only removed.
+    ConversationList to = ConversationList::none;
+    /// The row it now follows in `to`; unset means first in that list.  Meaningless, and always
+    /// unset, when `to` is `none`.
+    std::optional<ConversationId> after;
+};
 
 /// Notifications of everything the conversation layer changes, so that an application never has to
 /// ask.  A caller sets the handlers it cares about and leaves the rest empty; an unset handler is
@@ -48,16 +83,28 @@ namespace session::client {
 /// sorted the same way and a comparator copied from one gets the other wrong.
 struct callbacks {
     /// A conversation now exists that did not before.
-    std::function<void(AnyConversation&&)> conversation_added;
+    ///
+    /// Carries where it belongs, on the same terms as `conversation_updated`: `from` is normally
+    /// `none`, since a row that did not exist was not being held anywhere.
+    std::function<void(AnyConversation&&, ListPlacement&&)> conversation_added;
 
     /// A conversation's contents changed: a new or edited message, a name, an unread count, its
     /// last activity.  Fired once with the conversation's settled state rather than once per
     /// underlying change, so a poll that delivers fifty messages to one conversation fires this
     /// once.
-    std::function<void(AnyConversation&&)> conversation_updated;
+    ///
+    /// The second argument says where the row was and where it belongs now, which is enough to
+    /// apply without consulting anything: remove it from `from`, insert it into `to`.
+    ///
+    /// **Applying these in order is what keeps a list correct.**  Each one places a row relative to
+    /// another, so one applied out of order, or skipped, leaves the list wrong with nothing to
+    /// detect it.  A subscriber that has not read the list once with `conversations()` has nothing
+    /// to place rows into.
+    std::function<void(AnyConversation&&, ListPlacement&&)> conversation_updated;
 
-    /// A conversation is gone and should be dropped from the list.
-    std::function<void(ConversationId&&)> conversation_removed;
+    /// A conversation is gone and should be dropped from the list it is in, which is the second
+    /// argument -- `none` if it was never shown in one.  Saves searching both.
+    std::function<void(ConversationId&&, ConversationList)> conversation_removed;
 
     /// Priorities changed — a pin, unpin, hide or unhide — carrying the whole list in its new
     /// order.  A replacement rather than a description of what moved, because one config update

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1562,6 +1562,14 @@ std::span<const std::byte> Client::_self_or_none() {
     return core.globals.session_id();
 }
 
+// Which list a conversation is in, for a caller that has changed one row and needs to name the list
+// that made stale rather than both.  One indexed row, against the list query it saves.
+static bool is_request_row(sqlite::Connection& c, int64_t convo, std::span<const std::byte> self) {
+    return c.prepared_get<int64_t>(
+                   "SELECT {} {} WHERE c.id = ?2"_format(IS_REQUEST, SUBJECT_JOIN), self, convo) !=
+           0;
+}
+
 std::vector<AnyConversation> Client::_conversations() {
     auto c = core.database().conn();
     return query_conversations(
@@ -1908,6 +1916,7 @@ void Client::_set_nickname(const ConversationId& id, std::string_view nickname) 
 
 void Client::_set_priority(const ConversationId& id, int priority) {
     int changed = 0;
+    bool request = false;
     {
         auto c = core.database().conn();
         SQLite::Transaction tx{c.sql};
@@ -1921,12 +1930,17 @@ void Client::_set_priority(const ConversationId& id, int priority) {
                 "UPDATE conversations SET priority = ?1 WHERE id = ?2 AND priority IS NOT ?1",
                 priority,
                 convo);
+        // Read inside the transaction that changed it, and only when it did: the row stays in
+        // whichever list it was in -- priority moves it within one, never between the two -- so the
+        // other list has not changed and does not need reading.
+        if (changed > 0)
+            request = is_request_row(c, convo, _self_or_none());
         tx.commit();
     }
 
     if (changed > 0) {
         _sync_conversation(id);
-        _report_lists_replaced();
+        _report_lists_replaced(!request, request);
     }
 }
 
@@ -1982,7 +1996,7 @@ void Client::_clear_messages(const ConversationId& id) {
 
 void Client::_delete_conversation(const ConversationId& id, bool keep_messages) {
     auto now = clock_now_ms();
-    bool emptied = false, hidden = false;
+    bool emptied = false, hidden = false, request = false;
     {
         auto c = core.database().conn();
         SQLite::Transaction tx{c.sql};
@@ -2001,6 +2015,10 @@ void Client::_delete_conversation(const ConversationId& id, bool keep_messages) 
         hidden = c.prepared_exec(
                          "UPDATE conversations SET priority = -1 WHERE id = ? AND priority >= 0",
                          *convo) > 0;
+        // While the row is still readable and only when it went: hiding takes it out of the one
+        // list it was in, so the other has not changed.
+        if (hidden)
+            request = is_request_row(c, *convo, _self_or_none());
         tx.commit();
     }
 
@@ -2011,7 +2029,7 @@ void Client::_delete_conversation(const ConversationId& id, bool keep_messages) 
     if (emptied)
         _emit_history_replaced(id);
     if (hidden)
-        _report_lists_replaced();
+        _report_lists_replaced(!request, request);
 }
 
 void Client::_delete_contact(const ConversationId& id) {
@@ -2042,7 +2060,9 @@ void Client::_delete_contact(const ConversationId& id) {
 
     if (removed) {
         _emit_conversation_removed(id);
-        _report_lists_replaced();
+        // Both, unlike hiding: losing the contact row takes the approval with it, so the row does
+        // not merely leave a list, it stops being classifiable into either.
+        _report_lists_replaced(true, true);
     }
 }
 
@@ -2417,14 +2437,14 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
 // is approval, what removes it from either is hiding or deletion, and a caller that had to work out
 // which of those it just did would eventually get it wrong.  A replacement is idempotent, so the
 // cost of sending one nobody needed is a query.
-void Client::_report_lists_replaced() {
+void Client::_report_lists_replaced(bool convos, bool requests) {
     // Both lists, wholly: a row appeared, went, or changed where it sorts.  The subscriber is told
     // through whichever handler it registered, and that is the point of routing this through the
     // same path as a moved row rather than sending replacements outright -- a replacement carries
     // the order, so a subscriber holding only `conversation_order_updated` was told nothing at all
     // by the eight callers of this, and its arrangement stayed as it was until the next message
     // happened to move something.
-    _report_lists(true, true, true, true);
+    _report_lists(convos, convos, requests, requests);
 }
 
 // -- Config reconciliation ----------------------------------------------------------------------
@@ -2813,8 +2833,11 @@ WHERE id = ?1
         _touch(id);
     for (const auto& id : removed)
         _emit_conversation_removed(id);
+    // Each list only if something in it changed.  A removal can be from either -- what was taken
+    // out is gone from whichever list held it -- so it names both.
     if (order_changed || requests_changed || !removed.empty())
-        _report_lists_replaced();
+        _report_lists_replaced(
+                order_changed || !removed.empty(), requests_changed || !removed.empty());
 }
 
 void Client::_sync_all_contacts() {
@@ -3168,8 +3191,10 @@ WHERE id = ?1 AND (exp_mode, exp_timer) IS NOT (?2, ?3)
         _touch(me);
     if (history_changed)
         _emit_history_replaced(me);
+    // Note to self only, and it cannot be a request -- we are not our own contact -- so the request
+    // list cannot have been touched by this.
     if (order_changed)
-        _report_lists_replaced();
+        _report_lists_replaced(true, false);
 }
 
 // -- Messages ---------------------------------------------------------------------------------
@@ -3657,7 +3682,9 @@ int64_t Client::_send_message(const ConversationId& id, const OutgoingMessage& m
 
     if (approved) {
         _sync_contact(id);
-        _report_lists_replaced();
+        // Both: approving moves the row out of the requests and into the conversations, so one list
+        // lost it and the other gained it.
+        _report_lists_replaced(true, true);
     }
     if (created)
         _emit_conversation_added(id);
@@ -3849,7 +3876,9 @@ int64_t Client::_send_message(
 
     if (approved) {
         _sync_contact(id);
-        _report_lists_replaced();
+        // Both: approving moves the row out of the requests and into the conversations, so one list
+        // lost it and the other gained it.
+        _report_lists_replaced(true, true);
     }
     if (created)
         _emit_conversation_added(id);
@@ -5260,7 +5289,7 @@ void Client::_on_message_received(core::ReceivedMessage&& msg) {
     // Approval moves a conversation between the two lists, so both changed and neither changed in a
     // way that naming one row would describe.
     if (approved_them)
-        _report_lists_replaced();
+        _report_lists_replaced(true, true);
 }
 
 void Client::_on_send_status(

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -581,6 +581,14 @@ void Client::_flush_pending() {
         if (!convo)
             continue;
         // A hidden row is in neither list, so nothing about it makes either one stale.
+        //
+        // This reads the row's priority now, so it cannot tell a row that was always hidden from
+        // one that has just become hidden -- and the second of those did change both lists, by
+        // leaving one of them.  That case does not arrive here: every write to
+        // `conversations.priority` emits a replacement on its own path rather than dirtying the
+        // row and leaving this to report it, so the removal has already been sent by the time the
+        // row turns up in `_dirty`.  Should a fifth writer of that column ever appear, it has to do
+        // the same, because there is nothing here that could notice the transition.
         if (convo->priority() >= 0) {
             auto* dm = convo->dm();
             const bool request = dm && dm->request;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1926,7 +1926,7 @@ void Client::_set_priority(const ConversationId& id, int priority) {
 
     if (changed > 0) {
         _sync_conversation(id);
-        _emit_lists_replaced();
+        _report_lists_replaced();
     }
 }
 
@@ -2011,7 +2011,7 @@ void Client::_delete_conversation(const ConversationId& id, bool keep_messages) 
     if (emptied)
         _emit_history_replaced(id);
     if (hidden)
-        _emit_lists_replaced();
+        _report_lists_replaced();
 }
 
 void Client::_delete_contact(const ConversationId& id) {
@@ -2042,7 +2042,7 @@ void Client::_delete_contact(const ConversationId& id) {
 
     if (removed) {
         _emit_conversation_removed(id);
-        _emit_lists_replaced();
+        _report_lists_replaced();
     }
 }
 
@@ -2417,45 +2417,14 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
 // is approval, what removes it from either is hiding or deletion, and a caller that had to work out
 // which of those it just did would eventually get it wrong.  A replacement is idempotent, so the
 // cost of sending one nobody needed is a query.
-void Client::_emit_lists_replaced() {
-    // Both list queries are the expensive part, so neither runs for a handler that is not there.
-    // Checked per list rather than for the pair, since a subscriber may well want one and not the
-    // other -- a client with no requests screen has no use for the request list.
-    const bool want_convos = static_cast<bool>(_cbs->conversation_list_replaced);
-    const bool want_requests = static_cast<bool>(_cbs->request_list_replaced);
-
-    auto convos = want_convos ? _conversations() : std::vector<AnyConversation>{};
-    auto requests = want_requests ? _message_requests() : std::vector<AnyConversation>{};
-
-    // A replacement carries the order as much as an order event does, so record it as reported.
-    // Without this the record would describe an older belief than the subscriber actually holds,
-    // and an order event that happened to match that older belief would be suppressed -- leaving
-    // the subscriber arranged the way this replacement left it, and never corrected.  Taken from
-    // the rows already read rather than by querying again.
-    //
-    // Only for a list actually sent: an unsent one told the subscriber nothing, so the record of
-    // what it holds has to stay as it was.  Overwriting it with the empty list read above would
-    // claim the subscriber had been handed an empty order, and the next order event would be
-    // measured against that.
-    auto ids = [](const std::vector<AnyConversation>& list) {
-        std::vector<ConversationId> out;
-        out.reserve(list.size());
-        for (const auto& c : list)
-            out.push_back(c.id());
-        return out;
-    };
-    if (want_convos)
-        _reported_order = ids(convos);
-    if (want_requests)
-        _reported_request_order = ids(requests);
-
-    _emit([convos = std::move(convos),
-           requests = std::move(requests)](const callbacks& cbs) mutable {
-        if (cbs.conversation_list_replaced)
-            cbs.conversation_list_replaced(std::move(convos));
-        if (cbs.request_list_replaced)
-            cbs.request_list_replaced(std::move(requests));
-    });
+void Client::_report_lists_replaced() {
+    // Both lists, wholly: a row appeared, went, or changed where it sorts.  The subscriber is told
+    // through whichever handler it registered, and that is the point of routing this through the
+    // same path as a moved row rather than sending replacements outright -- a replacement carries
+    // the order, so a subscriber holding only `conversation_order_updated` was told nothing at all
+    // by the eight callers of this, and its arrangement stayed as it was until the next message
+    // happened to move something.
+    _report_lists(true, true, true, true);
 }
 
 // -- Config reconciliation ----------------------------------------------------------------------
@@ -2845,7 +2814,7 @@ WHERE id = ?1
     for (const auto& id : removed)
         _emit_conversation_removed(id);
     if (order_changed || requests_changed || !removed.empty())
-        _emit_lists_replaced();
+        _report_lists_replaced();
 }
 
 void Client::_sync_all_contacts() {
@@ -3200,7 +3169,7 @@ WHERE id = ?1 AND (exp_mode, exp_timer) IS NOT (?2, ?3)
     if (history_changed)
         _emit_history_replaced(me);
     if (order_changed)
-        _emit_lists_replaced();
+        _report_lists_replaced();
 }
 
 // -- Messages ---------------------------------------------------------------------------------
@@ -3688,7 +3657,7 @@ int64_t Client::_send_message(const ConversationId& id, const OutgoingMessage& m
 
     if (approved) {
         _sync_contact(id);
-        _emit_lists_replaced();
+        _report_lists_replaced();
     }
     if (created)
         _emit_conversation_added(id);
@@ -3880,7 +3849,7 @@ int64_t Client::_send_message(
 
     if (approved) {
         _sync_contact(id);
-        _emit_lists_replaced();
+        _report_lists_replaced();
     }
     if (created)
         _emit_conversation_added(id);
@@ -5291,7 +5260,7 @@ void Client::_on_message_received(core::ReceivedMessage&& msg) {
     // Approval moves a conversation between the two lists, so both changed and neither changed in a
     // way that naming one row would describe.
     if (approved_them)
-        _emit_lists_replaced();
+        _report_lists_replaced();
 }
 
 void Client::_on_send_status(

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -478,19 +478,32 @@ void Client::_emit_conversation_added(const ConversationId& id) {
     auto convo = _conversation(id);
     if (!convo)
         return;
+    // Placed here rather than left to the `conversation_updated` that follows: an add that says
+    // where the row goes is applicable on its own, and the alternative is a guarantee about the
+    // order of two callbacks that nothing enforces.
+    auto placement = _place(*convo);
     // Mutable so the value moves out: each _emit job runs once, and the handler owns what it gets.
-    _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
+    _emit([convo = std::move(*convo),
+           placement = std::move(placement)](const callbacks& cbs) mutable {
         if (cbs.conversation_added)
-            cbs.conversation_added(std::move(convo));
+            cbs.conversation_added(std::move(convo), std::move(placement));
     });
 }
 
 void Client::_emit_conversation_removed(const ConversationId& id) {
+    // Where the subscriber is holding it, so it knows which list to take it out of; `none` if it
+    // was never shown one.  Read and then dropped -- keeping it would leak an entry per
+    // conversation ever deleted, and the row is already gone from the database by now.
+    auto from = ConversationList::none;
+    if (auto held = _placed.find(id); held != _placed.end()) {
+        from = held->second;
+        _placed.erase(held);
+    }
     // `id = id` rather than `id`: a copy-capture of a const lvalue is itself const, which `mutable`
     // does not undo, and the handler is given the id outright.
-    _emit([id = id](const callbacks& cbs) mutable {
+    _emit([id = id, from](const callbacks& cbs) mutable {
         if (cbs.conversation_removed)
-            cbs.conversation_removed(std::move(id));
+            cbs.conversation_removed(std::move(id), from);
     });
 }
 
@@ -586,17 +599,21 @@ void Client::_flush_pending() {
             const bool request = dm && dm->request;
             (request ? requests_changed : convos_changed) = true;
         }
-        _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
+        // Read before the emit, and off the row this loop already fetched: the anchor is one
+        // indexed seek, against reading the whole list to say the same thing.
+        auto placement = _place(*convo);
+        _emit([convo = std::move(*convo),
+               placement = std::move(placement)](const callbacks& cbs) mutable {
             if (cbs.conversation_updated)
-                cbs.conversation_updated(std::move(convo));
+                cbs.conversation_updated(std::move(convo), std::move(placement));
         });
     }
 
     // And then the lists, each through whichever handler asked for it.
     //
-    // A `conversation_updated` names the row and says nothing about its position, so a subscriber
-    // applying one alone would have to work the order out for itself -- which means reimplementing
-    // this sort, and the two lists are not sorted the same way.
+    // A `conversation_updated` carries its row's position, so a subscriber applying those in order
+    // keeps its lists arranged without ever sorting -- which it could not do correctly anyway,
+    // since the two lists are not sorted the same way.
     //
     // Deliberately after that loop rather than before it, which is the guarantee
     // `conversation_order_updated` documents: the ids reported here always name conversations the
@@ -1374,6 +1391,23 @@ static const auto REQUEST_FILTER_ORDER =
         // still omitted -- hiding is the one thing another device *can* say about a request it does
         // not want to see.
         "WHERE c.priority >= 0 AND {} ORDER BY c.last_activity DESC, c.id"_format(IS_REQUEST);
+
+// The row a given one now follows, per list: each list's ordering reversed, taking the first row
+// that sorts before it.  Must stay in step with the two fragments above -- an anchor read in a
+// different order than the list is sorted in places the row in the wrong gap.
+//
+// One indexed seek against `conversations_order` rather than reading the list: measured at 0.11 ms
+// where reading the ordered ids is 1.85 ms and the rows 4.85 ms, at five thousand conversations.
+//
+// Binds are the self id, then the subject row's own sort key.
+static const auto CONVO_ANCHOR =
+        "WHERE c.priority >= 0 AND NOT {} AND (c.priority > ?2 OR (c.priority = ?2 AND "
+        "(c.last_activity > ?3 OR (c.last_activity = ?3 AND c.id < ?4)))) "
+        "ORDER BY c.priority ASC, c.last_activity ASC, c.id DESC LIMIT 1"_format(IS_REQUEST);
+static const auto REQUEST_ANCHOR =
+        "WHERE c.priority >= 0 AND {} AND "
+        "(c.last_activity > ?2 OR (c.last_activity = ?2 AND c.id < ?3)) "
+        "ORDER BY c.last_activity ASC, c.id DESC LIMIT 1"_format(IS_REQUEST);
 
 // Fills in the attachment side of the `last_preview` of every conversation that has one.
 // `previews` pairs the previewed message with the index of the conversation it belongs to.
@@ -2332,8 +2366,51 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
     contacts.set(*entry);
 }
 
+ListPlacement Client::_place(const AnyConversation& convo) {
+    ListPlacement out;
+
+    auto c = core.database().conn();
+    auto row = find_conversation(c, convo.id());
+    if (!row)
+        return out;
+
+    // Where the subscriber is holding it, which is what it has to take the row out of -- not what
+    // the database says now, which is where the row is going.  A row it has never been told about
+    // has no entry, and nothing to remove.
+    if (auto held = _placed.find(convo.id()); held != _placed.end())
+        out.from = held->second;
+
+    // Hidden is in neither list: taken out, and not put back.
+    if (convo.priority() < 0) {
+        _placed.erase(convo.id());
+        return out;
+    }
+
+    auto* dm = convo.dm();
+    const bool request = dm && dm->request;
+    out.to = request ? ConversationList::requests : ConversationList::conversations;
+    _placed[convo.id()] = out.to;
+
+    auto before = request ? c.prepared_maybe_get<int64_t>(
+                                    "SELECT c.id {} {}"_format(SUBJECT_JOIN, REQUEST_ANCHOR),
+                                    _self_or_none(),
+                                    epoch_ms(convo.last_activity()),
+                                    *row)
+                          : c.prepared_maybe_get<int64_t>(
+                                    "SELECT c.id {} {}"_format(SUBJECT_JOIN, CONVO_ANCHOR),
+                                    _self_or_none(),
+                                    convo.priority(),
+                                    epoch_ms(convo.last_activity()),
+                                    *row);
+    // Nothing sorts before it, so it goes first -- which an unset anchor is what says.
+    if (before)
+        out.after = conversation_id_at(c, *before);
+    return out;
+}
+
 void Client::_report_list(
         bool changed,
+        ConversationList list_kind,
         std::vector<AnyConversation> (Client::*rows)(),
         std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced) {
     // Before the query, not after: reading a list to hand it to nobody is the whole cost of the
@@ -2341,14 +2418,31 @@ void Client::_report_list(
     if (!changed || !((*_cbs).*replaced))
         return;
 
-    _emit([list = (this->*rows)(), replaced](const callbacks& cbs) mutable {
+    auto list = (this->*rows)();
+    // A replacement places every row it carries, so it is as much a report of where rows are as an
+    // update is.  Without recording it here the next update would offer a `from` describing an
+    // older belief than the subscriber actually holds.
+    {
+        for (const auto& convo : list)
+            _placed[convo.id()] = list_kind;
+    }
+
+    _emit([list = std::move(list), replaced](const callbacks& cbs) mutable {
         (cbs.*replaced)(std::move(list));
     });
 }
 
 void Client::_report_lists(bool convos_changed, bool requests_changed) {
-    _report_list(convos_changed, &Client::_conversations, &callbacks::conversation_list_replaced);
-    _report_list(requests_changed, &Client::_message_requests, &callbacks::request_list_replaced);
+    _report_list(
+            convos_changed,
+            ConversationList::conversations,
+            &Client::_conversations,
+            &callbacks::conversation_list_replaced);
+    _report_list(
+            requests_changed,
+            ConversationList::requests,
+            &Client::_message_requests,
+            &callbacks::request_list_replaced);
 }
 
 // Both lists, always, and deliberately not one or the other: what moves a conversation between them

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1357,6 +1357,22 @@ static const auto CONVO_COLUMNS = R"(
 static constexpr auto IS_REQUEST =
         "(c.dm IS NOT NULL AND coalesce(ct.approved, 0) = 0 AND a.session_id IS NOT ?1)"sv;
 
+// One fragment per list, shared by both queries that read that list: the one that reads the rows
+// and the one that reads only their order.  The two have to select and sort identically -- a
+// subscriber arranging rows from an order event and one just handed a replacement must arrive at
+// the same list -- and nothing would report them drifting apart.
+static const auto CONVO_FILTER_ORDER =
+        // Hidden (negative priority) conversations are not part of the list at all; pinned ones
+        // lead it, and equal priorities form a block that sorts among itself by recency.
+        "WHERE c.priority >= 0 AND NOT {} ORDER BY c.priority DESC, c.last_activity DESC, c.id"_format(
+                IS_REQUEST);
+static const auto REQUEST_FILTER_ORDER =
+        // No priority in the ordering: a request cannot be pinned, since pinning is a property of
+        // the config entry and there is nothing there to pin until it is approved.  Hidden ones are
+        // still omitted -- hiding is the one thing another device *can* say about a request it does
+        // not want to see.
+        "WHERE c.priority >= 0 AND {} ORDER BY c.last_activity DESC, c.id"_format(IS_REQUEST);
+
 // Fills in the attachment side of the `last_preview` of every conversation that has one.
 // `previews` pairs the previewed message with the index of the conversation it belongs to.
 //
@@ -1537,27 +1553,13 @@ std::span<const std::byte> Client::_self_or_none() {
 std::vector<AnyConversation> Client::_conversations() {
     auto c = core.database().conn();
     return query_conversations(
-            *this,
-            c,
-            // Hidden (negative priority) conversations are not part of the list at all; pinned ones
-            // lead it, and equal priorities form a block that sorts among itself by recency.
-            "{} WHERE c.priority >= 0 AND NOT {} ORDER BY c.priority DESC, c.last_activity DESC, c.id"_format(
-                    CONVO_COLUMNS, IS_REQUEST),
-            _self_or_none());
+            *this, c, "{} {}"_format(CONVO_COLUMNS, CONVO_FILTER_ORDER), _self_or_none());
 }
 
 std::vector<AnyConversation> Client::_message_requests() {
     auto c = core.database().conn();
-    // No priority ordering: a request cannot be pinned -- pinning is a property of the config entry
-    // and there is nothing there to pin until it is approved -- so recency is the only order there
-    // is.  Hidden ones are still omitted, since hiding is the one thing another device *can* say
-    // about a request it does not want to see.
     return query_conversations(
-            *this,
-            c,
-            "{} WHERE c.priority >= 0 AND {} ORDER BY c.last_activity DESC, c.id"_format(
-                    CONVO_COLUMNS, IS_REQUEST),
-            _self_or_none());
+            *this, c, "{} {}"_format(CONVO_COLUMNS, REQUEST_FILTER_ORDER), _self_or_none());
 }
 
 // The ordered ids of a list and nothing else.  `CONVO_COLUMNS` is most of the cost of reading a
@@ -1579,27 +1581,23 @@ static std::vector<ConversationId> query_conversation_ids(
     return out;
 }
 
-// The filter and the ORDER BY are `_conversations`' and `_message_requests`', and have to stay that
-// way: a subscriber arranging rows by an order event and one that has just been handed a
-// replacement must end up with the same list.
-static constexpr auto ORDER_COLUMNS = "SELECT c.id, a.session_id, g.group_id, m.base_url, m.room";
+// Carries its own join, as `CONVO_COLUMNS` does, so that a list query is a column set and a filter
+// and nothing else has to be remembered at the call site.
+static const auto ORDER_COLUMNS = R"(
+    SELECT c.id, a.session_id, g.group_id, m.base_url, m.room
+    {}
+)"_format(SUBJECT_JOIN);
 
 std::vector<ConversationId> Client::_conversation_order() {
     auto c = core.database().conn();
     return query_conversation_ids(
-            c,
-            "{} {} WHERE c.priority >= 0 AND NOT {} ORDER BY c.priority DESC, c.last_activity DESC, c.id"_format(
-                    ORDER_COLUMNS, SUBJECT_JOIN, IS_REQUEST),
-            _self_or_none());
+            c, "{} {}"_format(ORDER_COLUMNS, CONVO_FILTER_ORDER), _self_or_none());
 }
 
 std::vector<ConversationId> Client::_message_request_order() {
     auto c = core.database().conn();
     return query_conversation_ids(
-            c,
-            "{} {} WHERE c.priority >= 0 AND {} ORDER BY c.last_activity DESC, c.id"_format(
-                    ORDER_COLUMNS, SUBJECT_JOIN, IS_REQUEST),
-            _self_or_none());
+            c, "{} {}"_format(ORDER_COLUMNS, REQUEST_FILTER_ORDER), _self_or_none());
 }
 
 void Client::_emit_order_updated(bool conversations, bool requests) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -473,6 +473,8 @@ void Client::_dispatch_out(std::function<void()> job) {
 }
 
 void Client::_emit_conversation_added(const ConversationId& id) {
+    if (!_cbs->conversation_added)
+        return;
     auto convo = _conversation(id);
     if (!convo)
         return;
@@ -500,6 +502,8 @@ void Client::_emit_history_replaced(const ConversationId& id) {
 }
 
 void Client::_emit_message_alone(bool added, const ConversationId& id, int64_t message_id) {
+    if (!(added ? _cbs->message_added : _cbs->message_updated))
+        return;
     auto msg = _message(message_id);
     if (!msg)
         return;
@@ -1600,29 +1604,64 @@ std::vector<ConversationId> Client::_message_request_order() {
             c, "{} {}"_format(ORDER_COLUMNS, REQUEST_FILTER_ORDER), _self_or_none());
 }
 
+void Client::_report_list(
+        std::vector<ConversationId>& reported,
+        std::vector<AnyConversation> (Client::*rows)(),
+        std::vector<ConversationId> (Client::*ids)(),
+        std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
+        std::function<void(std::vector<ConversationId>)> callbacks::* reordered) {
+    const bool want_replaced = static_cast<bool>((*_cbs).*replaced);
+    const bool want_order = static_cast<bool>((*_cbs).*reordered);
+    // Before the query, not after: reading a list to hand it to nobody is the whole cost of the
+    // operation.
+    if (!want_replaced && !want_order)
+        return;
+
+    std::vector<AnyConversation> list;
+    std::vector<ConversationId> order;
+    if (want_replaced) {
+        list = (this->*rows)();
+        order.reserve(list.size());
+        for (const auto& convo : list)
+            order.push_back(convo.id());
+    } else {
+        order = (this->*ids)();
+    }
+
+    // Whether the order moved is knowable only by reading it, so the read happens either way and
+    // it is the send that is saved -- which is worth having, because a message landing in the
+    // conversation already at the top of its list moves nothing, and that is what most messages in
+    // an active conversation do.
+    const bool moved = order != reported;
+    reported = order;
+
+    // A replacement is not suppressed on an unchanged order, because the order is not what it
+    // carries: the row whose arrival brought us here has a new snippet, and a subscriber holding
+    // only this handler has no other way to learn it.  Suppressing it here would be comparing one
+    // thing to decide whether to send another.
+    if (want_replaced)
+        _emit([list = std::move(list), replaced](const callbacks& cbs) { (cbs.*replaced)(list); });
+    if (want_order && moved)
+        _emit([order = std::move(order), reordered](const callbacks& cbs) {
+            (cbs.*reordered)(order);
+        });
+}
+
 void Client::_emit_order_updated(bool conversations, bool requests) {
-    // Read, compare, and send only if it differs.  The read is the unavoidable part -- there is no
-    // way to know an order changed without asking -- but the callback, and everything a subscriber
-    // does with it, is saved every time a message lands in the conversation already at the top of
-    // its list, which is what most messages in an active conversation do.
-    if (conversations) {
-        if (auto order = _conversation_order(); order != _reported_order) {
-            _reported_order = order;
-            _emit([order = std::move(order)](const callbacks& cbs) {
-                if (cbs.conversation_order_updated)
-                    cbs.conversation_order_updated(order);
-            });
-        }
-    }
-    if (requests) {
-        if (auto order = _message_request_order(); order != _reported_request_order) {
-            _reported_request_order = order;
-            _emit([order = std::move(order)](const callbacks& cbs) {
-                if (cbs.request_order_updated)
-                    cbs.request_order_updated(order);
-            });
-        }
-    }
+    if (conversations)
+        _report_list(
+                _reported_order,
+                &Client::_conversations,
+                &Client::_conversation_order,
+                &callbacks::conversation_list_replaced,
+                &callbacks::conversation_order_updated);
+    if (requests)
+        _report_list(
+                _reported_request_order,
+                &Client::_message_requests,
+                &Client::_message_request_order,
+                &callbacks::request_list_replaced,
+                &callbacks::request_order_updated);
 }
 
 std::optional<AnyConversation> Client::_conversation(const ConversationId& id) {
@@ -2364,14 +2403,25 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
 // which of those it just did would eventually get it wrong.  A replacement is idempotent, so the
 // cost of sending one nobody needed is a query.
 void Client::_emit_lists_replaced() {
-    auto convos = _conversations();
-    auto requests = _message_requests();
+    // Both list queries are the expensive part, so neither runs for a handler that is not there.
+    // Checked per list rather than for the pair, since a subscriber may well want one and not the
+    // other -- a client with no requests screen has no use for the request list.
+    const bool want_convos = static_cast<bool>(_cbs->conversation_list_replaced);
+    const bool want_requests = static_cast<bool>(_cbs->request_list_replaced);
+
+    auto convos = want_convos ? _conversations() : std::vector<AnyConversation>{};
+    auto requests = want_requests ? _message_requests() : std::vector<AnyConversation>{};
 
     // A replacement carries the order as much as an order event does, so record it as reported.
     // Without this the record would describe an older belief than the subscriber actually holds,
     // and an order event that happened to match that older belief would be suppressed -- leaving
     // the subscriber arranged the way this replacement left it, and never corrected.  Taken from
     // the rows already read rather than by querying again.
+    //
+    // Only for a list actually sent: an unsent one told the subscriber nothing, so the record of
+    // what it holds has to stay as it was.  Overwriting it with the empty list read above would
+    // claim the subscriber had been handed an empty order, and the next order event would be
+    // measured against that.
     auto ids = [](const std::vector<AnyConversation>& list) {
         std::vector<ConversationId> out;
         out.reserve(list.size());
@@ -2379,8 +2429,10 @@ void Client::_emit_lists_replaced() {
             out.push_back(c.id());
         return out;
     };
-    _reported_order = ids(convos);
-    _reported_request_order = ids(requests);
+    if (want_convos)
+        _reported_order = ids(convos);
+    if (want_requests)
+        _reported_request_order = ids(requests);
 
     _emit([convos = std::move(convos),
            requests = std::move(requests)](const callbacks& cbs) mutable {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1626,7 +1626,7 @@ void Client::_report_list(
         std::vector<ConversationId>& reported,
         std::vector<AnyConversation> (Client::*rows)(),
         std::vector<ConversationId> (Client::*ids)(),
-        std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
+        std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced,
         std::function<void(std::vector<ConversationId>)> callbacks::* reordered) {
     // A whole list is stale as soon as any row in it changed; only a row that moved can have
     // changed the order.  `changed` is therefore the wider of the two, and `moved` implies it.
@@ -1660,7 +1660,9 @@ void Client::_report_list(
     // only this handler has no other way to learn it.  Suppressing it here would be comparing one
     // thing to decide whether to send another.
     if (want_replaced)
-        _emit([list = std::move(list), replaced](const callbacks& cbs) { (cbs.*replaced)(list); });
+        _emit([list = std::move(list), replaced](const callbacks& cbs) mutable {
+            (cbs.*replaced)(std::move(list));
+        });
     if (want_order && order_changed)
         _emit([order = std::move(order), reordered](const callbacks& cbs) {
             (cbs.*reordered)(order);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -565,21 +565,28 @@ void Client::_flush_pending() {
     auto dirty_order = std::move(_dirty_order);
     _dirty_order.clear();
 
-    // Which list a moved row sits in, read off the row this loop already fetches rather than by
-    // asking again: only a DM can be a request, and the two lists are complements, so each moved
-    // row asks for exactly one of them.
-    bool conversations = false, requests = false;
+    // Which list each dirty row sits in, read off the row this loop already fetches rather than by
+    // asking again: only a DM can be a request, and the two lists are complements, so each row
+    // belongs to exactly one of them -- or, hidden, to neither.
+    //
+    // Two questions per list, and they are not the same question.  A row whose *contents* changed
+    // makes the list stale for a subscriber holding whole lists, and most of what dirties a
+    // conversation does that: a read receipt, a nickname, an expiry.  A row that *moved* is the
+    // narrower case, and only that one can change the order.
+    bool convos_changed = false, requests_changed = false;
+    bool convos_moved = false, requests_moved = false;
 
     for (const auto& id : dirty) {
         auto convo = _conversation(id);
         if (!convo)
             continue;
-        if (std::ranges::find(dirty_order, id) != dirty_order.end()) {
+        // A hidden row is in neither list, so nothing about it makes either one stale.
+        if (convo->priority() >= 0) {
             auto* dm = convo->dm();
-            if (dm && dm->request)
-                requests = true;
-            else
-                conversations = true;
+            const bool request = dm && dm->request;
+            (request ? requests_changed : convos_changed) = true;
+            if (std::ranges::find(dirty_order, id) != dirty_order.end())
+                (request ? requests_moved : convos_moved) = true;
         }
         _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
             if (cbs.conversation_updated)
@@ -587,27 +594,20 @@ void Client::_flush_pending() {
         });
     }
 
-    // And the order, if anything in this batch moved rather than merely changed.  A
-    // `conversation_updated` names the row and says nothing about its position, so a subscriber
+    // And then the lists, each through whichever handler asked for it.
+    //
+    // A `conversation_updated` names the row and says nothing about its position, so a subscriber
     // applying one alone would have to work the order out for itself -- which means reimplementing
     // this sort, and the two lists are not sorted the same way.
-    //
-    // The ids only, and not a replacement of the rows: the loop above has just sent every changed
-    // row in full, so a replacement here would re-send the rest of the list to describe a change to
-    // one of them, and would send the changed row's snippet a second time.
     //
     // Deliberately after that loop rather than before it, which is the guarantee
     // `conversation_order_updated` documents: the ids reported here always name conversations the
     // subscriber has already been told about, so an id it does not recognise means it missed a
     // notification rather than that the two are racing.
     //
-    // Once for the batch, not once per message: a poll delivering fifty messages to one
-    // conversation reaches here a single time, which is the same reason `_dirty` exists.  And only
-    // when an ordering term actually moved, because most of what dirties a conversation does not --
-    // a read receipt, a nickname, an expiry -- and a query per read conversation is a lot to say
-    // nothing.
-    if (conversations || requests)
-        _emit_order_updated(conversations, requests);
+    // Once for the batch, not once per row: a poll delivering fifty messages to one conversation
+    // reaches here a single time, which is the same reason `_dirty` exists.
+    _report_lists(convos_changed, convos_moved, requests_changed, requests_moved);
 }
 
 // -- Asynchronous interface ---------------------------------------------------------------------
@@ -1605,13 +1605,17 @@ std::vector<ConversationId> Client::_message_request_order() {
 }
 
 void Client::_report_list(
+        bool changed,
+        bool moved,
         std::vector<ConversationId>& reported,
         std::vector<AnyConversation> (Client::*rows)(),
         std::vector<ConversationId> (Client::*ids)(),
         std::function<void(std::vector<AnyConversation>)> callbacks::* replaced,
         std::function<void(std::vector<ConversationId>)> callbacks::* reordered) {
-    const bool want_replaced = static_cast<bool>((*_cbs).*replaced);
-    const bool want_order = static_cast<bool>((*_cbs).*reordered);
+    // A whole list is stale as soon as any row in it changed; only a row that moved can have
+    // changed the order.  `changed` is therefore the wider of the two, and `moved` implies it.
+    const bool want_replaced = changed && static_cast<bool>((*_cbs).*replaced);
+    const bool want_order = moved && static_cast<bool>((*_cbs).*reordered);
     // Before the query, not after: reading a list to hand it to nobody is the whole cost of the
     // operation.
     if (!want_replaced && !want_order)
@@ -1632,7 +1636,7 @@ void Client::_report_list(
     // it is the send that is saved -- which is worth having, because a message landing in the
     // conversation already at the top of its list moves nothing, and that is what most messages in
     // an active conversation do.
-    const bool moved = order != reported;
+    const bool order_changed = order != reported;
     reported = order;
 
     // A replacement is not suppressed on an unchanged order, because the order is not what it
@@ -1641,27 +1645,30 @@ void Client::_report_list(
     // thing to decide whether to send another.
     if (want_replaced)
         _emit([list = std::move(list), replaced](const callbacks& cbs) { (cbs.*replaced)(list); });
-    if (want_order && moved)
+    if (want_order && order_changed)
         _emit([order = std::move(order), reordered](const callbacks& cbs) {
             (cbs.*reordered)(order);
         });
 }
 
-void Client::_emit_order_updated(bool conversations, bool requests) {
-    if (conversations)
-        _report_list(
-                _reported_order,
-                &Client::_conversations,
-                &Client::_conversation_order,
-                &callbacks::conversation_list_replaced,
-                &callbacks::conversation_order_updated);
-    if (requests)
-        _report_list(
-                _reported_request_order,
-                &Client::_message_requests,
-                &Client::_message_request_order,
-                &callbacks::request_list_replaced,
-                &callbacks::request_order_updated);
+void Client::_report_lists(
+        bool convos_changed, bool convos_moved, bool requests_changed, bool requests_moved) {
+    _report_list(
+            convos_changed,
+            convos_moved,
+            _reported_order,
+            &Client::_conversations,
+            &Client::_conversation_order,
+            &callbacks::conversation_list_replaced,
+            &callbacks::conversation_order_updated);
+    _report_list(
+            requests_changed,
+            requests_moved,
+            _reported_request_order,
+            &Client::_message_requests,
+            &Client::_message_request_order,
+            &callbacks::request_list_replaced,
+            &callbacks::request_order_updated);
 }
 
 std::optional<AnyConversation> Client::_conversation(const ConversationId& id) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -2033,7 +2033,7 @@ void Client::_delete_conversation(const ConversationId& id, bool keep_messages) 
 }
 
 void Client::_delete_contact(const ConversationId& id) {
-    bool removed = false;
+    bool removed = false, was_request = false, was_listed = false;
     {
         auto c = core.database().conn();
         SQLite::Transaction tx{c.sql};
@@ -2042,6 +2042,18 @@ void Client::_delete_contact(const ConversationId& id) {
                 "SELECT id FROM accounts WHERE session_id = ?", id.session_id());
         if (!account)
             return;
+
+        // Which list it is in, before either delete below.  Not merely before the conversation
+        // goes: whether it is a request is read from `ct.approved`, which is a column of the
+        // contact row that is about to be deleted, so asking afterwards answers about a
+        // relationship that no longer exists and calls every deleted conversation a request.
+        //
+        // A hidden one is in neither list, so its going changes neither.
+        if (auto convo = c.prepared_maybe_get<int64_t>(
+                    "SELECT id FROM conversations WHERE dm = ? AND priority >= 0", *account)) {
+            was_listed = true;
+            was_request = is_request_row(c, *convo, _self_or_none());
+        }
 
         // The nickname, both approvals and the block are columns of the row being deleted, so
         // there is nothing to reset first: they exist only for as long as the relationship does.
@@ -2060,9 +2072,9 @@ void Client::_delete_contact(const ConversationId& id) {
 
     if (removed) {
         _emit_conversation_removed(id);
-        // Both, unlike hiding: losing the contact row takes the approval with it, so the row does
-        // not merely leave a list, it stops being classifiable into either.
-        _report_lists_replaced(true, true);
+        // The one list it was in.  A conversation is in exactly one of the two, so deleting it
+        // outright leaves the other exactly as it was.
+        _report_lists_replaced(was_listed && !was_request, was_listed && was_request);
     }
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -548,20 +548,62 @@ void Client::_touch(const ConversationId& id) {
     }
 }
 
+void Client::_touch_reordered(const ConversationId& id) {
+    if (std::ranges::find(_dirty_order, id) == _dirty_order.end())
+        _dirty_order.push_back(id);
+    _touch(id);
+}
+
 void Client::_flush_pending() {
     _flush_scheduled = false;
     auto dirty = std::move(_dirty);
     _dirty.clear();
+    auto dirty_order = std::move(_dirty_order);
+    _dirty_order.clear();
+
+    // Which list a moved row sits in, read off the row this loop already fetches rather than by
+    // asking again: only a DM can be a request, and the two lists are complements, so each moved
+    // row asks for exactly one of them.
+    bool conversations = false, requests = false;
 
     for (const auto& id : dirty) {
         auto convo = _conversation(id);
         if (!convo)
             continue;
+        if (std::ranges::find(dirty_order, id) != dirty_order.end()) {
+            auto* dm = convo->dm();
+            if (dm && dm->request)
+                requests = true;
+            else
+                conversations = true;
+        }
         _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
             if (cbs.conversation_updated)
                 cbs.conversation_updated(std::move(convo));
         });
     }
+
+    // And the order, if anything in this batch moved rather than merely changed.  A
+    // `conversation_updated` names the row and says nothing about its position, so a subscriber
+    // applying one alone would have to work the order out for itself -- which means reimplementing
+    // this sort, and the two lists are not sorted the same way.
+    //
+    // The ids only, and not a replacement of the rows: the loop above has just sent every changed
+    // row in full, so a replacement here would re-send the rest of the list to describe a change to
+    // one of them, and would send the changed row's snippet a second time.
+    //
+    // Deliberately after that loop rather than before it, which is the guarantee
+    // `conversation_order_updated` documents: the ids reported here always name conversations the
+    // subscriber has already been told about, so an id it does not recognise means it missed a
+    // notification rather than that the two are racing.
+    //
+    // Once for the batch, not once per message: a poll delivering fifty messages to one
+    // conversation reaches here a single time, which is the same reason `_dirty` exists.  And only
+    // when an ordering term actually moved, because most of what dirties a conversation does not --
+    // a read receipt, a nickname, an expiry -- and a query per read conversation is a lot to say
+    // nothing.
+    if (conversations || requests)
+        _emit_order_updated(conversations, requests);
 }
 
 // -- Asynchronous interface ---------------------------------------------------------------------
@@ -1518,6 +1560,73 @@ std::vector<AnyConversation> Client::_message_requests() {
             _self_or_none());
 }
 
+// The ordered ids of a list and nothing else.  `CONVO_COLUMNS` is most of the cost of reading a
+// list -- a display name to coalesce, an unread count, and a correlated subquery for the snippet,
+// per row -- and none of it says anything about where a row sits.  The identity columns are what
+// `subject_to_id` needs, and are already joined for the filter.
+template <typename... Bind>
+static std::vector<ConversationId> query_conversation_ids(
+        sqlite::Connection& c, const std::string& query, const Bind&... bind) {
+    std::vector<ConversationId> out;
+    for (auto [convo, sid, gid, url, room] :
+         c.prepared_results<
+                 int64_t,
+                 std::optional<sqlite::blob_guts<b33>>,
+                 std::optional<sqlite::blob_guts<b33>>,
+                 std::optional<std::string>,
+                 std::optional<std::string>>(query, bind...))
+        out.push_back(subject_to_id(convo, sid, gid, url, room));
+    return out;
+}
+
+// The filter and the ORDER BY are `_conversations`' and `_message_requests`', and have to stay that
+// way: a subscriber arranging rows by an order event and one that has just been handed a
+// replacement must end up with the same list.
+static constexpr auto ORDER_COLUMNS = "SELECT c.id, a.session_id, g.group_id, m.base_url, m.room";
+
+std::vector<ConversationId> Client::_conversation_order() {
+    auto c = core.database().conn();
+    return query_conversation_ids(
+            c,
+            "{} {} WHERE c.priority >= 0 AND NOT {} ORDER BY c.priority DESC, c.last_activity DESC, c.id"_format(
+                    ORDER_COLUMNS, SUBJECT_JOIN, IS_REQUEST),
+            _self_or_none());
+}
+
+std::vector<ConversationId> Client::_message_request_order() {
+    auto c = core.database().conn();
+    return query_conversation_ids(
+            c,
+            "{} {} WHERE c.priority >= 0 AND {} ORDER BY c.last_activity DESC, c.id"_format(
+                    ORDER_COLUMNS, SUBJECT_JOIN, IS_REQUEST),
+            _self_or_none());
+}
+
+void Client::_emit_order_updated(bool conversations, bool requests) {
+    // Read, compare, and send only if it differs.  The read is the unavoidable part -- there is no
+    // way to know an order changed without asking -- but the callback, and everything a subscriber
+    // does with it, is saved every time a message lands in the conversation already at the top of
+    // its list, which is what most messages in an active conversation do.
+    if (conversations) {
+        if (auto order = _conversation_order(); order != _reported_order) {
+            _reported_order = order;
+            _emit([order = std::move(order)](const callbacks& cbs) {
+                if (cbs.conversation_order_updated)
+                    cbs.conversation_order_updated(order);
+            });
+        }
+    }
+    if (requests) {
+        if (auto order = _message_request_order(); order != _reported_request_order) {
+            _reported_request_order = order;
+            _emit([order = std::move(order)](const callbacks& cbs) {
+                if (cbs.request_order_updated)
+                    cbs.request_order_updated(order);
+            });
+        }
+    }
+}
+
 std::optional<AnyConversation> Client::_conversation(const ConversationId& id) {
     auto c = core.database().conn();
     auto convo = find_conversation(c, id);
@@ -2259,6 +2368,22 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
 void Client::_emit_lists_replaced() {
     auto convos = _conversations();
     auto requests = _message_requests();
+
+    // A replacement carries the order as much as an order event does, so record it as reported.
+    // Without this the record would describe an older belief than the subscriber actually holds,
+    // and an order event that happened to match that older belief would be suppressed -- leaving
+    // the subscriber arranged the way this replacement left it, and never corrected.  Taken from
+    // the rows already read rather than by querying again.
+    auto ids = [](const std::vector<AnyConversation>& list) {
+        std::vector<ConversationId> out;
+        out.reserve(list.size());
+        for (const auto& c : list)
+            out.push_back(c.id());
+        return out;
+    };
+    _reported_order = ids(convos);
+    _reported_request_order = ids(requests);
+
     _emit([convos = std::move(convos),
            requests = std::move(requests)](const callbacks& cbs) mutable {
         if (cbs.conversation_list_replaced)
@@ -3504,7 +3629,7 @@ int64_t Client::_send_message(const ConversationId& id, const OutgoingMessage& m
         _emit_conversation_added(id);
     _reveal_note_to_self(id);
     _emit_message(true, id, client_id);
-    _touch(id);
+    _touch_reordered(id);
 
     log::debug(cat, "send_message: message {} to conversation {}", client_id, id.to_string());
 
@@ -3696,7 +3821,7 @@ int64_t Client::_send_message(
         _emit_conversation_added(id);
     _reveal_note_to_self(id);
     _emit_message(true, id, client_id);
-    _touch(id);
+    _touch_reordered(id);
 
     log::debug(
             cat,
@@ -5096,7 +5221,7 @@ void Client::_on_message_received(core::ReceivedMessage&& msg) {
         _emit_message(true, convo_id, client_id);
     }
     if (inserted || renamed)
-        _touch(convo_id);
+        _touch_reordered(convo_id);
 
     // Approval moves a conversation between the two lists, so both changed and neither changed in a
     // way that naming one row would describe.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -552,18 +552,11 @@ void Client::_touch(const ConversationId& id) {
     }
 }
 
-void Client::_touch_reordered(const ConversationId& id) {
-    if (std::ranges::find(_dirty_order, id) == _dirty_order.end())
-        _dirty_order.push_back(id);
-    _touch(id);
-}
 
 void Client::_flush_pending() {
     _flush_scheduled = false;
     auto dirty = std::move(_dirty);
     _dirty.clear();
-    auto dirty_order = std::move(_dirty_order);
-    _dirty_order.clear();
 
     // Which list each dirty row sits in, read off the row this loop already fetches rather than by
     // asking again: only a DM can be a request, and the two lists are complements, so each row
@@ -574,7 +567,6 @@ void Client::_flush_pending() {
     // conversation does that: a read receipt, a nickname, an expiry.  A row that *moved* is the
     // narrower case, and only that one can change the order.
     bool convos_changed = false, requests_changed = false;
-    bool convos_moved = false, requests_moved = false;
 
     for (const auto& id : dirty) {
         auto convo = _conversation(id);
@@ -593,8 +585,6 @@ void Client::_flush_pending() {
             auto* dm = convo->dm();
             const bool request = dm && dm->request;
             (request ? requests_changed : convos_changed) = true;
-            if (std::ranges::find(dirty_order, id) != dirty_order.end())
-                (request ? requests_moved : convos_moved) = true;
         }
         _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
             if (cbs.conversation_updated)
@@ -615,7 +605,7 @@ void Client::_flush_pending() {
     //
     // Once for the batch, not once per row: a poll delivering fifty messages to one conversation
     // reaches here a single time, which is the same reason `_dirty` exists.
-    _report_lists(convos_changed, convos_moved, requests_changed, requests_moved);
+    _report_lists(convos_changed, requests_changed);
 }
 
 // -- Asynchronous interface ---------------------------------------------------------------------
@@ -1582,112 +1572,7 @@ std::vector<AnyConversation> Client::_message_requests() {
             *this, c, "{} {}"_format(CONVO_COLUMNS, REQUEST_FILTER_ORDER), _self_or_none());
 }
 
-// The ordered ids of a list and nothing else.  `CONVO_COLUMNS` is most of the cost of reading a
-// list -- a display name to coalesce, an unread count, and a correlated subquery for the snippet,
-// per row -- and none of it says anything about where a row sits.  The identity columns are what
-// `subject_to_id` needs, and are already joined for the filter.
-template <typename... Bind>
-static std::vector<ConversationId> query_conversation_ids(
-        sqlite::Connection& c, const std::string& query, const Bind&... bind) {
-    std::vector<ConversationId> out;
-    for (auto [convo, sid, gid, url, room] :
-         c.prepared_results<
-                 int64_t,
-                 std::optional<sqlite::blob_guts<b33>>,
-                 std::optional<sqlite::blob_guts<b33>>,
-                 std::optional<std::string>,
-                 std::optional<std::string>>(query, bind...))
-        out.push_back(subject_to_id(convo, sid, gid, url, room));
-    return out;
-}
 
-// Carries its own join, as `CONVO_COLUMNS` does, so that a list query is a column set and a filter
-// and nothing else has to be remembered at the call site.
-static const auto ORDER_COLUMNS = R"(
-    SELECT c.id, a.session_id, g.group_id, m.base_url, m.room
-    {}
-)"_format(SUBJECT_JOIN);
-
-std::vector<ConversationId> Client::_conversation_order() {
-    auto c = core.database().conn();
-    return query_conversation_ids(
-            c, "{} {}"_format(ORDER_COLUMNS, CONVO_FILTER_ORDER), _self_or_none());
-}
-
-std::vector<ConversationId> Client::_message_request_order() {
-    auto c = core.database().conn();
-    return query_conversation_ids(
-            c, "{} {}"_format(ORDER_COLUMNS, REQUEST_FILTER_ORDER), _self_or_none());
-}
-
-void Client::_report_list(
-        bool changed,
-        bool moved,
-        std::vector<ConversationId>& reported,
-        std::vector<AnyConversation> (Client::*rows)(),
-        std::vector<ConversationId> (Client::*ids)(),
-        std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced,
-        std::function<void(std::vector<ConversationId>)> callbacks::* reordered) {
-    // A whole list is stale as soon as any row in it changed; only a row that moved can have
-    // changed the order.  `changed` is therefore the wider of the two, and `moved` implies it.
-    const bool want_replaced = changed && static_cast<bool>((*_cbs).*replaced);
-    const bool want_order = moved && static_cast<bool>((*_cbs).*reordered);
-    // Before the query, not after: reading a list to hand it to nobody is the whole cost of the
-    // operation.
-    if (!want_replaced && !want_order)
-        return;
-
-    std::vector<AnyConversation> list;
-    std::vector<ConversationId> order;
-    if (want_replaced) {
-        list = (this->*rows)();
-        order.reserve(list.size());
-        for (const auto& convo : list)
-            order.push_back(convo.id());
-    } else {
-        order = (this->*ids)();
-    }
-
-    // Whether the order moved is knowable only by reading it, so the read happens either way and
-    // it is the send that is saved -- which is worth having, because a message landing in the
-    // conversation already at the top of its list moves nothing, and that is what most messages in
-    // an active conversation do.
-    const bool order_changed = order != reported;
-    reported = order;
-
-    // A replacement is not suppressed on an unchanged order, because the order is not what it
-    // carries: the row whose arrival brought us here has a new snippet, and a subscriber holding
-    // only this handler has no other way to learn it.  Suppressing it here would be comparing one
-    // thing to decide whether to send another.
-    if (want_replaced)
-        _emit([list = std::move(list), replaced](const callbacks& cbs) mutable {
-            (cbs.*replaced)(std::move(list));
-        });
-    if (want_order && order_changed)
-        _emit([order = std::move(order), reordered](const callbacks& cbs) {
-            (cbs.*reordered)(order);
-        });
-}
-
-void Client::_report_lists(
-        bool convos_changed, bool convos_moved, bool requests_changed, bool requests_moved) {
-    _report_list(
-            convos_changed,
-            convos_moved,
-            _reported_order,
-            &Client::_conversations,
-            &Client::_conversation_order,
-            &callbacks::conversation_list_replaced,
-            &callbacks::conversation_order_updated);
-    _report_list(
-            requests_changed,
-            requests_moved,
-            _reported_request_order,
-            &Client::_message_requests,
-            &Client::_message_request_order,
-            &callbacks::request_list_replaced,
-            &callbacks::request_order_updated);
-}
 
 std::optional<AnyConversation> Client::_conversation(const ConversationId& id) {
     auto c = core.database().conn();
@@ -2447,18 +2332,34 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
     contacts.set(*entry);
 }
 
+void Client::_report_list(
+        bool changed,
+        std::vector<AnyConversation> (Client::*rows)(),
+        std::function<void(std::vector<AnyConversation>&&)> callbacks::* replaced) {
+    // Before the query, not after: reading a list to hand it to nobody is the whole cost of the
+    // operation, and a client with no requests screen has no use for the request list.
+    if (!changed || !((*_cbs).*replaced))
+        return;
+
+    _emit([list = (this->*rows)(), replaced](const callbacks& cbs) mutable {
+        (cbs.*replaced)(std::move(list));
+    });
+}
+
+void Client::_report_lists(bool convos_changed, bool requests_changed) {
+    _report_list(convos_changed, &Client::_conversations, &callbacks::conversation_list_replaced);
+    _report_list(requests_changed, &Client::_message_requests, &callbacks::request_list_replaced);
+}
+
 // Both lists, always, and deliberately not one or the other: what moves a conversation between them
 // is approval, what removes it from either is hiding or deletion, and a caller that had to work out
 // which of those it just did would eventually get it wrong.  A replacement is idempotent, so the
 // cost of sending one nobody needed is a query.
 void Client::_report_lists_replaced(bool convos, bool requests) {
-    // Both lists, wholly: a row appeared, went, or changed where it sorts.  The subscriber is told
-    // through whichever handler it registered, and that is the point of routing this through the
-    // same path as a moved row rather than sending replacements outright -- a replacement carries
-    // the order, so a subscriber holding only `conversation_order_updated` was told nothing at all
-    // by the eight callers of this, and its arrangement stayed as it was until the next message
-    // happened to move something.
-    _report_lists(convos, convos, requests, requests);
+    // A row appeared, went, or moved to a new position.  Named for what the caller knows -- that a
+    // list is wholly different now -- rather than for the query, which is the one a changed row
+    // takes as well.
+    _report_lists(convos, requests);
 }
 
 // -- Config reconciliation ----------------------------------------------------------------------
@@ -3704,7 +3605,7 @@ int64_t Client::_send_message(const ConversationId& id, const OutgoingMessage& m
         _emit_conversation_added(id);
     _reveal_note_to_self(id);
     _emit_message(true, id, client_id);
-    _touch_reordered(id);
+    _touch(id);
 
     log::debug(cat, "send_message: message {} to conversation {}", client_id, id.to_string());
 
@@ -3898,7 +3799,7 @@ int64_t Client::_send_message(
         _emit_conversation_added(id);
     _reveal_note_to_self(id);
     _emit_message(true, id, client_id);
-    _touch_reordered(id);
+    _touch(id);
 
     log::debug(
             cat,
@@ -5298,7 +5199,7 @@ void Client::_on_message_received(core::ReceivedMessage&& msg) {
         _emit_message(true, convo_id, client_id);
     }
     if (inserted || renamed)
-        _touch_reordered(convo_id);
+        _touch(convo_id);
 
     // Approval moves a conversation between the two lists, so both changed and neither changed in a
     // way that naming one row would describe.

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -174,7 +174,6 @@ struct Recorder {
     std::vector<AnyConversation> added, updated;
     std::vector<ConversationId> removed;
     std::vector<std::vector<AnyConversation>> replaced, requests_replaced;
-    std::vector<std::vector<ConversationId>> reordered, requests_reordered;
     std::vector<std::pair<ConversationId, Message>> msg_added, msg_updated;
 
     callbacks handlers() {
@@ -204,16 +203,6 @@ struct Recorder {
                             order.push_back("requests");
                             requests_replaced.push_back(std::move(l));
                         },
-                .conversation_order_updated =
-                        [this](std::vector<ConversationId> ids) {
-                            order.push_back("reordered");
-                            reordered.push_back(std::move(ids));
-                        },
-                .request_order_updated =
-                        [this](std::vector<ConversationId> ids) {
-                            order.push_back("requests_reordered");
-                            requests_reordered.push_back(std::move(ids));
-                        },
                 .message_added =
                         [this](const ConversationId& id, Message&& m) {
                             order.push_back("message");
@@ -225,26 +214,6 @@ struct Recorder {
                             msg_updated.emplace_back(id, std::move(m));
                         },
         };
-    }
-
-    /// Which handlers a subscriber registers decides both what Client sends and which query it
-    /// runs to find out, so a test asserting either has to be able to say what it subscribed to.
-
-    /// Takes its ordering from the order events and never wants a whole list.
-    callbacks order_only() {
-        auto cbs = handlers();
-        cbs.conversation_list_replaced = nullptr;
-        cbs.request_list_replaced = nullptr;
-        return cbs;
-    }
-
-    /// Wants whole lists and does not handle order events -- an older subscriber, or one that would
-    /// rather re-read a list than track its order.
-    callbacks lists_only() {
-        auto cbs = handlers();
-        cbs.conversation_order_updated = nullptr;
-        cbs.request_order_updated = nullptr;
-        return cbs;
     }
 };
 

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -173,25 +173,32 @@ struct Recorder {
     std::vector<std::string> order;
     std::vector<AnyConversation> added, updated;
     std::vector<ConversationId> removed;
+    std::vector<ConversationList> removed_from;
     std::vector<std::vector<AnyConversation>> replaced, requests_replaced;
     std::vector<std::pair<ConversationId, Message>> msg_added, msg_updated;
+    /// Where each event said its row was and now belongs, kept apart so a test can say which
+    /// callback it means.
+    std::vector<ListPlacement> add_placements, placements;
 
     callbacks handlers() {
         return {
                 .conversation_added =
-                        [this](AnyConversation&& c) {
+                        [this](AnyConversation&& c, ListPlacement&& p) {
                             order.push_back("added");
                             added.push_back(std::move(c));
+                            add_placements.push_back(std::move(p));
                         },
                 .conversation_updated =
-                        [this](AnyConversation&& c) {
+                        [this](AnyConversation&& c, ListPlacement&& p) {
                             order.push_back("updated");
                             updated.push_back(std::move(c));
+                            placements.push_back(std::move(p));
                         },
                 .conversation_removed =
-                        [this](const ConversationId& id) {
+                        [this](ConversationId&& id, ConversationList from) {
                             order.push_back("removed");
-                            removed.push_back(id);
+                            removed.push_back(std::move(id));
+                            removed_from.push_back(from);
                         },
                 .conversation_list_replaced =
                         [this](std::vector<AnyConversation>&& l) {

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -174,6 +174,7 @@ struct Recorder {
     std::vector<AnyConversation> added, updated;
     std::vector<ConversationId> removed;
     std::vector<std::vector<AnyConversation>> replaced, requests_replaced;
+    std::vector<std::vector<ConversationId>> reordered, requests_reordered;
     std::vector<std::pair<ConversationId, Message>> msg_added, msg_updated;
 
     callbacks handlers() {
@@ -202,6 +203,16 @@ struct Recorder {
                         [this](std::vector<AnyConversation>&& l) {
                             order.push_back("requests");
                             requests_replaced.push_back(std::move(l));
+                        },
+                .conversation_order_updated =
+                        [this](std::vector<ConversationId> ids) {
+                            order.push_back("reordered");
+                            reordered.push_back(std::move(ids));
+                        },
+                .request_order_updated =
+                        [this](std::vector<ConversationId> ids) {
+                            order.push_back("requests_reordered");
+                            requests_reordered.push_back(std::move(ids));
                         },
                 .message_added =
                         [this](const ConversationId& id, Message&& m) {

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -226,6 +226,26 @@ struct Recorder {
                         },
         };
     }
+
+    /// Which handlers a subscriber registers decides both what Client sends and which query it
+    /// runs to find out, so a test asserting either has to be able to say what it subscribed to.
+
+    /// Takes its ordering from the order events and never wants a whole list.
+    callbacks order_only() {
+        auto cbs = handlers();
+        cbs.conversation_list_replaced = nullptr;
+        cbs.request_list_replaced = nullptr;
+        return cbs;
+    }
+
+    /// Wants whole lists and does not handle order events -- an older subscriber, or one that would
+    /// rather re-read a list than track its order.
+    callbacks lists_only() {
+        auto cbs = handlers();
+        cbs.conversation_order_updated = nullptr;
+        cbs.request_order_updated = nullptr;
+        return cbs;
+    }
 };
 
 /// Waits for work Client deferred onto the loop -- the coalesced conversation_updated -- to have

--- a/tests/test_client/configs.cpp
+++ b/tests/test_client/configs.cpp
@@ -72,7 +72,9 @@ TEST_CASE("Client: re-deriving a contact changes nothing", "[client][configs]") 
 TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][configs]") {
     std::vector<ConversationId> gone;
     callbacks cbs;
-    cbs.conversation_removed = [&](const ConversationId& id) { gone.push_back(id); };
+    cbs.conversation_removed = [&](ConversationId&& id, ConversationList) {
+        gone.push_back(std::move(id));
+    };
     TempClient c{cbs};
 
     auto them = "05" + std::string(64, 'c');
@@ -395,7 +397,9 @@ TEST_CASE("Client: hiding note to self keeps what is in it", "[client][configs]"
 TEST_CASE("Client: deleting a contact takes the entry that held the block", "[client][configs]") {
     std::vector<ConversationId> gone;
     callbacks cbs;
-    cbs.conversation_removed = [&](const ConversationId& id) { gone.push_back(id); };
+    cbs.conversation_removed = [&](ConversationId&& id, ConversationList) {
+        gone.push_back(std::move(id));
+    };
     TempClient c{cbs};
 
     auto them = "05" + std::string(64, '4');

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -238,6 +238,33 @@ TEST_CASE("Client: a replacement is sent even when nothing moved", "[client][sig
     CHECK(r.replaced[0][0].last_message() == "pong");
 }
 
+TEST_CASE("Client: a change that moves nothing still replaces the list", "[client][signals]") {
+    SenderKeys sender;
+    Recorder r;
+    TempClient c{r.lists_only()};
+    approve(*c, sender.session_id);
+    auto id = ConversationId::dm(sender.session_id);
+
+    deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
+    sync(*c);
+    REQUIRE(r.replaced.size() >= 1);
+    CHECK(r.replaced.back()[0].unread() == 1);
+    r.order.clear();
+    r.replaced.clear();
+
+    // Reading the conversation changes `unread_count` and moves nothing, so it never reaches
+    // `_touch_reordered`.  For this subscriber the list is the only thing carrying the count, so
+    // driving the replacement off what *moved* rather than off what *changed* would leave it
+    // showing an unread conversation the user has just read.
+    c->conversation(id, wait)->mark_read(wait);
+    sync(*c);
+
+    REQUIRE(r.replaced.size() == 1);
+    REQUIRE(r.replaced[0].size() == 1);
+    CHECK(r.replaced[0][0].unread() == 0);
+    CHECK(r.reordered.empty());
+}
+
 TEST_CASE("Client: a subscriber wanting both is sent both", "[client][signals]") {
     SenderKeys a, b;
     Recorder r;

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -110,7 +110,16 @@ TEST_CASE("Client: the application is told what changed", "[client][signals]") {
     sync(*c);
 
     auto convo = ConversationId::dm(sender.session_id);
-    CHECK(r.order == std::vector<std::string>{"added", "message", "updated"});
+    // The order follows the row, because a message moves it: `last_activity` is what both lists
+    // are ordered by, so a subscriber told only that the row changed would not know it had moved.
+    //
+    // The request list and not the conversation list: an inbound message from someone we have not
+    // written to is a request, and the two lists are complements, so only one of them moved.  And
+    // the ids only -- the row itself has just been sent, in full, as `updated`.
+    CHECK(r.order == std::vector<std::string>{"added", "message", "updated", "requests_reordered"});
+    REQUIRE(r.requests_reordered.size() == 1);
+    CHECK(r.requests_reordered[0] == std::vector<ConversationId>{convo});
+    CHECK(r.reordered.empty());
 
     // Every handler is given the state itself, not something to go and look up.
     REQUIRE(r.added.size() == 1);
@@ -122,11 +131,59 @@ TEST_CASE("Client: the application is told what changed", "[client][signals]") {
     CHECK(preview_body(r.updated[0]) == "ping");
     CHECK(r.updated[0].unread() == 1);
 
-    // A second message on an existing conversation does not re-announce the conversation.
+    // A second message on an existing conversation does not re-announce the conversation, and does
+    // not report the order either: this row was already first in its list and still is, so there is
+    // nothing about its position to say.  The new snippet reaches the subscriber as `updated`.
+    //
+    // This is the case the order event exists to make cheap, and it is the common one -- a
+    // back-and-forth in an open conversation moves nothing.
     r.order.clear();
     deliver(*c, sender, "pong", from_epoch_ms(2000), "h2");
     sync(*c);
     CHECK(r.order == std::vector<std::string>{"message", "updated"});
+    CHECK(r.requests_reordered.size() == 1);
+    REQUIRE(r.updated.size() == 2);
+    CHECK(r.updated.back().last_message() == "pong");
+}
+
+TEST_CASE("Client: a message that moves a conversation reports the new order", "[client][signals]") {
+    SenderKeys a, b;
+    Recorder r;
+    TempClient c{r.handlers()};
+    approve(*c, a.session_id);
+    approve(*c, b.session_id);
+    auto ida = ConversationId::dm(a.session_id);
+    auto idb = ConversationId::dm(b.session_id);
+
+    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
+    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
+    sync(*c);
+
+    // b spoke most recently, so b leads.
+    r.order.clear();
+    r.reordered.clear();
+    r.updated.clear();
+
+    // A message to the conversation that was second moves it in front of the other one.  This is
+    // the case the event exists for: one row changed, and where every row sits changed with it.
+    deliver(*c, a, "third", from_epoch_ms(3000), "h3");
+    sync(*c);
+
+    CHECK(r.order == std::vector<std::string>{"message", "updated", "reordered"});
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] == std::vector{ida, idb});
+
+    // The conversation list and not the request list: both of these were approved before anything
+    // arrived, so the request list is empty and did not move.
+    CHECK(r.requests_reordered.empty());
+
+    // And the rows themselves are not re-sent.  The one that moved arrived as `updated`, carrying
+    // its new snippet; the one it moved past was not touched at all, and a replacement would have
+    // sent every field of it to say that something else had changed.
+    CHECK(r.replaced.empty());
+    REQUIRE(r.updated.size() == 1);
+    CHECK(r.updated[0].id() == ida);
+    CHECK(r.updated[0].last_message() == "third");
 }
 
 TEST_CASE(

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -261,6 +261,109 @@ TEST_CASE(
     CHECK(preview_body(r.updated[0]) == "m4");
 }
 
+TEST_CASE("Client: an update says where its row was and now belongs", "[client][signals]") {
+    SenderKeys a, b;
+    Recorder r;
+    TempClient c{r.handlers()};
+    approve(*c, a.session_id);
+    approve(*c, b.session_id);
+    auto ida = ConversationId::dm(a.session_id);
+    auto idb = ConversationId::dm(b.session_id);
+
+    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
+    sync(*c);
+
+    // The add already says where it goes: nothing to remove, into the conversation list, and
+    // nothing above it -- which an unset anchor is what says.
+    REQUIRE(r.add_placements.size() == 1);
+    CHECK(r.add_placements[0].from == ConversationList::none);
+    CHECK(r.add_placements[0].to == ConversationList::conversations);
+    CHECK_FALSE(r.add_placements[0].after.has_value());
+
+    // The update that follows it agrees, and now knows where the add put it.
+    REQUIRE(r.placements.size() == 1);
+    CHECK(r.placements[0].from == ConversationList::conversations);
+    CHECK(r.placements[0].to == ConversationList::conversations);
+
+    // Pinning a puts it above everything unpinned, so the next row to move sits after it rather
+    // than at the top -- which is the case an anchor exists to express and a bare "moved to front"
+    // could not.
+    c->conversation(ida, wait)->set_priority(3, wait);
+    r.placements.clear();
+
+    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
+    sync(*c);
+
+    REQUIRE(r.placements.size() == 1);
+    CHECK(r.placements[0].from == ConversationList::conversations);
+    CHECK(r.placements[0].to == ConversationList::conversations);
+    REQUIRE(r.placements[0].after.has_value());
+    CHECK(*r.placements[0].after == ida);
+    CHECK(r.updated.back().id() == idb);
+}
+
+TEST_CASE("Client: a hidden row is given no position", "[client][signals]") {
+    SenderKeys sender;
+    Recorder r;
+    TempClient c{r.handlers()};
+    approve(*c, sender.session_id);
+    auto id = ConversationId::dm(sender.session_id);
+
+    deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
+    sync(*c);
+    c->conversation(id, wait)->set_priority(-1, wait);
+    r.placements.clear();
+
+    // Hidden is in neither list, so there is no gap to name.  Unset here means "do not place
+    // this", not "place it first" -- which is why the two are different states.
+    deliver(*c, sender, "pong", from_epoch_ms(2000), "h2");
+    sync(*c);
+
+    // Taken out of where it was and not put back: `to == none` is what hiding looks like, and
+    // `from` still names the list it has to come out of.
+    REQUIRE(r.placements.size() == 1);
+    CHECK(r.placements[0].from == ConversationList::conversations);
+    CHECK(r.placements[0].to == ConversationList::none);
+}
+
+TEST_CASE("Client: a request is placed in the request list", "[client][signals]") {
+    SenderKeys stranger;
+    Recorder r;
+    TempClient c{r.handlers()};
+
+    // Nobody approved: a stranger's first message is a request, so the position names that list.
+    deliver(*c, stranger, "hello", from_epoch_ms(1000), "h1");
+    sync(*c);
+
+    // The add places it in the request list; nothing held it before.
+    REQUIRE(r.add_placements.size() == 1);
+    CHECK(r.add_placements[0].from == ConversationList::none);
+    CHECK(r.add_placements[0].to == ConversationList::requests);
+    CHECK_FALSE(r.add_placements[0].after.has_value());
+}
+
+TEST_CASE("Client: a removal says which list to take it out of", "[client][signals]") {
+    SenderKeys sender;
+    Recorder r;
+    TempClient c{r.handlers()};
+    approve(*c, sender.session_id);
+    auto id = ConversationId::dm(sender.session_id);
+
+    deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
+    sync(*c);
+    r.order.clear();
+
+    // Deleting the contact removes the conversation row outright.  The list it was in has to come
+    // from what the subscriber was last told, not from the database -- by the time this is
+    // reported the row is already gone, so there is nothing left to look it up from.
+    c->dm(id, wait)->delete_contact(wait);
+
+    REQUIRE(r.removed.size() == 1);
+    CHECK(r.removed[0] == id);
+    REQUIRE(r.removed_from.size() == 1);
+    CHECK(r.removed_from[0] == ConversationList::conversations);
+}
+
 TEST_CASE("Client: state is committed before the handler fires", "[client][signals]") {
     SenderKeys sender;
     std::optional<std::string> body_seen_from_handler;

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -466,13 +466,12 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(3, wait);
 
     // Reported as a replacement, not as an update to the one conversation whose priority changed:
-    // what moved is the list.  Both lists are replaced together, because hiding takes a
-    // conversation out of whichever one it was in and the caller does not have to work out which.
+    // what moved is the list.  And the order alongside it, for this subscriber holding both
+    // handlers: pinning moved every row that was above the pinned one.
     //
-    // And the order alongside it, for this subscriber holding both handlers: pinning moved every
-    // row that was above the pinned one.  The request list is replaced but reports no order, since
-    // it was empty before this and still is.
-    CHECK(r.order == std::vector<std::string>{"replaced", "reordered", "requests"});
+    // The conversation list only.  Priority moves a row within the list it is in and never between
+    // the two, so the request list did not change and is not read.
+    CHECK(r.order == std::vector<std::string>{"replaced", "reordered"});
     REQUIRE(r.reordered.size() == 1);
     CHECK(r.reordered[0] ==
           std::vector{ConversationId::dm(a.session_id), ConversationId::dm(b.session_id)});
@@ -486,7 +485,7 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     r.replaced.clear();
     r.reordered.clear();
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
-    CHECK(r.order == std::vector<std::string>{"replaced", "reordered", "requests"});
+    CHECK(r.order == std::vector<std::string>{"replaced", "reordered"});
     REQUIRE(r.reordered.size() == 1);
     CHECK(r.reordered[0] == std::vector{ConversationId::dm(b.session_id)});
     REQUIRE(r.replaced.size() == 1);

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -104,7 +104,9 @@ TEST_CASE("Client: an in-flight send becomes interrupted after a restart", "[cli
 TEST_CASE("Client: the application is told what changed", "[client][signals]") {
     SenderKeys sender;
     Recorder r;
-    TempClient c{r.handlers()};
+    // Order events and no whole lists, which is what makes the assertions below about rows *not*
+    // being re-sent assertions about Client rather than about this subscriber's luck.
+    TempClient c{r.order_only()};
 
     deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
     sync(*c);
@@ -149,7 +151,7 @@ TEST_CASE("Client: the application is told what changed", "[client][signals]") {
 TEST_CASE("Client: a message that moves a conversation reports the new order", "[client][signals]") {
     SenderKeys a, b;
     Recorder r;
-    TempClient c{r.handlers()};
+    TempClient c{r.order_only()};
     approve(*c, a.session_id);
     approve(*c, b.session_id);
     auto ida = ConversationId::dm(a.session_id);
@@ -184,6 +186,87 @@ TEST_CASE("Client: a message that moves a conversation reports the new order", "
     REQUIRE(r.updated.size() == 1);
     CHECK(r.updated[0].id() == ida);
     CHECK(r.updated[0].last_message() == "third");
+}
+
+TEST_CASE("Client: a subscriber that wants lists is sent them", "[client][signals]") {
+    SenderKeys a, b;
+    Recorder r;
+    // No order handlers, so the order events have nowhere to go and a whole list is the only way
+    // this subscriber can learn that one row now sits in front of another.
+    TempClient c{r.lists_only()};
+    approve(*c, a.session_id);
+    approve(*c, b.session_id);
+    auto ida = ConversationId::dm(a.session_id);
+    auto idb = ConversationId::dm(b.session_id);
+
+    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
+    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
+    sync(*c);
+    r.order.clear();
+    r.replaced.clear();
+
+    deliver(*c, a, "third", from_epoch_ms(3000), "h3");
+    sync(*c);
+
+    CHECK(r.order == std::vector<std::string>{"message", "updated", "replaced"});
+    REQUIRE(r.replaced.size() == 1);
+    REQUIRE(r.replaced[0].size() == 2);
+    CHECK(r.replaced[0][0].id() == ida);
+    CHECK(r.replaced[0][1].id() == idb);
+    CHECK(r.reordered.empty());
+}
+
+TEST_CASE("Client: a replacement is sent even when nothing moved", "[client][signals]") {
+    SenderKeys sender;
+    Recorder r;
+    TempClient c{r.lists_only()};
+    approve(*c, sender.session_id);
+
+    deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
+    sync(*c);
+    r.order.clear();
+    r.replaced.clear();
+
+    // A second message to the only conversation moves nothing, so an order event would be
+    // suppressed -- but the snippet changed, and for this subscriber the list is the only thing
+    // carrying it.  Suppressing the list on an unchanged order would leave it showing "ping".
+    deliver(*c, sender, "pong", from_epoch_ms(2000), "h2");
+    sync(*c);
+
+    REQUIRE(r.replaced.size() == 1);
+    REQUIRE(r.replaced[0].size() == 1);
+    CHECK(r.replaced[0][0].last_message() == "pong");
+}
+
+TEST_CASE("Client: a subscriber wanting both is sent both", "[client][signals]") {
+    SenderKeys a, b;
+    Recorder r;
+    TempClient c{r.handlers()};
+    approve(*c, a.session_id);
+    approve(*c, b.session_id);
+    auto ida = ConversationId::dm(a.session_id);
+    auto idb = ConversationId::dm(b.session_id);
+
+    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
+    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
+    sync(*c);
+    r.order.clear();
+    r.replaced.clear();
+    r.reordered.clear();
+
+    deliver(*c, a, "third", from_epoch_ms(3000), "h3");
+    sync(*c);
+
+    // Redundant, and the subscriber's own choice to be: registering both says it wants the rows
+    // and the order, and the order it is told is the order of the rows it was just handed.
+    CHECK(r.order == std::vector<std::string>{"message", "updated", "replaced", "reordered"});
+    REQUIRE(r.replaced.size() == 1);
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] == std::vector{ida, idb});
+    std::vector<ConversationId> from_rows;
+    for (const auto& convo : r.replaced[0])
+        from_rows.push_back(convo.id());
+    CHECK(from_rows == r.reordered[0]);
 }
 
 TEST_CASE(

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -468,7 +468,14 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     // Reported as a replacement, not as an update to the one conversation whose priority changed:
     // what moved is the list.  Both lists are replaced together, because hiding takes a
     // conversation out of whichever one it was in and the caller does not have to work out which.
-    CHECK(r.order == std::vector<std::string>{"replaced", "requests"});
+    //
+    // And the order alongside it, for this subscriber holding both handlers: pinning moved every
+    // row that was above the pinned one.  The request list is replaced but reports no order, since
+    // it was empty before this and still is.
+    CHECK(r.order == std::vector<std::string>{"replaced", "reordered", "requests"});
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] ==
+          std::vector{ConversationId::dm(a.session_id), ConversationId::dm(b.session_id)});
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 2);
     CHECK(r.replaced[0][0].id() == ConversationId::dm(a.session_id));
@@ -477,8 +484,11 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     // Hiding removes it from the replacement list, which is how a subscriber learns it is gone.
     r.order.clear();
     r.replaced.clear();
+    r.reordered.clear();
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
-    CHECK(r.order == std::vector<std::string>{"replaced", "requests"});
+    CHECK(r.order == std::vector<std::string>{"replaced", "reordered", "requests"});
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] == std::vector{ConversationId::dm(b.session_id)});
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 1);
     CHECK(r.replaced[0][0].id() == ConversationId::dm(b.session_id));
@@ -487,6 +497,43 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     r.order.clear();
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
     CHECK(r.order.empty());
+}
+
+TEST_CASE("Client: a pin reaches a subscriber that only wants the order", "[client][signals]") {
+    SenderKeys a, b;
+    Recorder r;
+    // No list handlers, so a replacement has nowhere to go.  Pinning changes where every row above
+    // the pinned one sits, and the eight callers that report a wholesale list change used to send
+    // replacements outright -- which said nothing at all to this subscriber, leaving it arranged as
+    // it was until some later message happened to move something.
+    TempClient c{r.order_only()};
+    approve(*c, a.session_id);
+    approve(*c, b.session_id);
+    auto ida = ConversationId::dm(a.session_id);
+    auto idb = ConversationId::dm(b.session_id);
+
+    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
+    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
+    sync(*c);
+    // b spoke last, so b leads.
+    r.order.clear();
+    r.reordered.clear();
+
+    c->conversation(ida, wait)->set_priority(3, wait);
+
+    CHECK(r.order == std::vector<std::string>{"reordered"});
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] == std::vector{ida, idb});
+    CHECK(r.replaced.empty());
+
+    // Hiding it takes it out of the list, which this subscriber learns the same way.
+    r.order.clear();
+    r.reordered.clear();
+    c->conversation(ida, wait)->set_priority(-1, wait);
+
+    CHECK(r.order == std::vector<std::string>{"reordered"});
+    REQUIRE(r.reordered.size() == 1);
+    CHECK(r.reordered[0] == std::vector{idb});
 }
 
 TEST_CASE("Client: the two copies of a send report separately", "[client][send]") {

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -104,24 +104,18 @@ TEST_CASE("Client: an in-flight send becomes interrupted after a restart", "[cli
 TEST_CASE("Client: the application is told what changed", "[client][signals]") {
     SenderKeys sender;
     Recorder r;
-    // Order events and no whole lists, which is what makes the assertions below about rows *not*
-    // being re-sent assertions about Client rather than about this subscriber's luck.
-    TempClient c{r.order_only()};
+    TempClient c{r.handlers()};
 
     deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
     sync(*c);
 
     auto convo = ConversationId::dm(sender.session_id);
-    // The order follows the row, because a message moves it: `last_activity` is what both lists
-    // are ordered by, so a subscriber told only that the row changed would not know it had moved.
-    //
     // The request list and not the conversation list: an inbound message from someone we have not
-    // written to is a request, and the two lists are complements, so only one of them moved.  And
-    // the ids only -- the row itself has just been sent, in full, as `updated`.
-    CHECK(r.order == std::vector<std::string>{"added", "message", "updated", "requests_reordered"});
-    REQUIRE(r.requests_reordered.size() == 1);
-    CHECK(r.requests_reordered[0] == std::vector<ConversationId>{convo});
-    CHECK(r.reordered.empty());
+    // written to is a request, and the two lists are complements, so only the one it sits in is
+    // stale.  A conversation-list replacement here would say something false about the other.
+    CHECK(r.order == std::vector<std::string>{"added", "message", "updated", "requests"});
+    REQUIRE(r.requests_replaced.size() == 1);
+    CHECK(r.replaced.empty());
 
     // Every handler is given the state itself, not something to go and look up.
     REQUIRE(r.added.size() == 1);
@@ -133,59 +127,17 @@ TEST_CASE("Client: the application is told what changed", "[client][signals]") {
     CHECK(preview_body(r.updated[0]) == "ping");
     CHECK(r.updated[0].unread() == 1);
 
-    // A second message on an existing conversation does not re-announce the conversation, and does
-    // not report the order either: this row was already first in its list and still is, so there is
-    // nothing about its position to say.  The new snippet reaches the subscriber as `updated`.
-    //
-    // This is the case the order event exists to make cheap, and it is the common one -- a
-    // back-and-forth in an open conversation moves nothing.
+    // A second message on an existing conversation does not re-announce the conversation, but the
+    // list is stale again -- the row's snippet changed, and the list is what carries it for a
+    // subscriber that holds no per-row handler.
     r.order.clear();
+    r.requests_replaced.clear();
     deliver(*c, sender, "pong", from_epoch_ms(2000), "h2");
     sync(*c);
-    CHECK(r.order == std::vector<std::string>{"message", "updated"});
-    CHECK(r.requests_reordered.size() == 1);
+    CHECK(r.order == std::vector<std::string>{"message", "updated", "requests"});
+    CHECK(r.requests_replaced.size() == 1);
     REQUIRE(r.updated.size() == 2);
-    CHECK(r.updated.back().last_message() == "pong");
-}
-
-TEST_CASE("Client: a message that moves a conversation reports the new order", "[client][signals]") {
-    SenderKeys a, b;
-    Recorder r;
-    TempClient c{r.order_only()};
-    approve(*c, a.session_id);
-    approve(*c, b.session_id);
-    auto ida = ConversationId::dm(a.session_id);
-    auto idb = ConversationId::dm(b.session_id);
-
-    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
-    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
-    sync(*c);
-
-    // b spoke most recently, so b leads.
-    r.order.clear();
-    r.reordered.clear();
-    r.updated.clear();
-
-    // A message to the conversation that was second moves it in front of the other one.  This is
-    // the case the event exists for: one row changed, and where every row sits changed with it.
-    deliver(*c, a, "third", from_epoch_ms(3000), "h3");
-    sync(*c);
-
-    CHECK(r.order == std::vector<std::string>{"message", "updated", "reordered"});
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] == std::vector{ida, idb});
-
-    // The conversation list and not the request list: both of these were approved before anything
-    // arrived, so the request list is empty and did not move.
-    CHECK(r.requests_reordered.empty());
-
-    // And the rows themselves are not re-sent.  The one that moved arrived as `updated`, carrying
-    // its new snippet; the one it moved past was not touched at all, and a replacement would have
-    // sent every field of it to say that something else had changed.
-    CHECK(r.replaced.empty());
-    REQUIRE(r.updated.size() == 1);
-    CHECK(r.updated[0].id() == ida);
-    CHECK(r.updated[0].last_message() == "third");
+    CHECK(preview_body(r.updated.back()) == "pong");
 }
 
 TEST_CASE("Client: a subscriber that wants lists is sent them", "[client][signals]") {
@@ -193,7 +145,7 @@ TEST_CASE("Client: a subscriber that wants lists is sent them", "[client][signal
     Recorder r;
     // No order handlers, so the order events have nowhere to go and a whole list is the only way
     // this subscriber can learn that one row now sits in front of another.
-    TempClient c{r.lists_only()};
+    TempClient c{r.handlers()};
     approve(*c, a.session_id);
     approve(*c, b.session_id);
     auto ida = ConversationId::dm(a.session_id);
@@ -213,13 +165,12 @@ TEST_CASE("Client: a subscriber that wants lists is sent them", "[client][signal
     REQUIRE(r.replaced[0].size() == 2);
     CHECK(r.replaced[0][0].id() == ida);
     CHECK(r.replaced[0][1].id() == idb);
-    CHECK(r.reordered.empty());
 }
 
 TEST_CASE("Client: a replacement is sent even when nothing moved", "[client][signals]") {
     SenderKeys sender;
     Recorder r;
-    TempClient c{r.lists_only()};
+    TempClient c{r.handlers()};
     approve(*c, sender.session_id);
 
     deliver(*c, sender, "ping", from_epoch_ms(1000), "h1");
@@ -235,13 +186,13 @@ TEST_CASE("Client: a replacement is sent even when nothing moved", "[client][sig
 
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 1);
-    CHECK(r.replaced[0][0].last_message() == "pong");
+    CHECK(preview_body(r.replaced[0][0]) == "pong");
 }
 
 TEST_CASE("Client: a change that moves nothing still replaces the list", "[client][signals]") {
     SenderKeys sender;
     Recorder r;
-    TempClient c{r.lists_only()};
+    TempClient c{r.handlers()};
     approve(*c, sender.session_id);
     auto id = ConversationId::dm(sender.session_id);
 
@@ -253,7 +204,7 @@ TEST_CASE("Client: a change that moves nothing still replaces the list", "[clien
     r.replaced.clear();
 
     // Reading the conversation changes `unread_count` and moves nothing, so it never reaches
-    // `_touch_reordered`.  For this subscriber the list is the only thing carrying the count, so
+    // `_dirty_order`.  For this subscriber the list is the only thing carrying the count, so
     // driving the replacement off what *moved* rather than off what *changed* would leave it
     // showing an unread conversation the user has just read.
     c->conversation(id, wait)->mark_read(wait);
@@ -262,38 +213,6 @@ TEST_CASE("Client: a change that moves nothing still replaces the list", "[clien
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 1);
     CHECK(r.replaced[0][0].unread() == 0);
-    CHECK(r.reordered.empty());
-}
-
-TEST_CASE("Client: a subscriber wanting both is sent both", "[client][signals]") {
-    SenderKeys a, b;
-    Recorder r;
-    TempClient c{r.handlers()};
-    approve(*c, a.session_id);
-    approve(*c, b.session_id);
-    auto ida = ConversationId::dm(a.session_id);
-    auto idb = ConversationId::dm(b.session_id);
-
-    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
-    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
-    sync(*c);
-    r.order.clear();
-    r.replaced.clear();
-    r.reordered.clear();
-
-    deliver(*c, a, "third", from_epoch_ms(3000), "h3");
-    sync(*c);
-
-    // Redundant, and the subscriber's own choice to be: registering both says it wants the rows
-    // and the order, and the order it is told is the order of the rows it was just handed.
-    CHECK(r.order == std::vector<std::string>{"message", "updated", "replaced", "reordered"});
-    REQUIRE(r.replaced.size() == 1);
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] == std::vector{ida, idb});
-    std::vector<ConversationId> from_rows;
-    for (const auto& convo : r.replaced[0])
-        from_rows.push_back(convo.id());
-    CHECK(from_rows == r.reordered[0]);
 }
 
 TEST_CASE(
@@ -471,10 +390,7 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     //
     // The conversation list only.  Priority moves a row within the list it is in and never between
     // the two, so the request list did not change and is not read.
-    CHECK(r.order == std::vector<std::string>{"replaced", "reordered"});
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] ==
-          std::vector{ConversationId::dm(a.session_id), ConversationId::dm(b.session_id)});
+    CHECK(r.order == std::vector<std::string>{"replaced"});
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 2);
     CHECK(r.replaced[0][0].id() == ConversationId::dm(a.session_id));
@@ -483,11 +399,8 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     // Hiding removes it from the replacement list, which is how a subscriber learns it is gone.
     r.order.clear();
     r.replaced.clear();
-    r.reordered.clear();
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
-    CHECK(r.order == std::vector<std::string>{"replaced", "reordered"});
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] == std::vector{ConversationId::dm(b.session_id)});
+    CHECK(r.order == std::vector<std::string>{"replaced"});
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 1);
     CHECK(r.replaced[0][0].id() == ConversationId::dm(b.session_id));
@@ -496,43 +409,6 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     r.order.clear();
     c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
     CHECK(r.order.empty());
-}
-
-TEST_CASE("Client: a pin reaches a subscriber that only wants the order", "[client][signals]") {
-    SenderKeys a, b;
-    Recorder r;
-    // No list handlers, so a replacement has nowhere to go.  Pinning changes where every row above
-    // the pinned one sits, and the eight callers that report a wholesale list change used to send
-    // replacements outright -- which said nothing at all to this subscriber, leaving it arranged as
-    // it was until some later message happened to move something.
-    TempClient c{r.order_only()};
-    approve(*c, a.session_id);
-    approve(*c, b.session_id);
-    auto ida = ConversationId::dm(a.session_id);
-    auto idb = ConversationId::dm(b.session_id);
-
-    deliver(*c, a, "first", from_epoch_ms(1000), "h1");
-    deliver(*c, b, "second", from_epoch_ms(2000), "h2");
-    sync(*c);
-    // b spoke last, so b leads.
-    r.order.clear();
-    r.reordered.clear();
-
-    c->conversation(ida, wait)->set_priority(3, wait);
-
-    CHECK(r.order == std::vector<std::string>{"reordered"});
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] == std::vector{ida, idb});
-    CHECK(r.replaced.empty());
-
-    // Hiding it takes it out of the list, which this subscriber learns the same way.
-    r.order.clear();
-    r.reordered.clear();
-    c->conversation(ida, wait)->set_priority(-1, wait);
-
-    CHECK(r.order == std::vector<std::string>{"reordered"});
-    REQUIRE(r.reordered.size() == 1);
-    CHECK(r.reordered[0] == std::vector{idb});
 }
 
 TEST_CASE("Client: the two copies of a send report separately", "[client][send]") {


### PR DESCRIPTION
## The problem

A conversation's place in either list is decided by `last_activity` and `priority`. Storing a message
moves the first, and `_flush_pending` emitted `conversation_updated` for the row and stopped there —
so a subscriber was told the row had **changed** and never that it had **moved**.

Working the new position out on the other side of the callback means reimplementing this sort, and
the two lists are not sorted the same way — conversations are `priority DESC, last_activity DESC, id`
and requests are `last_activity DESC, id` with no priority term at all. A client that copies one
comparator gets the other list wrong. (Session's client had exactly that bug, and removing its
client-side sort is what surfaced this.)

## What this does

The three events that change a list now say where the row belongs:

```cpp
enum class ConversationList { none, conversations, requests };

struct ListPlacement {
    ConversationList from = ConversationList::none;   // where the subscriber is holding it
    ConversationList to   = ConversationList::none;   // where it belongs now
    std::optional<ConversationId> after;              // the row it follows; unset means first
};

std::function<void(AnyConversation&&, ListPlacement&&)>  conversation_added;
std::function<void(AnyConversation&&, ListPlacement&&)>  conversation_updated;
std::function<void(ConversationId&&, ConversationList)>  conversation_removed;
```

Enough to apply without consulting anything, and it reads as the two steps it is:

```cpp
if (p.from != ConversationList::none) remove(p.from, convo.id());
if (p.to   != ConversationList::none) insert(p.to, std::move(convo), p.after);
```

`none` is a real answer rather than a missing one: a hidden conversation is in neither list, and so
is one the subscriber has not been shown. A removal carries only the list, because the other two
fields would always be empty there.

## Why an anchor rather than the whole order

An earlier revision of this branch sent the whole ordered list of ids as its own event. Review asked
for an anchor on `conversation_updated` instead, and the measurements agree — per event, at five
thousand conversations:

| what it takes to produce | cost |
| --- | ---: |
| the rows (a full replacement) | 4.85 ms |
| the ordered ids | 1.85 ms |
| **one anchor** (an indexed seek on `conversations_order`) | **0.11 ms** |

That revision is still in this branch's history and removed in its own commit, so the logic is
recoverable if the anchor turns out not to cover a case.

## Why ids rather than indices

An index would be cheaper for a client to apply — measured in Node, applying one move at five
thousand conversations is **0.0007 ms** by index against **0.049 ms** by id. Three reasons it is
still the wrong trade:

- **It moves cost onto the wrong loop.** Producing an index is "count everything that sorts before
  this": **0.87 ms** at five thousand, against 0.11 ms for an anchor. So it saves ~0.05 ms on the
  client to spend ~0.75 ms here, on the loop that also polls and decrypts.
- **It fails silently.** A stale index splices out whatever happens to sit at that position. An
  unmatched id returns "not found", which a subscriber can act on.
- **It needs the whole ordered list to produce**, which is the thing this change exists to avoid.

For scale, decoding and projecting five thousand rows was measured at **12.67 ms on an iPhone X**, so
applying by id is still an order of magnitude cheaper than being handed the list.

## `from` is what the subscriber was told, not what the database says

`from` is read from a record of where each conversation was last *reported*, which is what the
subscriber is actually holding. That matters when a row changes lists twice between flushes: the
database would answer about the last hop, and the subscriber is still holding it from before the
first.

It is recorded wherever a row is reported placed — including by a whole-list replacement, which
places every row it carries — and dropped when a row is hidden or removed. Keyed by `ConversationId`
rather than row id, because a removal is reported *after* the row is deleted, so there would be
nothing left to look a row id up from.

## List replacements, while they are here

The replacement handlers were doing two things wrong, both found in review:

- **They read for handlers that were not there.** Both list queries ran before `_emit` looked at
  whether anyone was listening. Now nothing is read for a handler that is not registered — the same
  guard is on `_emit_conversation_added` and `_emit_message_alone`.
- **They named both lists whatever had happened.** Pinning a conversation re-read every message
  request as well. Each caller now names the list it touched: pin and hide read the row's list with
  one indexed query, the contacts reconcile already tracked the two separately, and the user-profile
  reconcile is note to self, which cannot be a request. Approval and losing a contact still name
  both, because those genuinely move a row from one list to the other.

A replacement is **not** suppressed when the order is unchanged. The order is not what it carries:
the row whose arrival brought us here has a new snippet, and for a subscriber holding no per-row
handler the list is the only thing carrying it.

## What this asks of a subscriber, and a question for review

Each placement is relative to another row, so **applying them in order is what keeps a list
correct** — one applied out of order, or skipped, leaves the list wrong with nothing to detect it.
A subscriber also has to have read the list once with `conversations()` to have anything to place
rows into.

That is a stronger contract than "each handler is independently meaningful", and review has said
elsewhere that few handlers are strictly required. **Worth settling explicitly**: if a subscriber may
register `conversation_updated` without ever reading the list, an anchor naming a row it was never
told about is unresolvable, and the design needs a fallback. The handler docs currently state the
sequence contract, which is the assumption the code makes.

## Testing

- `an update says where its row was and now belongs` — pins a conversation first, so the next row to
  move must land *after* the pinned one rather than at the top. Without the pin every case passes
  trivially, since a new message always leads.
- `a hidden row is given no position` — `to == none`, and `from` still names the list to take it out
  of.
- `a request is placed in the request list`.
- `a removal says which list to take it out of` — deletes a contact, which removes the row before the
  removal is reported, so it exercises the case a database lookup could not answer.
- Plus the existing `[client][signals]` cases, updated for the new shape.

**Anchors were checked against real data rather than only asserted**: for a thousand conversations
and three hundred requests, every anchor is the row immediately before it in that list's ordering,
and a leading row reports none.

⚠️ **The test suite has not been run locally.** `testAll` does not compile on macOS for a
pre-existing reason unrelated to this change: `session::client::wait` (`client/handler.hpp`) collides
with POSIX `wait()` from `<sys/wait.h>`, so every `tests/test_client` file that calls `wait` fails
with `error: reference to 'wait' is ambiguous`. Compiling each affected object with
`-ferror-limit=0` puts every error in that category or cascading from it, and none in the code this
branch adds. The library itself compiles and links clean. **So the tests here rely on CI.**
