### PR TITLE
Give a change handler its payload by value

### DIFF
--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -27,10 +27,11 @@ namespace session::client {
 ///
 /// **Handlers run on Core's event loop**, not the caller's thread.  A handler must not block and
 /// must not throw (an escaping exception is caught and logged, and the change is not redelivered).
-/// The conversation or message a handler receives is its own: it was read for this delivery and
-/// nothing else holds it, so a UI moves it into its own queue and wakes its render thread.  The
-/// signatures say which is which — what is given is taken by rvalue reference, and the ids are
-/// borrowed.
+/// What a handler receives is its own: it was read for this delivery and nothing else holds it, so
+/// a UI moves it into its own queue and wakes its render thread.  The signatures say which is
+/// which — what is given is taken by rvalue reference, what is lent by `const&`.  The two progress
+/// handlers are the ones that lend, because they report repeatedly against one captured id and a
+/// handler that moved from it would empty what the next report needs.
 ///
 /// A handler may declare such a parameter as `T&&`, `const T&` or `T`, whichever suits it: only the
 /// last constructs anything, and a handler that just reads pays nothing.  (`T&` is the one form that
@@ -51,7 +52,7 @@ struct callbacks {
     std::function<void(AnyConversation&&)> conversation_updated;
 
     /// A conversation is gone and should be dropped from the list.
-    std::function<void(const ConversationId&)> conversation_removed;
+    std::function<void(ConversationId&&)> conversation_removed;
 
     /// Priorities changed — a pin, unpin, hide or unhide — carrying the whole list in its new
     /// order.  A replacement rather than a description of what moved, because one config update
@@ -70,10 +71,10 @@ struct callbacks {
     std::function<void(std::vector<AnyConversation>&&)> request_list_replaced;
 
     /// A message was added, whether received or sent from here.
-    std::function<void(const ConversationId&, Message&&)> message_added;
+    std::function<void(ConversationId&&, Message&&)> message_added;
 
     /// An existing message changed — currently only its send state.
-    std::function<void(const ConversationId&, Message&&)> message_updated;
+    std::function<void(ConversationId&&, Message&&)> message_updated;
 
     /// Messages were deleted from a conversation, and anything displaying its history should read
     /// it again.
@@ -82,7 +83,7 @@ struct callbacks {
     /// themselves: a history is unbounded, and an application showing one page of it has no use for
     /// the rest.  What deletes messages is a delete-before instruction, which can take any number
     /// of them at once and is not otherwise describable as a sequence of removals.
-    std::function<void(const ConversationId&)> history_replaced;
+    std::function<void(ConversationId&&)> history_replaced;
 
     /// An attachment is being fetched that nobody asked for — see `Conversation::auto_download`.
     ///

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -27,20 +27,22 @@ namespace session::client {
 ///
 /// **Handlers run on Core's event loop**, not the caller's thread.  A handler must not block and
 /// must not throw (an escaping exception is caught and logged, and the change is not redelivered).
-/// A UI will typically copy the argument into its own queue and wake its render thread.
+/// The conversation or message a handler receives is its own: it was read for this delivery and
+/// nothing else holds it, so a UI moves it into its own queue and wakes its render thread. The
+/// ids are borrowed.
 ///
 /// The conversation list an application maintains from these is expected to be *complete*: ordering
 /// is a comparison against every other conversation, so a partial list cannot be sorted.  Showing
 /// only part of it is fine, holding only part of it is not.
 struct callbacks {
     /// A conversation now exists that did not before.
-    std::function<void(const AnyConversation&)> conversation_added;
+    std::function<void(AnyConversation)> conversation_added;
 
     /// A conversation's contents changed: a new or edited message, a name, an unread count, its
     /// last activity.  Fired once with the conversation's settled state rather than once per
     /// underlying change, so a poll that delivers fifty messages to one conversation fires this
     /// once.
-    std::function<void(const AnyConversation&)> conversation_updated;
+    std::function<void(AnyConversation)> conversation_updated;
 
     /// A conversation is gone and should be dropped from the list.
     std::function<void(const ConversationId&)> conversation_removed;
@@ -62,10 +64,10 @@ struct callbacks {
     std::function<void(std::vector<AnyConversation>)> request_list_replaced;
 
     /// A message was added, whether received or sent from here.
-    std::function<void(const ConversationId&, const Message&)> message_added;
+    std::function<void(const ConversationId&, Message)> message_added;
 
     /// An existing message changed — currently only its send state.
-    std::function<void(const ConversationId&, const Message&)> message_updated;
+    std::function<void(const ConversationId&, Message)> message_updated;
 
     /// Messages were deleted from a conversation, and anything displaying its history should read
     /// it again.

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -34,9 +34,10 @@ namespace session::client {
 /// handler that moved from it would empty what the next report needs.
 ///
 /// A handler may declare such a parameter as `T&&`, `const T&` or `T`, whichever suits it: only the
-/// last constructs anything, and a handler that just reads pays nothing.  (`T&` is the one form that
-/// will not bind.)  The `&&` is not perfect forwarding despite the spelling — `std::function` is not
-/// a template on its argument — it is a promise by the caller that the object is spent afterwards.
+/// last constructs anything, and a handler that just reads pays nothing.  (`T&` is the one form
+/// that will not bind.)  The `&&` is not perfect forwarding despite the spelling — `std::function`
+/// is not a template on its argument — it is a promise by the caller that the object is spent
+/// afterwards.
 ///
 /// The conversation list an application maintains from these is expected to be *complete*: ordering
 /// is a comparison against every other conversation, so a partial list cannot be sorted.  Showing

--- a/include/session/client/callbacks.hpp
+++ b/include/session/client/callbacks.hpp
@@ -28,21 +28,27 @@ namespace session::client {
 /// **Handlers run on Core's event loop**, not the caller's thread.  A handler must not block and
 /// must not throw (an escaping exception is caught and logged, and the change is not redelivered).
 /// The conversation or message a handler receives is its own: it was read for this delivery and
-/// nothing else holds it, so a UI moves it into its own queue and wakes its render thread. The
-/// ids are borrowed.
+/// nothing else holds it, so a UI moves it into its own queue and wakes its render thread.  The
+/// signatures say which is which — what is given is taken by rvalue reference, and the ids are
+/// borrowed.
+///
+/// A handler may declare such a parameter as `T&&`, `const T&` or `T`, whichever suits it: only the
+/// last constructs anything, and a handler that just reads pays nothing.  (`T&` is the one form that
+/// will not bind.)  The `&&` is not perfect forwarding despite the spelling — `std::function` is not
+/// a template on its argument — it is a promise by the caller that the object is spent afterwards.
 ///
 /// The conversation list an application maintains from these is expected to be *complete*: ordering
 /// is a comparison against every other conversation, so a partial list cannot be sorted.  Showing
 /// only part of it is fine, holding only part of it is not.
 struct callbacks {
     /// A conversation now exists that did not before.
-    std::function<void(AnyConversation)> conversation_added;
+    std::function<void(AnyConversation&&)> conversation_added;
 
     /// A conversation's contents changed: a new or edited message, a name, an unread count, its
     /// last activity.  Fired once with the conversation's settled state rather than once per
     /// underlying change, so a poll that delivers fifty messages to one conversation fires this
     /// once.
-    std::function<void(AnyConversation)> conversation_updated;
+    std::function<void(AnyConversation&&)> conversation_updated;
 
     /// A conversation is gone and should be dropped from the list.
     std::function<void(const ConversationId&)> conversation_removed;
@@ -52,7 +58,7 @@ struct callbacks {
     /// from another device can repin, reveal and hide arbitrarily many conversations at once, and
     /// because a replacement cannot leave the application subtly out of step the way a missed
     /// delta would.
-    std::function<void(std::vector<AnyConversation>)> conversation_list_replaced;
+    std::function<void(std::vector<AnyConversation>&&)> conversation_list_replaced;
 
     /// The message requests changed, carrying the whole list of them, for the same reasons and with
     /// the same guarantees as the above.
@@ -61,13 +67,13 @@ struct callbacks {
     /// both: it left the requests and joined the conversations.  `conversation_added` and the rest
     /// are shared between them — a request is a conversation in every respect except which list it
     /// belongs to — and `Conversation::request` is what says which one a given handler is about.
-    std::function<void(std::vector<AnyConversation>)> request_list_replaced;
+    std::function<void(std::vector<AnyConversation>&&)> request_list_replaced;
 
     /// A message was added, whether received or sent from here.
-    std::function<void(const ConversationId&, Message)> message_added;
+    std::function<void(const ConversationId&, Message&&)> message_added;
 
     /// An existing message changed — currently only its send state.
-    std::function<void(const ConversationId&, Message)> message_updated;
+    std::function<void(const ConversationId&, Message&&)> message_updated;
 
     /// Messages were deleted from a conversation, and anything displaying its history should read
     /// it again.

--- a/include/session/core/callbacks.hpp
+++ b/include/session/core/callbacks.hpp
@@ -70,6 +70,12 @@ enum class MessageSendStatus {
 
 /// Struct holding application callbacks to fire when libsession Core events happen to allow the
 /// Core object to fire into the application front-end.
+///
+/// The signatures say what a handler may keep.  A parameter taken by rvalue reference was read for
+/// this delivery and nothing else holds it, so a handler may move from it; one taken by `const&` or
+/// as a span is borrowed and valid only for the duration of the call.  A handler may declare an
+/// rvalue parameter as `T&&`, `const T&` or `T`, whichever suits it: only the last constructs
+/// anything, and a handler that just reads pays nothing.
 struct callbacks {
 
     /// Callback that is invoked when a device linking request is received for entry into the device
@@ -99,7 +105,7 @@ struct callbacks {
     ///   request.  The first 7 are the standard display; all 21 are available for the extended
     ///   view.  Formatting and joining is left to the caller.
     std::function<void(
-            int reqid, const device::Info& new_device, std::span<const std::string_view, 21> sas)>
+            int reqid, device::Info&& new_device, std::span<const std::string_view, 21> sas)>
             device_link_request;
 
     /// Callback that is invoked when a new device has been linked to the account.  If a batch
@@ -119,7 +125,7 @@ struct callbacks {
     ///   acceptance.  If there was no previous link request (such as when catching up on device
     ///   updates performed by other account devices) then the value will be 0.
     /// - new_device -- the metadata about the new device.
-    std::function<void(int reqid, const device::Info& new_device)> device_added;
+    std::function<void(int reqid, device::Info&& new_device)> device_added;
 
     /// Callback invoked when *this* device has been confirmed linked to the account by another
     /// device.
@@ -131,7 +137,7 @@ struct callbacks {
     ///
     /// Parameters:
     /// - removed_device -- the most recent info we have (locally) for the removed device.
-    std::function<void(const device::Info& removed_device)> device_removed;
+    std::function<void(device::Info&& removed_device)> device_removed;
 
     /// Callback invoked when *this* device has been confirmed removed from the account (typically
     /// from another device) from an incoming device group update.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -477,9 +477,10 @@ void Client::_emit_conversation_added(const ConversationId& id) {
     auto convo = _conversation(id);
     if (!convo)
         return;
-    _emit([convo = std::move(*convo)](const callbacks& cbs) {
+    // Mutable so the value moves out: each _emit job runs once, and the handler owns what it gets.
+    _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
         if (cbs.conversation_added)
-            cbs.conversation_added(convo);
+            cbs.conversation_added(std::move(convo));
     });
 }
 
@@ -501,10 +502,10 @@ void Client::_emit_message_alone(bool added, const ConversationId& id, int64_t m
     auto msg = _message(message_id);
     if (!msg)
         return;
-    _emit([added, id, msg = std::move(*msg)](const callbacks& cbs) {
+    _emit([added, id, msg = std::move(*msg)](const callbacks& cbs) mutable {
         const auto& h = added ? cbs.message_added : cbs.message_updated;
         if (h)
-            h(id, msg);
+            h(id, std::move(msg));
     });
 }
 
@@ -555,9 +556,9 @@ void Client::_flush_pending() {
         auto convo = _conversation(id);
         if (!convo)
             continue;
-        _emit([convo = std::move(*convo)](const callbacks& cbs) {
+        _emit([convo = std::move(*convo)](const callbacks& cbs) mutable {
             if (cbs.conversation_updated)
-                cbs.conversation_updated(convo);
+                cbs.conversation_updated(std::move(convo));
         });
     }
 }
@@ -2146,11 +2147,12 @@ void Client::_set_delete_before(const ConversationId& id, sys_ms before) {
 void Client::_emit_lists_replaced() {
     auto convos = _conversations();
     auto requests = _message_requests();
-    _emit([convos = std::move(convos), requests = std::move(requests)](const callbacks& cbs) {
+    _emit([convos = std::move(convos),
+           requests = std::move(requests)](const callbacks& cbs) mutable {
         if (cbs.conversation_list_replaced)
-            cbs.conversation_list_replaced(convos);
+            cbs.conversation_list_replaced(std::move(convos));
         if (cbs.request_list_replaced)
-            cbs.request_list_replaced(requests);
+            cbs.request_list_replaced(std::move(requests));
     });
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -485,16 +485,18 @@ void Client::_emit_conversation_added(const ConversationId& id) {
 }
 
 void Client::_emit_conversation_removed(const ConversationId& id) {
-    _emit([id](const callbacks& cbs) {
+    // `id = id` rather than `id`: a copy-capture of a const lvalue is itself const, which `mutable`
+    // does not undo, and the handler is given the id outright.
+    _emit([id = id](const callbacks& cbs) mutable {
         if (cbs.conversation_removed)
-            cbs.conversation_removed(id);
+            cbs.conversation_removed(std::move(id));
     });
 }
 
 void Client::_emit_history_replaced(const ConversationId& id) {
-    _emit([id](const callbacks& cbs) {
+    _emit([id = id](const callbacks& cbs) mutable {
         if (cbs.history_replaced)
-            cbs.history_replaced(id);
+            cbs.history_replaced(std::move(id));
     });
 }
 
@@ -502,10 +504,10 @@ void Client::_emit_message_alone(bool added, const ConversationId& id, int64_t m
     auto msg = _message(message_id);
     if (!msg)
         return;
-    _emit([added, id, msg = std::move(*msg)](const callbacks& cbs) mutable {
+    _emit([added, id = id, msg = std::move(*msg)](const callbacks& cbs) mutable {
         const auto& h = added ? cbs.message_added : cbs.message_updated;
         if (h)
-            h(id, std::move(msg));
+            h(std::move(id), std::move(msg));
     });
 }
 

--- a/src/core/devices.cpp
+++ b/src/core/devices.cpp
@@ -1455,7 +1455,9 @@ void Devices::parse_device_messages(std::span<const SwarmMessage> messages, bool
         load_device_extras(c, row_id, item.info);
     }
 
-    for (const auto& item : items) {
+    // Non-const so a handler can take the info: each item reaches exactly one branch below, and
+    // nothing after the switch reads `info` again.
+    for (auto& item : items) {
         bool is_self = (item.id == self_id);
         try {
             switch (item.processing) {
@@ -1466,7 +1468,9 @@ void Devices::parse_device_messages(std::span<const SwarmMessage> messages, bool
                                 sqlite::blob_guts<std::array<std::byte, 16>>>(
                                 "SELECT id, sas_seed FROM device_link_requests WHERE device = ?",
                                 item.row_id);
-                        f(static_cast<int>(lr_id), item.info, sas_from_seed(sas_seed));
+                        f(static_cast<int>(lr_id),
+                          std::move(item.info),
+                          sas_from_seed(sas_seed));
                     }
                     break;
                 case Processing::Registered:
@@ -1480,7 +1484,7 @@ void Devices::parse_device_messages(std::span<const SwarmMessage> messages, bool
                                              "SELECT id FROM device_link_requests WHERE device = ?",
                                              item.row_id)
                                             .value_or(0LL);
-                            f(static_cast<int>(reqid), item.info);
+                            f(static_cast<int>(reqid), std::move(item.info));
                         }
                         // Clean up any link request row (whether callback was set or not)
                         c.prepared_exec(
@@ -1493,7 +1497,7 @@ void Devices::parse_device_messages(std::span<const SwarmMessage> messages, bool
                             f();
                     } else {
                         if (auto& f = cb().device_removed)
-                            f(item.info);
+                            f(std::move(item.info));
                     }
                     break;
             }

--- a/src/core/devices.cpp
+++ b/src/core/devices.cpp
@@ -1468,9 +1468,7 @@ void Devices::parse_device_messages(std::span<const SwarmMessage> messages, bool
                                 sqlite::blob_guts<std::array<std::byte, 16>>>(
                                 "SELECT id, sas_seed FROM device_link_requests WHERE device = ?",
                                 item.row_id);
-                        f(static_cast<int>(lr_id),
-                          std::move(item.info),
-                          sas_from_seed(sas_seed));
+                        f(static_cast<int>(lr_id), std::move(item.info), sas_from_seed(sas_seed));
                     }
                     break;
                 case Processing::Registered:

--- a/tests/live/test_attachment_send.cpp
+++ b/tests/live/test_attachment_send.cpp
@@ -43,7 +43,7 @@ struct LiveClient {
 bool wait_until_sent(Client& c, int64_t id, std::chrono::seconds limit) {
     auto deadline = std::chrono::steady_clock::now() + limit;
     while (std::chrono::steady_clock::now() < deadline) {
-        auto msg = c.message(id);
+        auto msg = c.message(id, wait);
         REQUIRE(msg);
         if (msg->send_state == SendState::sent)
             return true;
@@ -73,11 +73,13 @@ TEST_CASE(
     std::vector<std::tuple<size_t, int64_t, int64_t, std::optional<int>>> reports;
     auto id = c->send_message(
             ConversationId::dm(me),
-            "with an attachment",
-            {OutgoingAttachment{.path = file, .content_type = "application/octet-stream"}},
+            {.body = "with an attachment",
+             .attachments = {OutgoingAttachment{
+                     .path = file, .content_type = "application/octet-stream"}}},
             [&](size_t idx, int64_t sent, int64_t total, std::optional<int> result) {
                 reports.emplace_back(idx, sent, total, result);
-            });
+            },
+            wait);
 
     REQUIRE(wait_until_sent(*c.client, id, 120s));
 

--- a/tests/test_client/common.hpp
+++ b/tests/test_client/common.hpp
@@ -180,14 +180,14 @@ struct Recorder {
     callbacks handlers() {
         return {
                 .conversation_added =
-                        [this](const AnyConversation& c) {
+                        [this](AnyConversation&& c) {
                             order.push_back("added");
-                            added.push_back(c);
+                            added.push_back(std::move(c));
                         },
                 .conversation_updated =
-                        [this](const AnyConversation& c) {
+                        [this](AnyConversation&& c) {
                             order.push_back("updated");
-                            updated.push_back(c);
+                            updated.push_back(std::move(c));
                         },
                 .conversation_removed =
                         [this](const ConversationId& id) {
@@ -195,24 +195,24 @@ struct Recorder {
                             removed.push_back(id);
                         },
                 .conversation_list_replaced =
-                        [this](std::vector<AnyConversation> l) {
+                        [this](std::vector<AnyConversation>&& l) {
                             order.push_back("replaced");
                             replaced.push_back(std::move(l));
                         },
                 .request_list_replaced =
-                        [this](std::vector<AnyConversation> l) {
+                        [this](std::vector<AnyConversation>&& l) {
                             order.push_back("requests");
                             requests_replaced.push_back(std::move(l));
                         },
                 .message_added =
-                        [this](const ConversationId& id, const Message& m) {
+                        [this](const ConversationId& id, Message&& m) {
                             order.push_back("message");
-                            msg_added.emplace_back(id, m);
+                            msg_added.emplace_back(id, std::move(m));
                         },
                 .message_updated =
-                        [this](const ConversationId& id, const Message& m) {
+                        [this](const ConversationId& id, Message&& m) {
                             order.push_back("message_updated");
-                            msg_updated.emplace_back(id, m);
+                            msg_updated.emplace_back(id, std::move(m));
                         },
         };
     }


### PR DESCRIPTION
The four payload-carrying handlers in `callbacks` took a const reference to a value `Client` had read for that one delivery and destroys straight afterwards. A handler that keeps what it is given, which is what `callbacks.hpp` asks it to do since it must not block, had to copy it: the body, the display name, the last message, the attachment vector. Handing it over by value and moving out of the emit job removes that copy rather than relocating it, because nothing else holds the value and each `_emit` job runs exactly once.

`_emit_lists_replaced` was paying the same cost from the other side. Its lambda was not mutable, so handing the captures to the already by-value list handlers copy-constructed both conversation vectors on every replacement.

## Compatibility

A handler written against the old signature still compiles, since a callable taking a const reference binds to a by-value `std::function` parameter. Existing callers get one fewer copy rather than a change they have to make; only code naming the `std::function` types themselves needs updating. The test client's own handlers are unchanged and still take const references.

## Testing

`./build-claude/tests/testAll` passes, 380 test cases.

Found while auditing every copy between libsession and a screen in session-app. Its bridge fills a struct per frame and hands it to JavaScript, so these values now move from the database read all the way into that frame.