### PR TITLE
Rename the blocking-call tag from `wait` to `block`

### DIFF
--- a/include/session/client.hpp
+++ b/include/session/client.hpp
@@ -139,7 +139,7 @@ class Client {
     //
     // Each returns immediately and invokes `cb` when the work is done -- through the dispatcher if
     // one was given, so on the application's own thread.  A caller that would rather block on the
-    // answer than be handed it passes `wait` in place of the handler and takes the return value.
+    // answer than be handed it passes `block` in place of the handler and takes the return value.
     //
     // **Every `cb` is invoked exactly once**, unless the Client is destroyed before its work runs.
     // That is what its leading `error` argument is for: unset when the call succeeded, and
@@ -160,7 +160,7 @@ class Client {
     /// Message requests are not in it — see `message_requests()` — and neither are hidden
     /// conversations.
     void conversations(failable_function<void(std::vector<AnyConversation>)> cb);
-    std::vector<AnyConversation> conversations(wait_t);
+    std::vector<AnyConversation> conversations(block_t);
 
     /// The message requests: accounts that have written to us and that we have never written to,
     /// most recently active first.
@@ -170,7 +170,7 @@ class Client {
     /// stops being a request when we answer it, since writing to someone is what approving them
     /// is; there is no separate accept, and no way back short of deleting the contact.
     void message_requests(failable_function<void(std::vector<AnyConversation>)> cb);
-    std::vector<AnyConversation> message_requests(wait_t);
+    std::vector<AnyConversation> message_requests(block_t);
 
     /// One conversation, or nullopt if we have no such conversation.
     ///
@@ -188,8 +188,8 @@ class Client {
     void conversation(
             const ConversationId& id, failable_function<void(std::optional<AnyConversation>)> cb);
     void dm(const ConversationId& id, failable_function<void(std::optional<DM>)> cb);
-    std::optional<AnyConversation> conversation(const ConversationId& id, wait_t);
-    std::optional<DM> dm(const ConversationId& id, wait_t);
+    std::optional<AnyConversation> conversation(const ConversationId& id, block_t);
+    std::optional<DM> dm(const ConversationId& id, block_t);
 
     /// The conversation with someone, made if it was not there already — "open a chat with this
     /// account", which is the one thing `conversation()` cannot express.
@@ -207,7 +207,7 @@ class Client {
     ///
     /// @throws std::invalid_argument if the id is not a one-to-one conversation.
     void open_dm(const ConversationId& id, failable_function<void(std::optional<DM>)> cb);
-    DM open_dm(const ConversationId& id, wait_t);
+    DM open_dm(const ConversationId& id, block_t);
 
     /// True if this is our own account's session ID.
     ///
@@ -229,7 +229,7 @@ class Client {
 
     /// A single message by its Client-assigned id, or nullopt if it does not exist.
     void message(int64_t id, failable_function<void(std::optional<Message>)> cb);
-    std::optional<Message> message(int64_t id, wait_t);
+    std::optional<Message> message(int64_t id, block_t);
 
     /// Blocks or unblocks an account named by id.
     ///
@@ -240,7 +240,7 @@ class Client {
     ///
     /// @throws std::invalid_argument if the id is not a one-to-one conversation, or is our own.
     void set_blocked(const ConversationId& id, bool blocked, failable_function<void()> cb);
-    void set_blocked(const ConversationId& id, bool blocked, wait_t);
+    void set_blocked(const ConversationId& id, bool blocked, block_t);
 
     /// Sends to a conversation named by id, creating it if it does not exist.
     ///
@@ -268,8 +268,8 @@ class Client {
             const ConversationId& id,
             OutgoingMessage msg,
             Conversation::upload_progress on_upload,
-            wait_t);
-    int64_t send_message(const ConversationId& id, OutgoingMessage msg, wait_t);
+            block_t);
+    int64_t send_message(const ConversationId& id, OutgoingMessage msg, block_t);
 
     /// Sends a failed message again, resuming rather than restarting: attachments that already
     /// reached the file server are left alone and only the ones that did not are uploaded, because
@@ -291,8 +291,8 @@ class Client {
                     void(size_t index, int64_t sent, int64_t total, std::optional<int> result)>
                     on_upload,
             failable_function<void(bool started)> cb);
-    bool retry_send(int64_t message_id, Conversation::upload_progress on_upload, wait_t);
-    bool retry_send(int64_t message_id, wait_t);
+    bool retry_send(int64_t message_id, Conversation::upload_progress on_upload, block_t);
+    bool retry_send(int64_t message_id, block_t);
 
     /// Deletes one message from this device: its body, its decrypted content and everything it
     /// recorded about its attachments go, and what is left says only that someone said something
@@ -319,7 +319,7 @@ class Client {
     /// Returns false, having done nothing, if there is no such message.  Deleting one already
     /// deleted here is not an error and changes nothing.
     void delete_message(int64_t message_id, failable_function<void(bool deleted)> cb);
-    bool delete_message(int64_t message_id, wait_t);
+    bool delete_message(int64_t message_id, block_t);
 
     /// Deletes a message we sent, here and everywhere else it reached.
     ///
@@ -343,7 +343,7 @@ class Client {
     /// The message is marked `Deletion::everywhere` locally either way, since that records what we
     /// asked for, and it is what stops a client offering the same deletion twice.
     void delete_message_everywhere(int64_t message_id, failable_function<void(bool deleted)> cb);
-    bool delete_message_everywhere(int64_t message_id, wait_t);
+    bool delete_message_everywhere(int64_t message_id, block_t);
 
     /// Shows, or stops showing, a message as a gallery.
     ///
@@ -356,7 +356,7 @@ class Client {
     /// leaves its images unfetched, and getting them is the caller's move — `attachment_data` for
     /// each — because a setter that reached for the network would surprise whoever called it.
     void set_gallery(int64_t message_id, bool gallery, failable_function<void(bool set)> cb);
-    bool set_gallery(int64_t message_id, bool gallery, wait_t);
+    bool set_gallery(int64_t message_id, bool gallery, block_t);
 
     /// An attachment's contents, decrypted and whole.
     ///
@@ -384,7 +384,7 @@ class Client {
     /// Refusing a live message is the point rather than a nicety: this is the one operation here
     /// that removes history outright, and it is only ever entitled to remove what a deletion left.
     void purge_deleted_message(int64_t message_id, failable_function<void(bool removed)> cb);
-    bool purge_deleted_message(int64_t message_id, wait_t);
+    bool purge_deleted_message(int64_t message_id, block_t);
 
     /// The message as it arrived on the wire, rendered as indented text: one line per field that is
     /// set, named, with nested messages beneath their field and enums by name.
@@ -407,7 +407,7 @@ class Client {
     /// pruning removed.  Also nullopt if the stored bytes no longer parse, which is corruption
     /// rather than absence and is logged as such.
     void message_debug(int64_t message_id, failable_function<void(std::optional<std::string>)> cb);
-    std::optional<std::string> message_debug(int64_t message_id, wait_t);
+    std::optional<std::string> message_debug(int64_t message_id, block_t);
 
     /// Fetches one of a message's attachments and writes it to `dest`, decrypting it on the way.
     ///
@@ -547,9 +547,9 @@ class Client {
     /// `set_cache_dir`, which is the application's to decide every run — a stored path would be the
     /// wrong one the moment the database moved.
     void set_attachment_cache_limit(std::optional<int64_t> bytes, failable_function<void()> cb);
-    void set_attachment_cache_limit(std::optional<int64_t> bytes, wait_t);
+    void set_attachment_cache_limit(std::optional<int64_t> bytes, block_t);
     void attachment_cache_limit(failable_function<void(std::optional<int64_t>)> cb);
-    std::optional<int64_t> attachment_cache_limit(wait_t);
+    std::optional<int64_t> attachment_cache_limit(block_t);
 
     /// The largest attachment that will be fetched *unasked*, or nullopt for no limit.
     ///
@@ -563,9 +563,9 @@ class Client {
     ///
     /// Persisted and device-local, for the same reasons as the cache limit.
     void set_auto_download_max_size(std::optional<int64_t> bytes, failable_function<void()> cb);
-    void set_auto_download_max_size(std::optional<int64_t> bytes, wait_t);
+    void set_auto_download_max_size(std::optional<int64_t> bytes, block_t);
     void auto_download_max_size(failable_function<void(std::optional<int64_t>)> cb);
-    std::optional<int64_t> auto_download_max_size(wait_t);
+    std::optional<int64_t> auto_download_max_size(block_t);
 
     // -- Our own account ----------------------------------------------------------------------
     //
@@ -582,9 +582,9 @@ class Client {
     /// conversation works only once that conversation exists, which is a bug waiting for a fresh
     /// account.
     void display_name(failable_function<void(std::string)> cb);
-    std::string display_name(wait_t);
+    std::string display_name(block_t);
     void set_display_name(std::string_view name, failable_function<void()> cb);
-    void set_display_name(std::string_view name, wait_t);
+    void set_display_name(std::string_view name, block_t);
 
     /// Whether to tell somebody when we save a file they sent us.
     ///
@@ -593,9 +593,9 @@ class Client {
     /// and cannot require one, so a caller passing false is never overruled, and a client with no
     /// setting of its own still honours a choice made elsewhere.
     void notify_media_saved(failable_function<void(bool)> cb);
-    bool notify_media_saved(wait_t);
+    bool notify_media_saved(block_t);
     void set_notify_media_saved(bool notify, failable_function<void()> cb);
-    void set_notify_media_saved(bool notify, wait_t);
+    void set_notify_media_saved(bool notify, block_t);
 
     /// How often a handler that reports continuously — such as attachment upload progress — is
     /// allowed to fire, per thing being reported on.  Defaults to 100ms; zero lets every update

--- a/include/session/client/conversation.hpp
+++ b/include/session/client/conversation.hpp
@@ -84,8 +84,8 @@ struct MessagePreview {
 /// that this object has not looked yet.
 ///
 /// Every operation comes in two forms: one taking a handler, which returns immediately and reports
-/// later, and one taking `wait`, which blocks the calling thread and throws instead of reporting.
-/// See `wait_t` for which to use where.
+/// later, and one taking `block`, which blocks the calling thread and throws instead of reporting.
+/// See `block_t` for which to use where.
 ///
 /// Cheap to copy and safe to hold, including on another thread — but it names a Client and must not
 /// outlive it.
@@ -208,11 +208,11 @@ class Conversation {
             std::optional<MessageCursor> before,
             bool include_deleted,
             failable_function<void(std::vector<Message>)> cb) const;
-    std::vector<Message> messages(wait_t) const;
-    std::vector<Message> messages(int limit, wait_t) const;
-    std::vector<Message> messages(int limit, std::optional<MessageCursor> before, wait_t) const;
+    std::vector<Message> messages(block_t) const;
+    std::vector<Message> messages(int limit, block_t) const;
+    std::vector<Message> messages(int limit, std::optional<MessageCursor> before, block_t) const;
     std::vector<Message> messages(
-            int limit, std::optional<MessageCursor> before, bool include_deleted, wait_t) const;
+            int limit, std::optional<MessageCursor> before, bool include_deleted, block_t) const;
 
     /// Removes every deleted message's leftover row from this conversation, and says how many went.
     ///
@@ -233,7 +233,7 @@ class Conversation {
     /// Messages we sent and deleted everywhere are not exposed to this: their swarm copy is already
     /// gone, so there is nothing left to return.
     void purge_deleted(failable_function<void(size_t removed)> cb);
-    size_t purge_deleted(wait_t);
+    size_t purge_deleted(block_t);
 
     // -- Read state ---------------------------------------------------------------------------
 
@@ -246,13 +246,13 @@ class Conversation {
     /// is the thing that was being asked for.
     void mark_read(failable_function<void()> cb);
     void mark_read(std::optional<sys_ms> up_to, failable_function<void()> cb);
-    void mark_read(wait_t);
-    void mark_read(std::optional<sys_ms> up_to, wait_t);
+    void mark_read(block_t);
+    void mark_read(std::optional<sys_ms> up_to, block_t);
 
     /// Marks the conversation unread, or clears that — the deliberate "I want to come back to this"
     /// rather than a count of messages.  Synced, so it follows you between devices.
     void set_marked_unread(bool unread, failable_function<void()> cb);
-    void set_marked_unread(bool unread, wait_t);
+    void set_marked_unread(bool unread, block_t);
 
     // -- Settings -----------------------------------------------------------------------------
 
@@ -262,7 +262,7 @@ class Conversation {
     /// conversation, because hiding removes a conversation from the list and unhiding returns it —
     /// so what changed is the list, not a row in it.
     void set_priority(int priority, failable_function<void()> cb);
-    void set_priority(int priority, wait_t);
+    void set_priority(int priority, block_t);
 
     /// Sets when to notify, and until when to stay quiet.  Separate calls because they are separate
     /// decisions: muting until Monday does not change what you want notified after Monday, and a UI
@@ -270,16 +270,16 @@ class Conversation {
     ///
     /// A `mute_until` in the past, or the epoch, is not muted.
     void set_notifications(config::notify_mode mode, failable_function<void()> cb);
-    void set_notifications(config::notify_mode mode, wait_t);
+    void set_notifications(config::notify_mode mode, block_t);
     void set_mute_until(std::chrono::sys_seconds until, failable_function<void()> cb);
-    void set_mute_until(std::chrono::sys_seconds until, wait_t);
+    void set_mute_until(std::chrono::sys_seconds until, block_t);
 
     /// Sets the disappearing-message mode and timer together, because neither means anything
     /// alone: a timer with no mode does not expire, and a mode with no timer has nothing to count.
     /// `expiration_mode::none` clears the timer whatever is passed with it.
     void set_expiry(
             config::expiration_mode mode, std::chrono::seconds timer, failable_function<void()> cb);
-    void set_expiry(config::expiration_mode mode, std::chrono::seconds timer, wait_t);
+    void set_expiry(config::expiration_mode mode, std::chrono::seconds timer, block_t);
 
     /// Sets what this conversation fetches without being asked.
     ///
@@ -291,7 +291,7 @@ class Conversation {
     /// prompts on first use should call it with whatever answer it was given — `none` included,
     /// since that is not the same as never having asked, and only the latter should prompt again.
     void set_auto_download(AutoDownload mode, failable_function<void()> cb);
-    void set_auto_download(AutoDownload mode, wait_t);
+    void set_auto_download(AutoDownload mode, block_t);
 
     // -- Sending ------------------------------------------------------------------------------
 
@@ -355,8 +355,8 @@ class Conversation {
             upload_progress on_upload,
             failable_function<void(int64_t message_id)> cb);
     void send_message(OutgoingMessage msg, failable_function<void(int64_t message_id)> cb);
-    int64_t send_message(OutgoingMessage msg, upload_progress on_upload, wait_t);
-    int64_t send_message(OutgoingMessage msg, wait_t);
+    int64_t send_message(OutgoingMessage msg, upload_progress on_upload, block_t);
+    int64_t send_message(OutgoingMessage msg, block_t);
 
     // -- Destroying ---------------------------------------------------------------------------
     //
@@ -376,7 +376,7 @@ class Conversation {
     /// Deletes the messages, keeping the conversation itself and everything that describes it — the
     /// contact, the nickname, the pin.
     void clear_messages(failable_function<void()> cb);
-    void clear_messages(wait_t);
+    void clear_messages(block_t);
 
     /// Removes the conversation from the list without forgetting who it is with: the contact entry
     /// stays, so a nickname and an approval survive, and a new message brings the conversation
@@ -387,8 +387,8 @@ class Conversation {
     /// history to come back with it.
     void delete_conversation(failable_function<void()> cb);
     void delete_conversation(bool keep_messages, failable_function<void()> cb);
-    void delete_conversation(wait_t);
-    void delete_conversation(bool keep_messages, wait_t);
+    void delete_conversation(block_t);
+    void delete_conversation(bool keep_messages, block_t);
 
   protected:
     /// Never null, and not owned: the Client this came from, which must outlive it.
@@ -456,7 +456,7 @@ class DM : public Conversation {
     /// Sets or clears the name we have given them, which is ours rather than theirs and follows us
     /// between devices.  An empty nickname removes it, so `display_name` falls back to `name`.
     void set_nickname(std::string_view nickname, failable_function<void()> cb);
-    void set_nickname(std::string_view nickname, wait_t);
+    void set_nickname(std::string_view nickname, block_t);
 
     /// Blocks or unblocks the account.  Blocking is synced, so it takes effect on every device, and
     /// what they send is refused on arrival rather than hidden when drawing.
@@ -465,7 +465,7 @@ class DM : public Conversation {
     /// about a relationship and there is nowhere else to record it.  It does not approve them, and
     /// unblocking does not undo anything else the block implied.
     void set_blocked(bool blocked, failable_function<void()> cb);
-    void set_blocked(bool blocked, wait_t);
+    void set_blocked(bool blocked, block_t);
 
     /// Deletes the contact along with the conversation and its history, everywhere.
     ///
@@ -482,7 +482,7 @@ class DM : public Conversation {
     ///
     /// @throws std::invalid_argument for our own account, which is not a contact of ours.
     void delete_contact(failable_function<void()> cb);
-    void delete_contact(wait_t);
+    void delete_contact(block_t);
 };
 
 /// A closed group.  Nothing of its own yet: what distinguishes a group — its membership, who

--- a/include/session/client/handler.hpp
+++ b/include/session/client/handler.hpp
@@ -6,7 +6,8 @@
 
 namespace session::client {
 
-/// Passed where a handler would go, to say "wait for this and give me the answer" instead.
+/// Passed where a handler would go, to say "block until this is done and give me the answer"
+/// instead.
 ///
 /// Every asynchronous method has a blocking twin taking one of these.  The work is the same and
 /// happens in the same place -- on Core's loop -- so the only difference is who waits: the twin
@@ -14,15 +15,20 @@ namespace session::client {
 /// have reported through its `error` argument.
 ///
 /// A tag rather than a second class, and rather than an overload with no handler at all, because
-/// the point is that it be visible where it is used.  Waiting is a decision about the calling
+/// the point is that it be visible where it is used.  Blocking is a decision about the calling
 /// thread, so it belongs at the call site: a render loop must not do it, and a review can grep for
 /// it, neither of which works when the choice was made wherever the variable was declared.
 ///
 /// Calling one from a Client handler is safe rather than a deadlock -- the loop runs the work
 /// inline when it is already the current thread -- but it is still waiting, and anything else the
 /// loop owes is waiting behind it.
-struct wait_t {};
-inline constexpr wait_t wait{};
+///
+/// Named `block` rather than the more obvious `wait` because POSIX declares `::wait` in
+/// <sys/wait.h>: a client that does `using namespace session::client;` would then find both names
+/// and be able to use neither, and there is no using-declaration that resolves that at namespace
+/// scope.
+struct block_t {};
+inline constexpr block_t block{};
 
 /// Runs a job on the application's own thread.
 ///

--- a/include/session/client/message.hpp
+++ b/include/session/client/message.hpp
@@ -69,9 +69,9 @@ enum class Deletion : int {
 /// field rather than doubling the overload set — which it had already done once.  Designated
 /// initialisers make a call say which parts it is using:
 ///
-///     convo->send_message({.body = "hi"}, wait);
-///     convo->send_message({.body = "look", .attachments = {...}}, on_upload, wait);
-///     convo->send_message({.body = "agreed", .reply_to = other_id}, wait);
+///     convo->send_message({.body = "hi"}, block);
+///     convo->send_message({.body = "look", .attachments = {...}}, on_upload, block);
+///     convo->send_message({.body = "agreed", .reply_to = other_id}, block);
 struct OutgoingMessage {
     std::string body;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -652,14 +652,14 @@ void Client::retry_send(
             std::move(cb));
 }
 
-bool Client::retry_send(int64_t message_id, Conversation::upload_progress on_upload, wait_t) {
+bool Client::retry_send(int64_t message_id, Conversation::upload_progress on_upload, block_t) {
     return loop.call_get([this, message_id, on_upload = std::move(on_upload)] {
         return _retry_send(message_id, on_upload);
     });
 }
 
-bool Client::retry_send(int64_t message_id, wait_t) {
-    return retry_send(message_id, nullptr, wait);
+bool Client::retry_send(int64_t message_id, block_t) {
+    return retry_send(message_id, nullptr, block);
 }
 
 void Client::message_debug(
@@ -667,7 +667,7 @@ void Client::message_debug(
     _async([this, message_id] { return _message_debug(message_id); }, std::move(cb));
 }
 
-std::optional<std::string> Client::message_debug(int64_t message_id, wait_t) {
+std::optional<std::string> Client::message_debug(int64_t message_id, block_t) {
     return loop.call_get([this, message_id] { return _message_debug(message_id); });
 }
 
@@ -676,7 +676,7 @@ void Client::delete_message(int64_t message_id, failable_function<void(bool)> cb
            std::move(cb));
 }
 
-bool Client::delete_message(int64_t message_id, wait_t) {
+bool Client::delete_message(int64_t message_id, block_t) {
     return loop.call_get(
             [this, message_id] { return _delete_message(message_id, Deletion::here); });
 }
@@ -889,13 +889,13 @@ void Client::set_attachment_cache_limit(
         std::optional<int64_t> bytes, failable_function<void()> cb) {
     _async([this, bytes] { set_limit(core.globals, CACHE_LIMIT_KEY, bytes); }, std::move(cb));
 }
-void Client::set_attachment_cache_limit(std::optional<int64_t> bytes, wait_t) {
+void Client::set_attachment_cache_limit(std::optional<int64_t> bytes, block_t) {
     loop.call_get([this, bytes] { set_limit(core.globals, CACHE_LIMIT_KEY, bytes); });
 }
 void Client::attachment_cache_limit(failable_function<void(std::optional<int64_t>)> cb) {
     _async([this] { return core.globals.get_integer(CACHE_LIMIT_KEY); }, std::move(cb));
 }
-std::optional<int64_t> Client::attachment_cache_limit(wait_t) {
+std::optional<int64_t> Client::attachment_cache_limit(block_t) {
     return loop.call_get([this] { return core.globals.get_integer(CACHE_LIMIT_KEY); });
 }
 
@@ -903,13 +903,13 @@ void Client::set_auto_download_max_size(
         std::optional<int64_t> bytes, failable_function<void()> cb) {
     _async([this, bytes] { set_limit(core.globals, AUTO_DL_MAX_KEY, bytes); }, std::move(cb));
 }
-void Client::set_auto_download_max_size(std::optional<int64_t> bytes, wait_t) {
+void Client::set_auto_download_max_size(std::optional<int64_t> bytes, block_t) {
     loop.call_get([this, bytes] { set_limit(core.globals, AUTO_DL_MAX_KEY, bytes); });
 }
 void Client::auto_download_max_size(failable_function<void(std::optional<int64_t>)> cb) {
     _async([this] { return core.globals.get_integer(AUTO_DL_MAX_KEY); }, std::move(cb));
 }
-std::optional<int64_t> Client::auto_download_max_size(wait_t) {
+std::optional<int64_t> Client::auto_download_max_size(block_t) {
     return loop.call_get([this] { return core.globals.get_integer(AUTO_DL_MAX_KEY); });
 }
 
@@ -918,7 +918,7 @@ void Client::display_name(failable_function<void(std::string)> cb) {
            std::move(cb));
 }
 
-std::string Client::display_name(wait_t) {
+std::string Client::display_name(block_t) {
     return loop.call_get(
             [this] { return std::string{core.configs.user_profile().get_name().value_or("")}; });
 }
@@ -928,7 +928,7 @@ void Client::set_display_name(std::string_view name, failable_function<void()> c
            std::move(cb));
 }
 
-void Client::set_display_name(std::string_view name, wait_t) {
+void Client::set_display_name(std::string_view name, block_t) {
     loop.call_get([this, name] { core.configs.user_profile().set_name(name); });
 }
 
@@ -936,7 +936,7 @@ void Client::notify_media_saved(failable_function<void(bool)> cb) {
     _async([this] { return core.configs.user_profile().get_notify_media_saved(); }, std::move(cb));
 }
 
-bool Client::notify_media_saved(wait_t) {
+bool Client::notify_media_saved(block_t) {
     return loop.call_get([this] { return core.configs.user_profile().get_notify_media_saved(); });
 }
 
@@ -945,7 +945,7 @@ void Client::set_notify_media_saved(bool notify, failable_function<void()> cb) {
            std::move(cb));
 }
 
-void Client::set_notify_media_saved(bool notify, wait_t) {
+void Client::set_notify_media_saved(bool notify, block_t) {
     loop.call_get([this, notify] { core.configs.user_profile().set_notify_media_saved(notify); });
 }
 
@@ -953,7 +953,7 @@ void Client::delete_message_everywhere(int64_t message_id, failable_function<voi
     _async([this, message_id] { return _delete_message_everywhere(message_id); }, std::move(cb));
 }
 
-bool Client::delete_message_everywhere(int64_t message_id, wait_t) {
+bool Client::delete_message_everywhere(int64_t message_id, block_t) {
     return loop.call_get([this, message_id] { return _delete_message_everywhere(message_id); });
 }
 
@@ -1100,7 +1100,7 @@ void Client::set_gallery(int64_t message_id, bool gallery, failable_function<voi
            std::move(cb));
 }
 
-bool Client::set_gallery(int64_t message_id, bool gallery, wait_t) {
+bool Client::set_gallery(int64_t message_id, bool gallery, block_t) {
     return loop.call_get([this, message_id, gallery] { return _set_gallery(message_id, gallery); });
 }
 
@@ -1108,7 +1108,7 @@ void Client::purge_deleted_message(int64_t message_id, failable_function<void(bo
     _async([this, message_id] { return _purge_deleted_message(message_id); }, std::move(cb));
 }
 
-bool Client::purge_deleted_message(int64_t message_id, wait_t) {
+bool Client::purge_deleted_message(int64_t message_id, block_t) {
     return loop.call_get([this, message_id] { return _purge_deleted_message(message_id); });
 }
 
@@ -1153,36 +1153,36 @@ void Client::set_blocked(
     _async([this, id, blocked] { _set_blocked(id, blocked); }, std::move(cb));
 }
 
-void Client::set_blocked(const ConversationId& id, bool blocked, wait_t) {
+void Client::set_blocked(const ConversationId& id, bool blocked, block_t) {
     _require_contact("set_blocked", id);
     loop.call_get([this, id, blocked] { _set_blocked(id, blocked); });
 }
 
-std::vector<AnyConversation> Client::conversations(wait_t) {
+std::vector<AnyConversation> Client::conversations(block_t) {
     return loop.call_get([this] { return _conversations(); });
 }
 
-std::vector<AnyConversation> Client::message_requests(wait_t) {
+std::vector<AnyConversation> Client::message_requests(block_t) {
     return loop.call_get([this] { return _message_requests(); });
 }
 
-std::optional<AnyConversation> Client::conversation(const ConversationId& id, wait_t) {
+std::optional<AnyConversation> Client::conversation(const ConversationId& id, block_t) {
     return loop.call_get([this, id] { return _conversation(id); });
 }
 
-std::optional<Message> Client::message(int64_t id, wait_t) {
+std::optional<Message> Client::message(int64_t id, block_t) {
     return loop.call_get([this, id] { return _message(id); });
 }
 
-int64_t Client::send_message(const ConversationId& id, OutgoingMessage msg, wait_t) {
-    return send_message(id, std::move(msg), nullptr, wait);
+int64_t Client::send_message(const ConversationId& id, OutgoingMessage msg, block_t) {
+    return send_message(id, std::move(msg), nullptr, block);
 }
 
 int64_t Client::send_message(
         const ConversationId& id,
         OutgoingMessage msg,
         Conversation::upload_progress on_upload,
-        wait_t) {
+        block_t) {
     _require_sendable("send_message", id, msg);
     return loop.call_get([&] { return _send_message(id, msg, std::move(on_upload)); });
 }
@@ -1210,7 +1210,7 @@ void Client::dm(
     _async([this, id] { return as_dm(_conversation(id)); }, std::move(cb));
 }
 
-std::optional<DM> Client::dm(const ConversationId& id, wait_t) {
+std::optional<DM> Client::dm(const ConversationId& id, block_t) {
     _require_dm("dm", id);
     return loop.call_get([this, id] { return as_dm(_conversation(id)); });
 }
@@ -1223,7 +1223,7 @@ void Client::open_dm(
            std::move(cb));
 }
 
-DM Client::open_dm(const ConversationId& id, wait_t) {
+DM Client::open_dm(const ConversationId& id, block_t) {
     _require_dm("open_dm", id);
     return loop.call_get([this, id] {
         return *as_dm(std::optional<AnyConversation>{_create_conversation(id)});

--- a/src/client/conversation.cpp
+++ b/src/client/conversation.cpp
@@ -9,7 +9,7 @@
 // **A handler form must not capture `this`.**  It returns before the work runs, and the caller is
 // under no obligation to keep this object alive until then: the natural way to write any of these
 // is on a temporary (`client.conversation(id, …)` hands one to a handler, and
-// `*client.conversation(id, wait)` is a temporary outright), and a list element dies whenever the
+// `*client.conversation(id, block)` is a temporary outright), and a list element dies whenever the
 // list is replaced.  So each captures the two things the work needs -- the Client, which outlives
 // everything here, and the id, which is a value -- and nothing else.  Capturing `this` reads the id
 // out of freed memory, which surfaces as a `ConversationId::Type` outside the enum and an
@@ -48,18 +48,18 @@ void Conversation::messages(
             std::move(cb));
 }
 
-std::vector<Message> Conversation::messages(wait_t) const {
-    return messages(50, std::nullopt, wait);
+std::vector<Message> Conversation::messages(block_t) const {
+    return messages(50, std::nullopt, block);
 }
-std::vector<Message> Conversation::messages(int limit, wait_t) const {
-    return messages(limit, std::nullopt, wait);
-}
-std::vector<Message> Conversation::messages(
-        int limit, std::optional<MessageCursor> before, wait_t) const {
-    return messages(limit, before, false, wait);
+std::vector<Message> Conversation::messages(int limit, block_t) const {
+    return messages(limit, std::nullopt, block);
 }
 std::vector<Message> Conversation::messages(
-        int limit, std::optional<MessageCursor> before, bool include_deleted, wait_t) const {
+        int limit, std::optional<MessageCursor> before, block_t) const {
+    return messages(limit, before, false, block);
+}
+std::vector<Message> Conversation::messages(
+        int limit, std::optional<MessageCursor> before, bool include_deleted, block_t) const {
     return _client->loop.call_get([this, limit, before, include_deleted] {
         return _client->_messages(id, limit, before, include_deleted);
     });
@@ -69,7 +69,7 @@ void Conversation::purge_deleted(failable_function<void(size_t)> cb) {
     _client->_require_dm("purge_deleted", id);
     _client->_async([c = _client, id = id] { return c->_purge_deleted(id); }, std::move(cb));
 }
-size_t Conversation::purge_deleted(wait_t) {
+size_t Conversation::purge_deleted(block_t) {
     _client->_require_dm("purge_deleted", id);
     return _client->loop.call_get([this] { return _client->_purge_deleted(id); });
 }
@@ -82,10 +82,10 @@ void Conversation::mark_read(failable_function<void()> cb) {
 void Conversation::mark_read(std::optional<sys_ms> up_to, failable_function<void()> cb) {
     _client->_async([c = _client, id = id, up_to] { c->_mark_read(id, up_to); }, std::move(cb));
 }
-void Conversation::mark_read(wait_t) {
-    mark_read(std::nullopt, wait);
+void Conversation::mark_read(block_t) {
+    mark_read(std::nullopt, block);
 }
-void Conversation::mark_read(std::optional<sys_ms> up_to, wait_t) {
+void Conversation::mark_read(std::optional<sys_ms> up_to, block_t) {
     _client->loop.call_get([this, up_to] { _client->_mark_read(id, up_to); });
 }
 
@@ -93,7 +93,7 @@ void Conversation::set_marked_unread(bool unread, failable_function<void()> cb) 
     _client->_async(
             [c = _client, id = id, unread] { c->_set_marked_unread(id, unread); }, std::move(cb));
 }
-void Conversation::set_marked_unread(bool unread, wait_t) {
+void Conversation::set_marked_unread(bool unread, block_t) {
     _client->loop.call_get([this, unread] { _client->_set_marked_unread(id, unread); });
 }
 
@@ -103,7 +103,7 @@ void Conversation::set_priority(int priority, failable_function<void()> cb) {
     _client->_async(
             [c = _client, id = id, priority] { c->_set_priority(id, priority); }, std::move(cb));
 }
-void Conversation::set_priority(int priority, wait_t) {
+void Conversation::set_priority(int priority, block_t) {
     _client->loop.call_get([this, priority] { _client->_set_priority(id, priority); });
 }
 
@@ -111,7 +111,7 @@ void Conversation::set_notifications(config::notify_mode mode, failable_function
     _client->_async(
             [c = _client, id = id, mode] { c->_set_notifications(id, mode); }, std::move(cb));
 }
-void Conversation::set_notifications(config::notify_mode mode, wait_t) {
+void Conversation::set_notifications(config::notify_mode mode, block_t) {
     _client->loop.call_get([this, mode] { _client->_set_notifications(id, mode); });
 }
 
@@ -119,7 +119,7 @@ void Conversation::set_mute_until(std::chrono::sys_seconds until, failable_funct
     _client->_async(
             [c = _client, id = id, until] { c->_set_mute_until(id, until); }, std::move(cb));
 }
-void Conversation::set_mute_until(std::chrono::sys_seconds until, wait_t) {
+void Conversation::set_mute_until(std::chrono::sys_seconds until, block_t) {
     _client->loop.call_get([this, until] { _client->_set_mute_until(id, until); });
 }
 
@@ -129,7 +129,7 @@ void Conversation::set_expiry(
             [c = _client, id = id, mode, timer] { c->_set_expiry(id, mode, timer); },
             std::move(cb));
 }
-void Conversation::set_expiry(config::expiration_mode mode, std::chrono::seconds timer, wait_t) {
+void Conversation::set_expiry(config::expiration_mode mode, std::chrono::seconds timer, block_t) {
     _client->loop.call_get([this, mode, timer] { _client->_set_expiry(id, mode, timer); });
 }
 
@@ -137,7 +137,7 @@ void Conversation::set_auto_download(AutoDownload mode, failable_function<void()
     _client->_async(
             [c = _client, id = id, mode] { c->_set_auto_download(id, mode); }, std::move(cb));
 }
-void Conversation::set_auto_download(AutoDownload mode, wait_t) {
+void Conversation::set_auto_download(AutoDownload mode, block_t) {
     _client->loop.call_get([this, mode] { _client->_set_auto_download(id, mode); });
 }
 
@@ -158,10 +158,10 @@ void Conversation::send_message(
         OutgoingMessage msg, failable_function<void(int64_t message_id)> cb) {
     send_message(std::move(msg), nullptr, std::move(cb));
 }
-int64_t Conversation::send_message(OutgoingMessage msg, wait_t) {
-    return send_message(std::move(msg), nullptr, wait);
+int64_t Conversation::send_message(OutgoingMessage msg, block_t) {
+    return send_message(std::move(msg), nullptr, block);
 }
-int64_t Conversation::send_message(OutgoingMessage msg, upload_progress on_upload, wait_t) {
+int64_t Conversation::send_message(OutgoingMessage msg, upload_progress on_upload, block_t) {
     _client->_require_sendable("send_message", id, msg);
     return _client->loop.call_get(
             [&] { return _client->_send_message(id, msg, std::move(on_upload)); });
@@ -173,7 +173,7 @@ void Conversation::clear_messages(failable_function<void()> cb) {
     _client->_require_dm("clear_messages", id);
     _client->_async([c = _client, id = id] { c->_clear_messages(id); }, std::move(cb));
 }
-void Conversation::clear_messages(wait_t) {
+void Conversation::clear_messages(block_t) {
     _client->_require_dm("clear_messages", id);
     _client->loop.call_get([this] { _client->_clear_messages(id); });
 }
@@ -187,10 +187,10 @@ void Conversation::delete_conversation(bool keep_messages, failable_function<voi
             [c = _client, id = id, keep_messages] { c->_delete_conversation(id, keep_messages); },
             std::move(cb));
 }
-void Conversation::delete_conversation(wait_t) {
-    delete_conversation(false, wait);
+void Conversation::delete_conversation(block_t) {
+    delete_conversation(false, block);
 }
-void Conversation::delete_conversation(bool keep_messages, wait_t) {
+void Conversation::delete_conversation(bool keep_messages, block_t) {
     _client->_require_dm("delete_conversation", id);
     _client->loop.call_get(
             [this, keep_messages] { _client->_delete_conversation(id, keep_messages); });
@@ -203,7 +203,7 @@ void DM::set_blocked(bool blocked, failable_function<void()> cb) {
     _client->_async(
             [c = _client, id = id, blocked] { c->_set_blocked(id, blocked); }, std::move(cb));
 }
-void DM::set_blocked(bool blocked, wait_t) {
+void DM::set_blocked(bool blocked, block_t) {
     _client->_require_contact("set_blocked", id);
     _client->loop.call_get([this, blocked] { _client->_set_blocked(id, blocked); });
 }
@@ -216,7 +216,7 @@ void DM::set_nickname(std::string_view nickname, failable_function<void()> cb) {
             },
             std::move(cb));
 }
-void DM::set_nickname(std::string_view nickname, wait_t) {
+void DM::set_nickname(std::string_view nickname, block_t) {
     _client->_require_contact("set_nickname", id);
     _client->loop.call_get([this, nickname] { _client->_set_nickname(id, nickname); });
 }
@@ -225,7 +225,7 @@ void DM::delete_contact(failable_function<void()> cb) {
     _client->_require_contact("delete_contact", id);
     _client->_async([c = _client, id = id] { c->_delete_contact(id); }, std::move(cb));
 }
-void DM::delete_contact(wait_t) {
+void DM::delete_contact(block_t) {
     _client->_require_contact("delete_contact", id);
     _client->loop.call_get([this] { _client->_delete_contact(id); });
 }

--- a/tests/live/test_attachment_send.cpp
+++ b/tests/live/test_attachment_send.cpp
@@ -43,7 +43,7 @@ struct LiveClient {
 bool wait_until_sent(Client& c, int64_t id, std::chrono::seconds limit) {
     auto deadline = std::chrono::steady_clock::now() + limit;
     while (std::chrono::steady_clock::now() < deadline) {
-        auto msg = c.message(id, wait);
+        auto msg = c.message(id, block);
         REQUIRE(msg);
         if (msg->send_state == SendState::sent)
             return true;
@@ -79,7 +79,7 @@ TEST_CASE(
             [&](size_t idx, int64_t sent, int64_t total, std::optional<int> result) {
                 reports.emplace_back(idx, sent, total, result);
             },
-            wait);
+            block);
 
     REQUIRE(wait_until_sent(*c.client, id, 120s));
 

--- a/tests/test_client/attachments.cpp
+++ b/tests/test_client/attachments.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Client: an arriving message records the files it names", "[client][at
             });
     sync(*c);
 
-    auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
+    auto msgs = c->conversation(ConversationId::dm(peer.session_id), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     const auto& m = msgs[0];
     CHECK(m.body.empty());
@@ -111,9 +111,9 @@ TEST_CASE("Client: a message reports the attachments it carries", "[client][send
                       OutgoingAttachment{
                               .path = doc, .content_type = "application/x-my-own", .width = 4},
                       OutgoingAttachment{.path = mystery, .voice_message = true}}},
-            wait);
+            block);
 
-    auto msg = c->message(id, wait);
+    auto msg = c->message(id, block);
     REQUIRE(msg.has_value());
 
     // An attachments-only message: nothing to show but the files, which is exactly the case that
@@ -146,7 +146,7 @@ TEST_CASE("Client: a message reports the attachments it carries", "[client][send
     // Each file reached the server, and the size recorded is the file's own -- read at upload time,
     // not the padded ciphertext's length that the server reports back.
     sync(*c);
-    msg = c->message(id, wait);
+    msg = c->message(id, block);
     REQUIRE(msg.has_value());
     for (const auto& a : msg->attachments) {
         CHECK(a.uploaded);
@@ -154,7 +154,7 @@ TEST_CASE("Client: a message reports the attachments it carries", "[client][send
     }
 
     // The same list reaches a paged read, not only the single-message one.
-    auto page = c->conversation(ConversationId::dm(me), wait)->messages(wait);
+    auto page = c->conversation(ConversationId::dm(me), block)->messages(block);
     REQUIRE(page.size() == 1);
     CHECK(page[0].attachments.size() == 3);
     CHECK(page[0].attachments[0].content_type == "image/png");
@@ -197,7 +197,7 @@ TEST_CASE(
             42);
     sync(*c);
 
-    auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
+    auto msgs = c->conversation(ConversationId::dm(peer.session_id), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     auto msg_id = msgs[0].id;
 
@@ -257,7 +257,7 @@ TEST_CASE(
 
     // We also remember that we saved it, which is what stops a client offering "save" forever and
     // writing a second copy.  Recorded whether or not the sender was told.
-    auto saved = c->message(msg_id, wait);
+    auto saved = c->message(msg_id, block);
     REQUIRE(saved.has_value());
     REQUIRE(saved->attachments.size() == 1);
     REQUIRE(saved->attachments[0].saved_at.has_value());
@@ -287,7 +287,8 @@ TEST_CASE(
     };
     deliver(*c, peer, "", from_epoch_ms(2000), "h2", "", std::nullopt, add, 43);
     sync(*c);
-    auto msg_id = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait)[0].id;
+    auto msg_id =
+            c->conversation(ConversationId::dm(peer.session_id), block)->messages(block)[0].id;
 
     auto dir = std::filesystem::temp_directory_path() / random::unique_id("test_save", 7);
     std::filesystem::create_directories(dir);
@@ -322,7 +323,7 @@ TEST_CASE(
         CHECK(stores(*net).empty());
 
         // Telling them and remembering it ourselves are separate: a private save is still a save.
-        CHECK(c->message(msg_id, wait)->attachments[0].saved_at.has_value());
+        CHECK(c->message(msg_id, block)->attachments[0].saved_at.has_value());
     }
 
     // The account's own answer refuses the notification even when the caller asked for it, so a
@@ -388,11 +389,11 @@ TEST_CASE("Client: an attachment we sent can be saved back", "[client][attachmen
     auto id = c->send_message(
             ConversationId::dm(me),
             {.body = "here it is", .attachments = {OutgoingAttachment{.path = source}}},
-            wait);
+            block);
     sync(*c);
     REQUIRE(accept_stores(*net) == 1);
 
-    auto msg = c->message(id, wait);
+    auto msg = c->message(id, block);
     REQUIRE(msg.has_value());
     REQUIRE(msg->attachments.size() == 1);
     CHECK(msg->attachments[0].uploaded);
@@ -426,7 +427,7 @@ TEST_CASE("Client: an attachment we sent can be saved back", "[client][attachmen
 
     // Stamped, even though the message is outgoing: this conversation is with ourselves, so the
     // recipient saving it and us saving it are the same event.
-    CHECK(c->message(id, wait)->attachments[0].saved_at.has_value());
+    CHECK(c->message(id, block)->attachments[0].saved_at.has_value());
 
     std::filesystem::remove_all(dir);
 }
@@ -451,7 +452,7 @@ TEST_CASE(
     auto id = c->send_message(
             ConversationId::dm(me),
             {.body = "here", .attachments = {OutgoingAttachment{.path = source}}},
-            wait);
+            block);
     sync(*c);
     REQUIRE(accept_stores(*net) == 1);
 
@@ -514,7 +515,7 @@ TEST_CASE(
     auto id = c->send_message(
             ConversationId::dm(me),
             {.body = "here", .attachments = {OutgoingAttachment{.path = source}}},
-            wait);
+            block);
     sync(*c);
     REQUIRE(accept_stores(*net) == 1);
 
@@ -570,7 +571,7 @@ TEST_CASE(
     auto id = c->send_message(
             ConversationId::dm(peer.session_id),
             {.body = "for you", .attachments = {OutgoingAttachment{.path = source}}},
-            wait);
+            block);
     sync(*c);
     REQUIRE(accept_stores(*net) >= 1);
 
@@ -591,7 +592,7 @@ TEST_CASE(
     // it as "the file reached a person rather than a file server".  Our own copy says nothing about
     // that, so it must leave the field alone -- otherwise a UI reports "they have it" about someone
     // who may never have opened the conversation.
-    auto msg = c->message(id, wait);
+    auto msg = c->message(id, block);
     REQUIRE(msg);
     REQUIRE(msg->attachments.size() == 1);
     CHECK_FALSE(msg->attachments[0].saved_at.has_value());
@@ -618,11 +619,11 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
             ConversationId::dm(peer.session_id),
             {.body = "two of them",
              .attachments = {OutgoingAttachment{.path = one}, OutgoingAttachment{.path = two}}},
-            wait);
+            block);
     sync(*c);
     REQUIRE(accept_stores(*net) == 2);
 
-    auto sent = c->message(id, wait);
+    auto sent = c->message(id, block);
     REQUIRE(sent.has_value());
     REQUIRE(sent->attachments.size() == 2);
     // Nobody has said anything yet, and an upload reaching the file server is not someone saving
@@ -663,7 +664,7 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
             },
             saved_at);
 
-    auto after = c->message(id, wait);
+    auto after = c->message(id, block);
     REQUIRE(after.has_value());
     // Only the one they named, and stamped with when *they* saved it -- not the message's own
     // timestamp, which is what identifies it and is generally older.
@@ -681,7 +682,7 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
             },
             all_at);
 
-    auto all = c->message(id, wait);
+    auto all = c->message(id, block);
     REQUIRE(all->attachments[0].saved_at == all_at);
     // The later save overwrites the earlier one: what this answers is "is there any point offering
     // save again", not a history of every time they did.
@@ -699,7 +700,7 @@ TEST_CASE("Client: a peer can tell us they saved what we sent", "[client][attach
             from_epoch_ms(9'900'000));
     notify([&](auto* note) { note->set_timestamp(12345); }, from_epoch_ms(9'900'000));
 
-    auto unchanged = c->message(id, wait);
+    auto unchanged = c->message(id, block);
     CHECK(unchanged->attachments[0].saved_at == all_at);
     CHECK(unchanged->attachments[1].saved_at == all_at);
 
@@ -758,7 +759,7 @@ TEST_CASE("Client: a legacy attachment is saved", "[client][attachments][legacy]
             44);
     sync(*c);
 
-    auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
+    auto msgs = c->conversation(ConversationId::dm(peer.session_id), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     REQUIRE(msgs[0].attachments.size() == 1);
 
@@ -802,13 +803,13 @@ TEST_CASE(
                     ConversationId::dm(me),
                     {.body = "here you go",
                      .attachments = {OutgoingAttachment{.path = "/nonexistent/nope.png"}}},
-                    wait),
+                    block),
             std::invalid_argument);
 
     // Rejected before anything was stored, rather than leaving a message that can never be sent --
     // and not even a conversation, which is a stronger thing to be able to say than that it has no
     // messages in it.
-    CHECK_FALSE(c->conversation(ConversationId::dm(me), wait).has_value());
+    CHECK_FALSE(c->conversation(ConversationId::dm(me), block).has_value());
 }
 
 TEST_CASE(
@@ -836,10 +837,10 @@ TEST_CASE(
             [&](size_t idx, int64_t sent, int64_t total, std::optional<int> result) {
                 reports.emplace_back(idx, sent, total, result);
             },
-            wait);
+            block);
     sync(*c);
 
-    auto msg = c->message(id, wait);
+    auto msg = c->message(id, block);
     REQUIRE(msg);
     CHECK(msg->body == "here you go");
     CHECK(msg->send_state == SendState::failed);
@@ -875,12 +876,12 @@ TEST_CASE(
             ConversationId::dm(me),
             {.body = "here you go", .attachments = {OutgoingAttachment{.path = file}}},
             [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
-            wait);
+            block);
     sync(*c);
 
     // With no network the upload cannot start, so the one report is its failure -- which is the
     // point: an outcome is never a thing the throttle may drop.
-    CHECK(c->message(id, wait)->send_state == SendState::failed);
+    CHECK(c->message(id, block)->send_state == SendState::failed);
     REQUIRE(results.size() == 1);
     REQUIRE(results.front().has_value());
     CHECK(*results.front() != 0);
@@ -903,9 +904,9 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     auto id = c->send_message(
             ConversationId::dm(me),
             {.body = "here you go", .attachments = {OutgoingAttachment{.path = file}}},
-            wait);
+            block);
     sync(*c);
-    REQUIRE(c->message(id, wait)->send_state == SendState::failed);
+    REQUIRE(c->message(id, block)->send_state == SendState::failed);
 
     // Retrying is allowed while the failure is one that might not recur, and reports itself as
     // started rather than as succeeded -- the outcome arrives through the message's state.
@@ -913,10 +914,10 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     CHECK(c->retry_send(
             id,
             [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
-            wait));
+            block));
     sync(*c);
     REQUIRE(results.size() == 1);
-    CHECK(c->message(id, wait)->send_state == SendState::failed);
+    CHECK(c->message(id, block)->send_state == SendState::failed);
 
     // With the file gone the retry can only ever fail the same way, so the message becomes
     // terminal rather than staying something an application would offer to try again.
@@ -926,14 +927,14 @@ TEST_CASE("Client: retrying a send that cannot work", "[client][send][attachment
     CHECK(c->retry_send(
             id,
             [&](size_t, int64_t, int64_t, std::optional<int> result) { results.push_back(result); },
-            wait));
+            block));
     sync(*c);
     REQUIRE(results.size() == 1);
     CHECK(results.front() == ATTACHMENT_FILE_MISSING);
-    CHECK(c->message(id, wait)->send_state == SendState::unsendable);
+    CHECK(c->message(id, block)->send_state == SendState::unsendable);
 
     // ... and being terminal, it is refused rather than attempted again.
-    CHECK_FALSE(c->retry_send(id, wait));
+    CHECK_FALSE(c->retry_send(id, block));
 }
 
 TEST_CASE(
@@ -975,7 +976,8 @@ TEST_CASE(
             42);
     sync(*c);
 
-    auto msg_id = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait)[0].id;
+    auto msg_id =
+            c->conversation(ConversationId::dm(peer.session_id), block)->messages(block)[0].id;
 
     auto dir = std::filesystem::temp_directory_path() / random::unique_id("test_size", 7);
     std::filesystem::create_directories(dir);
@@ -1039,7 +1041,8 @@ TEST_CASE(
             },
             42);
     sync(*c);
-    auto msg_id = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait)[0].id;
+    auto msg_id =
+            c->conversation(ConversationId::dm(peer.session_id), block)->messages(block)[0].id;
 
     std::vector<std::optional<std::vector<std::byte>>> got(2);
     std::vector<std::vector<AttachmentProgress>> seen(2);
@@ -1127,7 +1130,8 @@ TEST_CASE("Client: saving joins a fetch already under way", "[client][attachment
             },
             42);
     sync(*c);
-    auto msg_id = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait)[0].id;
+    auto msg_id =
+            c->conversation(ConversationId::dm(peer.session_id), block)->messages(block)[0].id;
 
     // A display asks first, so the file is being accumulated.
     std::optional<std::vector<std::byte>> shown;
@@ -1192,7 +1196,7 @@ TEST_CASE("Client: a conversation set to auto-download fetches on arrival", "[cl
     c->set_cache_dir(dir.path);
 
     auto convo = ConversationId::dm(peer.session_id);
-    c->open_dm(convo, wait);
+    c->open_dm(convo, block);
 
     std::vector<std::byte> image(4000), doc(4000);
     random::fill(image);
@@ -1234,56 +1238,56 @@ TEST_CASE("Client: a conversation set to auto-download fetches on arrival", "[cl
 
     SECTION("unasked means nothing is fetched") {
         // Never having been asked is not consent, and is what a client prompts on.
-        REQUIRE_FALSE(c->conversation(convo, wait)->auto_download().has_value());
+        REQUIRE_FALSE(c->conversation(convo, block)->auto_download().has_value());
         arrive("h1", false);
         CHECK(net->downloads.empty());
         CHECK(progress.empty());
-        CHECK_FALSE(c->conversation(convo, wait)->messages(wait)[0].gallery);
+        CHECK_FALSE(c->conversation(convo, block)->messages(block)[0].gallery);
     }
 
     SECTION("images only fetches the image and leaves the document") {
-        c->conversation(convo, wait)->set_auto_download(AutoDownload::image_attachments, wait);
+        c->conversation(convo, block)->set_auto_download(AutoDownload::image_attachments, block);
         arrive("h2", true);
         REQUIRE(net->downloads.size() == 1);
         CHECK(net->downloads[0].download_url.find("img") != std::string::npos);
 
         // Not a gallery: one of its attachments is not an image, so it cannot be shown as one.
-        auto m = c->conversation(convo, wait)->messages(wait)[0];
+        auto m = c->conversation(convo, block)->messages(block)[0];
         CHECK_FALSE(m.gallery_viewable);
         CHECK_FALSE(m.gallery);
     }
 
     SECTION("all fetches both, and an all-image message opens as a gallery") {
-        c->conversation(convo, wait)->set_auto_download(AutoDownload::all, wait);
+        c->conversation(convo, block)->set_auto_download(AutoDownload::all, block);
         arrive("h3", true);
         CHECK(net->downloads.size() == 2);
 
         // Two attachments, one of them a pdf: still not gallery viewable even though both were
         // fetched.  What is downloaded and what can be displayed as a gallery are different
         // questions.
-        CHECK_FALSE(c->conversation(convo, wait)->messages(wait)[0].gallery);
+        CHECK_FALSE(c->conversation(convo, block)->messages(block)[0].gallery);
 
         arrive("h4", false);
-        auto m = c->conversation(convo, wait)->messages(wait)[0];
+        auto m = c->conversation(convo, block)->messages(block)[0];
         CHECK(m.gallery_viewable);
         CHECK(m.gallery);
     }
 
     SECTION("a size limit refuses what is too big, before fetching it") {
-        c->conversation(convo, wait)->set_auto_download(AutoDownload::all, wait);
-        c->set_auto_download_max_size(1000, wait);
+        c->conversation(convo, block)->set_auto_download(AutoDownload::all, block);
+        c->set_auto_download_max_size(1000, block);
         arrive("h5", false);
         CHECK(net->downloads.empty());
 
         // Raising it lets the next one through, so the limit is read per message rather than
         // remembered from startup.
-        c->set_auto_download_max_size(std::nullopt, wait);
+        c->set_auto_download_max_size(std::nullopt, block);
         arrive("h6", false);
         CHECK(net->downloads.size() == 1);
     }
 
     SECTION("the fetch is reported, cached, and never told to the sender") {
-        c->conversation(convo, wait)->set_auto_download(AutoDownload::all, wait);
+        c->conversation(convo, block)->set_auto_download(AutoDownload::all, block);
         arrive("h7", false);
         REQUIRE(net->downloads.size() == 1);
         REQUIRE(serve_downloads(*net, image_ct) == 1);
@@ -1314,8 +1318,8 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
     c->set_cache_dir(dir.path);
 
     auto convo = ConversationId::dm(peer.session_id);
-    c->open_dm(convo, wait);
-    c->conversation(convo, wait)->set_auto_download(AutoDownload::all, wait);
+    c->open_dm(convo, block);
+    c->conversation(convo, block)->set_auto_download(AutoDownload::all, block);
 
     // `last_used` is a millisecond timestamp, and the whole of this test would otherwise run inside
     // one of them, leaving every row tied and the eviction order arbitrary.  Real uses are spread
@@ -1355,7 +1359,7 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
         sync(*c);
         REQUIRE(serve_downloads(*net, ct) == 1);
         sync(*c);
-        ids.push_back(c->conversation(convo, wait)->messages(wait)[0].id);
+        ids.push_back(c->conversation(convo, block)->messages(block)[0].id);
     }
 
     auto cached = [&](const std::string& url) {
@@ -1373,7 +1377,7 @@ TEST_CASE("Client: the cache evicts least recently used", "[client][auto][evict]
     // Now a limit that only two of the three fit under.
     auto one =
             std::filesystem::file_size(cache::path_for(dir.path, cache::ATTACHMENT_DIR, urls[0]));
-    c->set_attachment_cache_limit(static_cast<int64_t>(one * 2 + one / 2), wait);
+    c->set_attachment_cache_limit(static_cast<int64_t>(one * 2 + one / 2), block);
 
     // Nothing happens until something is added, which is the only moment the total can grow.
     CHECK(cached(urls[1]));
@@ -1433,8 +1437,8 @@ TEST_CASE("Client: the sweep reconciles the cache with what the database says", 
     auto* net = attach_mock_network(c->core);
     c->set_cache_dir(dir.path);
 
-    c->open_dm(convo, wait);
-    c->conversation(convo, wait)->set_auto_download(AutoDownload::all, wait);
+    c->open_dm(convo, block);
+    c->conversation(convo, block)->set_auto_download(AutoDownload::all, block);
 
     std::vector<std::byte> data(2000);
     random::fill(data);
@@ -1571,7 +1575,7 @@ TEST_CASE("Client: the list preview describes a message's attachments", "[client
             [&](auto& data) { add(data, "image/png", "photo.png"); });
     sync(*c);
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 4);
 
     auto preview_of = [&](const SenderKeys& who) {
@@ -1615,7 +1619,7 @@ TEST_CASE("Client: a text-only message previews no attachments", "[client][attac
     deliver(*c, peer, "just words", from_epoch_ms(1000), "h1");
     sync(*c);
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     REQUIRE(convos[0].last_preview());
     // A message with no attachments does not come back from the aggregate query at all, so this is

--- a/tests/test_client/config_helpers.hpp
+++ b/tests/test_client/config_helpers.hpp
@@ -43,7 +43,7 @@ inline ConversationId self_convo(Client& c) {
 }
 
 inline bool listed(Client& c, const ConversationId& id) {
-    auto all = c.conversations(wait);
+    auto all = c.conversations(block);
     return std::ranges::any_of(all, [&](const auto& x) { return x.id() == id; });
 }
 

--- a/tests/test_client/configs.cpp
+++ b/tests/test_client/configs.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Client: a merged contact reaches all three tables", "[client][configs
 
     // The conversation exists because the config says the contact does, not because anything has
     // been said in it.
-    auto convo = c->conversation(id, wait);
+    auto convo = c->conversation(id, block);
     REQUIRE(convo);
     CHECK(convo->priority() == 3);
 
@@ -83,7 +83,7 @@ TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][con
         e.approved = true;
     });
     merge_contacts(*c.client, pushed);
-    REQUIRE(c->conversation(id, wait));
+    REQUIRE(c->conversation(id, block));
 
     auto conn = c->core.database().conn();
     auto account = conn.prepared_get<int64_t>(
@@ -92,7 +92,7 @@ TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][con
             R"(INSERT INTO messages (conversation, sender, outgoing, timestamp, body)
                VALUES ((SELECT id FROM conversations WHERE dm = ?1), ?1, 0, 1000, 'hi'))",
             account);
-    REQUIRE(c->conversation(id, wait)->messages(wait).size() == 1);
+    REQUIRE(c->conversation(id, block)->messages(block).size() == 1);
 
     // Now the other device removes them entirely.  An absent entry can only mean the stronger
     // thing, since hiding arrives as a negative priority instead.
@@ -101,7 +101,7 @@ TEST_CASE("Client: a contact removed elsewhere takes its history", "[client][con
     merge_contacts(*c.client, emptied);
 
     // Conversation and history both gone, and reported.
-    CHECK_FALSE(c->conversation(id, wait));
+    CHECK_FALSE(c->conversation(id, block));
     CHECK(conn.prepared_get<int64_t>("SELECT count(*) FROM messages WHERE sender = ?", account) ==
           0);
     CHECK(std::ranges::find(gone, id) != gone.end());
@@ -124,7 +124,7 @@ TEST_CASE(
         e.approved = true;
     });
     merge_contacts(*c.client, pushed);
-    REQUIRE(c->conversation(id, wait));
+    REQUIRE(c->conversation(id, block));
 
     // Stand in for a crash between committing the row and writing the dump: the tables hold a
     // contact the config has never heard of.  Reconciled inward first, that is indistinguishable
@@ -134,7 +134,7 @@ TEST_CASE(
     c.reopen();
 
     // Startup derives outward before reconciling inward, so it is published rather than deleted.
-    CHECK(c->conversation(id, wait));
+    CHECK(c->conversation(id, block));
     CHECK(c->core.configs.contacts().get(them).has_value());
 }
 
@@ -155,7 +155,7 @@ TEST_CASE("Client: writing a note to self reveals it", "[client][configs]") {
 
     REQUIRE_FALSE(listed(*c.client, me));
 
-    c->send_message(me, {.body = "a reminder"}, wait);
+    c->send_message(me, {.body = "a reminder"}, block);
 
     // Both halves: it is in our own list, and UserProfile says so, which is what stops the other
     // devices on the account from carrying on hiding it.
@@ -170,13 +170,13 @@ TEST_CASE("Client: revealing note to self keeps a pin it already had", "[client]
 
     auto pinned = profile_from_another_device(*c.client, [](auto& p) { p.set_nts_priority(7); });
     merge_profile(*c.client, pinned);
-    REQUIRE(c->conversation(me, wait)->priority() == 7);
+    REQUIRE(c->conversation(me, block)->priority() == 7);
 
-    c->send_message(me, {.body = "a reminder"}, wait);
+    c->send_message(me, {.body = "a reminder"}, block);
 
     // Already visible, so there is nothing to reveal and the pin is left where the user put it.
     CHECK(c->core.configs.user_profile().get_nts_priority() == 7);
-    CHECK(c->conversation(me, wait)->priority() == 7);
+    CHECK(c->conversation(me, block)->priority() == 7);
 }
 
 TEST_CASE("Client: our own profile reaches the conversation", "[client][configs]") {
@@ -189,7 +189,7 @@ TEST_CASE("Client: our own profile reaches the conversation", "[client][configs]
     });
     merge_profile(*c.client, pushed);
 
-    auto convo = c->conversation(me, wait);
+    auto convo = c->conversation(me, block);
     REQUIRE(convo);
     CHECK(convo->display_name() == "Leia");
     CHECK(convo->dm()->note_to_self);
@@ -216,7 +216,7 @@ TEST_CASE("Client: hiding note to self elsewhere keeps it out of the list", "[cl
 
     // Still reachable by name -- hiding is a statement about the list, not about existence -- but
     // gone from it.
-    auto convo = c->conversation(me, wait);
+    auto convo = c->conversation(me, block);
     REQUIRE(convo);
     CHECK(convo->priority() == -1);
     CHECK_FALSE(listed(*c.client, me));
@@ -231,12 +231,12 @@ TEST_CASE("Client: a note-to-self timer waits for the conversation", "[client][c
     auto pushed = profile_from_another_device(
             *c.client, [](auto& p) { p.set_nts_expiry(std::chrono::seconds{600}); });
     merge_profile(*c.client, pushed);
-    REQUIRE_FALSE(c->conversation(me, wait));
+    REQUIRE_FALSE(c->conversation(me, block));
 
     // Writing a note brings the conversation into being, and everything the config was holding for
     // it lands at that moment rather than being lost.
-    c->send_message(me, {.body = "a reminder"}, wait);
-    REQUIRE(c->conversation(me, wait));
+    c->send_message(me, {.body = "a reminder"}, block);
+    REQUIRE(c->conversation(me, block));
 
     auto [mode, timer] = c->core.database().conn().prepared_get<int, int64_t>(
             "SELECT exp_mode, exp_timer FROM conversations"
@@ -258,19 +258,19 @@ TEST_CASE("Client: a restart reconciles what nothing announced", "[client][confi
         p.set_nts_priority(0);
     });
     merge_profile(*c.client, pushed);
-    REQUIRE(c->conversation(me, wait)->display_name() == "Leia");
+    REQUIRE(c->conversation(me, block)->display_name() == "Leia");
 
     // Put the database behind the config behind its back, which is what a crash between merging and
     // reconciling leaves -- or a config merged by a version that could not yet reconcile it.  In
     // neither case is a further notification owed, so nothing would ever come back for it.
     c->core.database().conn().prepared_exec(
             "UPDATE accounts SET name = NULL WHERE session_id = ?", c->core.globals.session_id());
-    REQUIRE(c->conversation(me, wait)->display_name().empty());
+    REQUIRE(c->conversation(me, block)->display_name().empty());
 
     c.reopen();
 
     // Starting up reconciles regardless of whether anything changed, so it is repaired.
-    CHECK(c->conversation(me, wait)->display_name() == "Leia");
+    CHECK(c->conversation(me, block)->display_name() == "Leia");
 }
 
 TEST_CASE("Client: reconciling twice does not disturb the list", "[client][configs]") {
@@ -283,7 +283,7 @@ TEST_CASE("Client: reconciling twice does not disturb the list", "[client][confi
     });
     merge_profile(*c.client, pushed);
 
-    auto before = c->conversation(me, wait);
+    auto before = c->conversation(me, block);
     REQUIRE(before);
 
     // The same profile again reconciles again, since the seqno detector overfires on an identical
@@ -292,7 +292,7 @@ TEST_CASE("Client: reconciling twice does not disturb the list", "[client][confi
     // note to self to the top of the list on every single config merge.
     merge_profile(*c.client, pushed);
 
-    auto after = c->conversation(me, wait);
+    auto after = c->conversation(me, block);
     REQUIRE(after);
     CHECK(after->last_activity() == before->last_activity());
     CHECK(after->display_name() == before->display_name());
@@ -313,7 +313,7 @@ TEST_CASE("Client: blocking someone makes them a contact", "[client][configs]") 
 
     // Through Client, not through a DM: there is no conversation here, which is exactly the case
     // that carve-out exists for.
-    c->set_blocked(id, true, wait);
+    c->set_blocked(id, true, block);
 
     // The block has to be synced and the entry is the only place it can live, so blocking makes
     // one.  It does not approve them: refusing someone's messages is not accepting them.
@@ -322,7 +322,7 @@ TEST_CASE("Client: blocking someone makes them a contact", "[client][configs]") 
     CHECK(entry->blocked);
     CHECK_FALSE(entry->approved);
 
-    c->set_blocked(id, false, wait);
+    c->set_blocked(id, false, block);
     REQUIRE(c->core.configs.contacts().get(them));
     CHECK_FALSE(c->core.configs.contacts().get(them)->blocked);
 }
@@ -335,15 +335,15 @@ TEST_CASE("Client: clearing a conversation says when it was cleared", "[client][
 
     auto them = "05" + std::string(64, '2');
     auto id = dm_from_hex(them);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
     insert_message(*c.client, id, 1000, "hi");
-    REQUIRE(c->conversation(id, wait)->messages(wait).size() == 1);
+    REQUIRE(c->conversation(id, block)->messages(block).size() == 1);
 
     auto before = std::chrono::floor<std::chrono::seconds>(clock_now_ms());
-    c->conversation(id, wait)->clear_messages(wait);
+    c->conversation(id, block)->clear_messages(block);
 
-    CHECK(c->conversation(id, wait)->messages(wait).empty());
-    CHECK(c->conversation(id, wait));  // The conversation stays; only its history went.
+    CHECK(c->conversation(id, block)->messages(block).empty());
+    CHECK(c->conversation(id, block));  // The conversation stays; only its history went.
     CHECK(std::ranges::find(reloaded, id) != reloaded.end());
 
     // And the moment is recorded rather than the deletion being local, so a device that has been
@@ -357,15 +357,15 @@ TEST_CASE("Client: deleting a conversation keeps the contact", "[client][configs
     TempClient c;
     auto them = "05" + std::string(64, '3');
     auto id = dm_from_hex(them);
-    c->open_dm(id, wait);
-    c->conversation(id, wait)->set_priority(5, wait);
+    c->open_dm(id, block);
+    c->conversation(id, block)->set_priority(5, block);
     insert_message(*c.client, id, 1000, "hi");
     REQUIRE(listed(*c.client, id));
 
-    c->conversation(id, wait)->delete_conversation(wait);
+    c->conversation(id, block)->delete_conversation(block);
 
     CHECK_FALSE(listed(*c.client, id));
-    CHECK(c->conversation(id, wait)->messages(wait).empty());
+    CHECK(c->conversation(id, block)->messages(block).empty());
 
     auto entry = c->core.configs.contacts().get(them);
     REQUIRE(entry);  // Still a contact, so a message from them brings the conversation back.
@@ -377,14 +377,14 @@ TEST_CASE("Client: deleting a conversation keeps the contact", "[client][configs
 TEST_CASE("Client: hiding note to self keeps what is in it", "[client][configs]") {
     TempClient c;
     auto me = self_convo(*c.client);
-    c->open_dm(me, wait);
+    c->open_dm(me, block);
     insert_message(*c.client, me, 1000, "note");
     REQUIRE(listed(*c.client, me));
 
-    c->conversation(me, wait)->delete_conversation(/*keep_messages=*/true, wait);
+    c->conversation(me, block)->delete_conversation(/*keep_messages=*/true, block);
 
     CHECK_FALSE(listed(*c.client, me));
-    CHECK(c->conversation(me, wait)->messages(wait).size() == 1);
+    CHECK(c->conversation(me, block)->messages(block).size() == 1);
     CHECK(c->core.configs.user_profile().get_nts_priority() == -1);
 
     // No instruction to destroy anything, which is the whole difference between hiding a
@@ -400,13 +400,13 @@ TEST_CASE("Client: deleting a contact takes the entry that held the block", "[cl
 
     auto them = "05" + std::string(64, '4');
     auto id = dm_from_hex(them);
-    c->open_dm(id, wait);
-    c->dm(id, wait)->set_blocked(true, wait);
+    c->open_dm(id, block);
+    c->dm(id, block)->set_blocked(true, block);
     insert_message(*c.client, id, 1000, "hi");
 
-    c->dm(id, wait)->delete_contact(wait);
+    c->dm(id, block)->delete_contact(block);
 
-    CHECK_FALSE(c->conversation(id, wait));
+    CHECK_FALSE(c->conversation(id, block));
     CHECK(std::ranges::find(gone, id) != gone.end());
 
     // No entry means no delete-before instruction is owed: another device merging this drops the
@@ -427,11 +427,11 @@ TEST_CASE("Client: a delete-before from another device destroys history", "[clie
 
     auto pushed = contacts_from_another_device(*c.client, them, [](auto& e) { e.approved = true; });
     merge_contacts(*c.client, pushed);
-    REQUIRE(c->conversation(id, wait));
+    REQUIRE(c->conversation(id, block));
 
     insert_message(*c.client, id, 1'000'000, "old");
     insert_message(*c.client, id, 3'000'000, "new");
-    REQUIRE(c->conversation(id, wait)->messages(wait).size() == 2);
+    REQUIRE(c->conversation(id, block)->messages(block).size() == 2);
 
     // Retroactive: what the instruction is about is the history that was there when someone chose
     // to destroy it, not merely what arrives after it.
@@ -442,7 +442,7 @@ TEST_CASE("Client: a delete-before from another device destroys history", "[clie
     });
     merge_contacts(*c.client, cleared);
 
-    auto left = c->conversation(id, wait)->messages(wait);
+    auto left = c->conversation(id, block)->messages(block);
     REQUIRE(left.size() == 1);
     CHECK(left[0].body == "new");
 }
@@ -452,7 +452,7 @@ TEST_CASE("Client: approval is not walked back by a merge", "[client][configs]")
     auto them = "05" + std::string(64, '7');
     auto id = dm_from_hex(them);
 
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
     REQUIRE(c->core.configs.contacts().get(them));
     REQUIRE(c->core.configs.contacts().get(them)->approved);
 
@@ -467,16 +467,16 @@ TEST_CASE("Client: approval is not walked back by a merge", "[client][configs]")
     });
     merge_contacts(*c.client, unapproved);
 
-    CHECK(c->message_requests(wait).empty());
-    REQUIRE(c->conversation(id, wait));
-    CHECK_FALSE(c->conversation(id, wait)->dm()->request);
+    CHECK(c->message_requests(block).empty());
+    REQUIRE(c->conversation(id, block));
+    CHECK_FALSE(c->conversation(id, block)->dm()->request);
 }
 
 TEST_CASE("Client: a delete-before is not walked back", "[client][configs]") {
     TempClient c;
     auto them = "05" + std::string(64, '6');
     auto id = dm_from_hex(them);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
 
     // Another device cleared at a moment this one has not reached yet -- clock skew is enough for
     // that.  Publishing our own, smaller value would tell it to un-delete what it destroyed.
@@ -486,7 +486,7 @@ TEST_CASE("Client: a delete-before is not walked back", "[client][configs]") {
     entry.delete_before = later;
     contacts.set(entry);
 
-    c->conversation(id, wait)->clear_messages(wait);
+    c->conversation(id, block)->clear_messages(block);
 
     REQUIRE(contacts.get(them));
     CHECK(contacts.get(them)->delete_before == later);
@@ -497,32 +497,32 @@ TEST_CASE("Client: our own profile is account state, not a conversation", "[clie
 
     // Nothing set yet, and -- the point of this being on Client -- no note-to-self conversation
     // needed for the question to have an answer.
-    CHECK(c->conversations(wait).empty());
-    CHECK(c->display_name(wait).empty());
+    CHECK(c->conversations(block).empty());
+    CHECK(c->display_name(block).empty());
 
-    c->set_display_name("Leia", wait);
-    CHECK(c->display_name(wait) == "Leia");
+    c->set_display_name("Leia", block);
+    CHECK(c->display_name(block) == "Leia");
     CHECK(c->core.configs.user_profile().get_name() == "Leia");
 
     // Still no conversation: setting a name is not writing to yourself.
-    CHECK(c->conversations(wait).empty());
+    CHECK(c->conversations(block).empty());
 }
 
 TEST_CASE("Client: the save-notification preference follows the account", "[client][configs]") {
     TempClient c;
 
     // Session's default is to tell people when you save their files.
-    CHECK(c->notify_media_saved(wait));
+    CHECK(c->notify_media_saved(block));
 
-    c->set_notify_media_saved(false, wait);
-    CHECK_FALSE(c->notify_media_saved(wait));
+    c->set_notify_media_saved(false, block);
+    CHECK_FALSE(c->notify_media_saved(block));
     CHECK_FALSE(c->core.configs.user_profile().get_notify_media_saved());
 
     // What another device set reaches us through a merge, like any other profile field.
     auto pushed = profile_from_another_device(
             *c.client, [](config::UserProfile& p) { p.set_notify_media_saved(true); });
     merge_profile(*c.client, pushed);
-    CHECK(c->notify_media_saved(wait));
+    CHECK(c->notify_media_saved(block));
 }
 
 TEST_CASE(
@@ -538,22 +538,22 @@ TEST_CASE(
     });
     merge_contacts(*c.client, pushed);
 
-    auto convo = c->conversation(id, wait);
+    auto convo = c->conversation(id, block);
     REQUIRE(convo);
     CHECK(convo->picture().url == "http://fs.example/file/99#pubkey=aa");
     CHECK(convo->picture().key == key);
 
     // Somebody we know nothing about has none, which is not the same as an error.
     auto stranger = dm_from_hex("05" + std::string(64, 'c'));
-    c->open_dm(stranger, wait);
-    CHECK(c->conversation(stranger, wait)->picture().url.empty());
+    c->open_dm(stranger, block);
+    CHECK(c->conversation(stranger, block)->picture().url.empty());
 }
 
 TEST_CASE("Client: no picture is nullopt rather than a failure", "[client][configs]") {
     TempClient c;
     SenderKeys them;
     auto id = ConversationId::dm(them.session_id);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
 
     std::optional<std::vector<std::byte>> got;
     std::optional<std::string> err;

--- a/tests/test_client/conversation_api.cpp
+++ b/tests/test_client/conversation_api.cpp
@@ -4,9 +4,9 @@ TEST_CASE("Client: a conversation reports the settings it carries", "[client][co
     TempClient c;
     auto them = "05" + std::string(64, 'a');
     auto id = dm_from_hex(them);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
 
-    auto convo = [&] { return *c->conversation(id, wait); };
+    auto convo = [&] { return *c->conversation(id, block); };
 
     // Defaults, and the ones a screen needs in order to draw a toggle rather than a button.
     CHECK(convo().notifications() == config::notify_mode::defaulted);
@@ -14,11 +14,11 @@ TEST_CASE("Client: a conversation reports the settings it carries", "[client][co
     CHECK(convo().exp_mode() == config::expiration_mode::none);
     CHECK_FALSE(convo().dm()->blocked);
 
-    c->conversation(id, wait)->set_notifications(config::notify_mode::disabled, wait);
-    c->conversation(id, wait)->set_mute_until(std::chrono::sys_seconds{1700000000s}, wait);
-    c->conversation(id, wait)->set_expiry(config::expiration_mode::after_read, 86400s, wait);
-    c->set_blocked(id, true, wait);
-    c->dm(id, wait)->set_nickname("Bilbo", wait);
+    c->conversation(id, block)->set_notifications(config::notify_mode::disabled, block);
+    c->conversation(id, block)->set_mute_until(std::chrono::sys_seconds{1700000000s}, block);
+    c->conversation(id, block)->set_expiry(config::expiration_mode::after_read, 86400s, block);
+    c->set_blocked(id, true, block);
+    c->dm(id, block)->set_nickname("Bilbo", block);
 
     CHECK(convo().notifications() == config::notify_mode::disabled);
     CHECK(convo().mute_until() == std::chrono::sys_seconds{1700000000s});
@@ -44,12 +44,12 @@ TEST_CASE("Client: a conversation reports the settings it carries", "[client][co
     CHECK(entry->nickname == "Bilbo");
 
     // Clearing the nickname falls back to what they call themselves.
-    c->dm(id, wait)->set_nickname("", wait);
+    c->dm(id, block)->set_nickname("", block);
     CHECK(convo().dm()->nickname.empty());
     CHECK_FALSE(c->core.configs.contacts().get(them)->nickname == "Bilbo");
 
     // A timer without a mode expires nothing, so it is not stored as though it were a setting.
-    c->conversation(id, wait)->set_expiry(config::expiration_mode::none, 3600s, wait);
+    c->conversation(id, block)->set_expiry(config::expiration_mode::none, 3600s, block);
     CHECK(convo().exp_mode() == config::expiration_mode::none);
     CHECK(convo().exp_timer() == 0s);
 }
@@ -71,7 +71,7 @@ TEST_CASE("Client: settings from another device reach the conversation", "[clien
     });
     merge_contacts(*c.client, pushed);
 
-    auto convo = c->conversation(id, wait);
+    auto convo = c->conversation(id, block);
     REQUIRE(convo);
     CHECK(convo->notifications() == config::notify_mode::disabled);
     CHECK(convo->mute_until() == std::chrono::sys_seconds{1700000000s});
@@ -88,9 +88,9 @@ TEST_CASE("Client: a conversation knows which kind it is", "[client][convos]") {
     TempClient c;
     SenderKeys them;
     auto id = ConversationId::dm(them.session_id);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
 
-    auto convo = c->conversation(id, wait);
+    auto convo = c->conversation(id, block);
     REQUIRE(convo);
 
     // The kind is what makes a question askable: `request` is a thing only a DM can be, and asking
@@ -113,7 +113,7 @@ TEST_CASE(
     auto id = ConversationId::dm(them.session_id);
     approve(*c, them.session_id);
     deliver(*c, them, "hi", from_epoch_ms(5000), "h1");
-    REQUIRE(c->conversation(id, wait)->unread() == 1);
+    REQUIRE(c->conversation(id, block)->unread() == 1);
 
     // The natural way to write any of these is on something that has already gone by the time the
     // work runs: a temporary, a handler's parameter, or a list element whose list got replaced.  So
@@ -121,19 +121,19 @@ TEST_CASE(
     // wrong, since the waiting form runs before it returns.
     std::optional<std::string> error = "not called";
     {
-        auto convo = c->conversation(id, wait);
+        auto convo = c->conversation(id, block);
         REQUIRE(convo);
         convo->mark_read([&](auto err) { error = std::move(err); });
     }  // convo destroyed here, before the loop has run the work
     sync(*c);
 
     CHECK_FALSE(error.has_value());
-    CHECK(c->conversation(id, wait)->unread() == 0);
+    CHECK(c->conversation(id, block)->unread() == 0);
 
     // And on an outright temporary, which is how it reads at a call site.
     std::optional<std::string> paged = "not called";
     size_t got = 0;
-    c->conversation(id, wait)->messages(50, [&](auto err, auto msgs) {
+    c->conversation(id, block)->messages(50, [&](auto err, auto msgs) {
         paged = std::move(err);
         got = msgs.size();
     });
@@ -162,18 +162,18 @@ TEST_CASE("Client: auto-download is per conversation and stays here", "[client][
     TempClient c;
     SenderKeys them;
     auto id = ConversationId::dm(them.session_id);
-    c->open_dm(id, wait);
+    c->open_dm(id, block);
 
     // Unset means nobody has been asked, which is what a client prompts on.  It is not `none`.
-    CHECK_FALSE(c->conversation(id, wait)->auto_download().has_value());
+    CHECK_FALSE(c->conversation(id, block)->auto_download().has_value());
 
-    c->conversation(id, wait)->set_auto_download(AutoDownload::image_attachments, wait);
-    CHECK(c->conversation(id, wait)->auto_download() == AutoDownload::image_attachments);
+    c->conversation(id, block)->set_auto_download(AutoDownload::image_attachments, block);
+    CHECK(c->conversation(id, block)->auto_download() == AutoDownload::image_attachments);
 
     // Answering "none" is an answer: it records that the question was asked, so a client that
     // prompts when unset does not prompt again.
-    c->conversation(id, wait)->set_auto_download(AutoDownload::none, wait);
-    auto after = c->conversation(id, wait)->auto_download();
+    c->conversation(id, block)->set_auto_download(AutoDownload::none, block);
+    auto after = c->conversation(id, block)->auto_download();
     REQUIRE(after.has_value());
     CHECK(*after == AutoDownload::none);
 
@@ -183,11 +183,11 @@ TEST_CASE("Client: auto-download is per conversation and stays here", "[client][
     auto& contacts = c->core.configs.contacts();
     TestHelper::sync_contact(*c.client, id);
     auto before_push = contacts.needs_push();
-    c->conversation(id, wait)->set_auto_download(AutoDownload::all, wait);
+    c->conversation(id, block)->set_auto_download(AutoDownload::all, block);
     TestHelper::sync_contact(*c.client, id);
     CHECK(contacts.needs_push() == before_push);
 
     // And it survives a restart, being a stored property rather than a session's opinion.
     c.reopen();
-    CHECK(c->conversation(id, wait)->auto_download() == AutoDownload::all);
+    CHECK(c->conversation(id, block)->auto_download() == AutoDownload::all);
 }

--- a/tests/test_client/interop_and_threading.cpp
+++ b/tests/test_client/interop_and_threading.cpp
@@ -112,8 +112,8 @@ TEST_CASE("Client: reads are safe while messages arrive on another thread", "[cl
     std::thread reader{[&] {
         try {
             while (writing) {
-                for (const auto& convo_row : c->conversations(wait))
-                    convo_row.messages(50, wait);
+                for (const auto& convo_row : c->conversations(block))
+                    convo_row.messages(50, block);
                 reads++;
             }
         } catch (...) {
@@ -131,5 +131,5 @@ TEST_CASE("Client: reads are safe while messages arrive on another thread", "[cl
         std::rethrow_exception(reader_err);
 
     CHECK(reads > 0);  // the reader really did run alongside, rather than after
-    CHECK(c->conversation(convo, wait)->messages(N + 10, wait).size() == N);
+    CHECK(c->conversation(convo, block)->messages(N + 10, block).size() == N);
 }

--- a/tests/test_client/receiving.cpp
+++ b/tests/test_client/receiving.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Client: a received DM creates a conversation and a message", "[client
 
     deliver(*c, sender, "hello there", from_epoch_ms(5000), "hash1", "Obi-Wan");
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     CHECK(convos[0].id() == ConversationId::dm(sender.session_id));
     CHECK(convos[0].display_name() == "Obi-Wan");
@@ -17,7 +17,7 @@ TEST_CASE("Client: a received DM creates a conversation and a message", "[client
     CHECK(convos[0].last_activity() == from_epoch_ms(5000));
     CHECK(convos[0].unread() == 1);
 
-    auto msgs = c->conversation(convos[0].id(), wait)->messages(wait);
+    auto msgs = c->conversation(convos[0].id(), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     CHECK(msgs[0].body == "hello there");
     CHECK_FALSE(msgs[0].outgoing);
@@ -26,8 +26,8 @@ TEST_CASE("Client: a received DM creates a conversation and a message", "[client
     CHECK(msgs[0].hash == "hash1");
     CHECK_FALSE(msgs[0].send_state.has_value());
 
-    CHECK(c->message(msgs[0].id, wait)->body == "hello there");
-    CHECK_FALSE(c->message(msgs[0].id + 1000, wait).has_value());
+    CHECK(c->message(msgs[0].id, block)->body == "hello there");
+    CHECK_FALSE(c->message(msgs[0].id + 1000, block).has_value());
 }
 
 TEST_CASE(
@@ -45,12 +45,12 @@ TEST_CASE(
             "",
             peer.session_id);
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     CHECK(convos[0].id() == ConversationId::dm(peer.session_id));
     CHECK(convos[0].unread() == 0);
 
-    auto msgs = c->conversation(convos[0].id(), wait)->messages(wait);
+    auto msgs = c->conversation(convos[0].id(), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     CHECK(msgs[0].body == "sent from my phone");
     CHECK(msgs[0].outgoing);
@@ -67,14 +67,14 @@ TEST_CASE("Client: a message to ourselves is a conversation with ourselves", "[c
     deliver(*c, self_keys(*c), "targeted", from_epoch_ms(5000), "self1", "", me);
     deliver(*c, self_keys(*c), "untargeted", from_epoch_ms(6000), "self2");
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     CHECK(convos[0].id() == ConversationId::dm(me));
     CHECK(convos[0].unread() == 0);
     CHECK(convos[0].dm()->note_to_self);
     CHECK(c->is_note_to_self(convos[0].id()));
 
-    auto msgs = c->conversation(convos[0].id(), wait)->messages(wait);
+    auto msgs = c->conversation(convos[0].id(), block)->messages(block);
     REQUIRE(msgs.size() == 2);
     CHECK(msgs[0].outgoing);
     CHECK(msgs[1].outgoing);
@@ -90,11 +90,11 @@ TEST_CASE("Client: reads answer emptily before an account exists", "[client][con
     constexpr auto sid = "05fe94b7ad4b7f1cc1bb92671f1f0d243f226e115b33770465e82b503fc3e96e1f"_hex_b;
     auto convo = ConversationId::dm(sid);
 
-    CHECK(c->conversations(wait).empty());
-    CHECK(c->message_requests(wait).empty());
-    CHECK_FALSE(c->conversation(convo, wait).has_value());
-    CHECK_FALSE(c->dm(convo, wait).has_value());
-    CHECK_FALSE(c->message(1, wait).has_value());
+    CHECK(c->conversations(block).empty());
+    CHECK(c->message_requests(block).empty());
+    CHECK_FALSE(c->conversation(convo, block).has_value());
+    CHECK_FALSE(c->dm(convo, block).has_value());
+    CHECK_FALSE(c->message(1, block).has_value());
     CHECK_FALSE(c->is_note_to_self(convo));
 
     // Nothing here asks what a *nonexistent* conversation's messages are, or what marking one read
@@ -108,14 +108,14 @@ TEST_CASE("Client: note to self is reported, not left to the caller", "[client][
 
     // open_dm hands back a DM rather than an AnyConversation, so the flag is a plain field: asking
     // for the kind is what removes the narrowing.
-    auto self = c->open_dm(ConversationId::dm(own_sid(*c)), wait);
+    auto self = c->open_dm(ConversationId::dm(own_sid(*c)), block);
     CHECK(self.note_to_self);
-    CHECK(c->conversation(self.id, wait)->dm()->note_to_self);
+    CHECK(c->conversation(self.id, block)->dm()->note_to_self);
     CHECK(c->is_note_to_self(self.id));
 
-    auto other = c->open_dm(ConversationId::dm(peer.session_id), wait);
+    auto other = c->open_dm(ConversationId::dm(peer.session_id), block);
     CHECK_FALSE(other.note_to_self);
-    CHECK_FALSE(c->conversation(other.id, wait)->dm()->note_to_self);
+    CHECK_FALSE(c->conversation(other.id, block)->dm()->note_to_self);
     CHECK_FALSE(c->is_note_to_self(other.id));
 
     // A group or community is never note-to-self, whatever its id happens to be.
@@ -124,7 +124,7 @@ TEST_CASE("Client: note to self is reported, not left to the caller", "[client][
     CHECK_FALSE(c->is_note_to_self(ConversationId::community("http://example.com", "room")));
 
     // The list form agrees with the single-conversation form.
-    for (const auto& convo : c->conversations(wait))
+    for (const auto& convo : c->conversations(block))
         CHECK(convo.dm()->note_to_self == c->is_note_to_self(convo.id()));
 }
 
@@ -135,11 +135,11 @@ TEST_CASE("Client: syncTarget from another sender is ignored", "[client][receive
 
     deliver(*c, peer, "not yours to file", from_epoch_ms(5000), "h1", "", elsewhere.session_id);
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     CHECK(convos[0].id() == ConversationId::dm(peer.session_id));
 
-    auto msgs = c->conversation(convos[0].id(), wait)->messages(wait);
+    auto msgs = c->conversation(convos[0].id(), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     CHECK_FALSE(msgs[0].outgoing);
 }
@@ -152,12 +152,12 @@ TEST_CASE("Client: redelivery of the same swarm hash is ignored", "[client][rece
     deliver(*c, sender, "only once", from_epoch_ms(5000), "dup");
 
     auto convo = ConversationId::dm(sender.session_id);
-    CHECK(c->conversation(convo, wait)->messages(wait).size() == 1);
-    CHECK(c->conversation(convo, wait)->unread() == 1);
+    CHECK(c->conversation(convo, block)->messages(block).size() == 1);
+    CHECK(c->conversation(convo, block)->unread() == 1);
 
     // A genuinely different message from the same sender still lands.
     deliver(*c, sender, "and again", from_epoch_ms(6000), "notdup");
-    CHECK(c->conversation(convo, wait)->messages(wait).size() == 2);
+    CHECK(c->conversation(convo, block)->messages(block).size() == 2);
 }
 
 TEST_CASE("Client: the same message under a different swarm hash is deduped", "[client][receive]") {
@@ -187,8 +187,8 @@ TEST_CASE("Client: the same message under a different swarm hash is deduped", "[
             nullptr,
             7);
 
-    CHECK(c->conversation(convo, wait)->messages(wait).size() == 1);
-    CHECK(c->conversation(convo, wait)->unread() == 1);
+    CHECK(c->conversation(convo, block)->messages(block).size() == 1);
+    CHECK(c->conversation(convo, block)->unread() == 1);
 
     // Same millisecond, different message: the case the timestamp alone cannot tell apart, and the
     // whole reason the id exists.  Identical body, so nothing but the id distinguishes them.
@@ -201,14 +201,14 @@ TEST_CASE("Client: the same message under a different swarm hash is deduped", "[
             std::nullopt,
             nullptr,
             8);
-    CHECK(c->conversation(convo, wait)->messages(wait).size() == 2);
+    CHECK(c->conversation(convo, block)->messages(block).size() == 2);
 
     // A sender too old to set one has no identity beyond its timestamp, so two arrivals under
     // different swarm hashes cannot be told from one message stored twice.  Both land: a visible
     // duplicate is the failure we chose over silently dropping a real message.
     deliver(*c, sender, "from an old client", from_epoch_ms(6000), "old_a");
     deliver(*c, sender, "from an old client", from_epoch_ms(6000), "old_b");
-    CHECK(c->conversation(convo, wait)->messages(wait).size() == 4);
+    CHECK(c->conversation(convo, block)->messages(block).size() == 4);
 }
 
 TEST_CASE("Client: display name is unset rather than empty until known", "[client][convos]") {
@@ -222,7 +222,7 @@ TEST_CASE("Client: display name is unset rather than empty until known", "[clien
     auto stored = c->core.database().conn().prepared_get<std::optional<std::string>>(
             "SELECT name FROM accounts WHERE session_id = ?", sender.session_id);
     CHECK_FALSE(stored.has_value());
-    CHECK(c->conversation(convo, wait)->display_name().empty());
+    CHECK(c->conversation(convo, block)->display_name().empty());
 }
 
 TEST_CASE("Client: a later profile name updates the conversation", "[client][receive]") {
@@ -231,17 +231,17 @@ TEST_CASE("Client: a later profile name updates the conversation", "[client][rec
     auto convo = ConversationId::dm(sender.session_id);
 
     deliver(*c, sender, "one", from_epoch_ms(1000), "h1");
-    CHECK(c->conversation(convo, wait)->display_name().empty());
+    CHECK(c->conversation(convo, block)->display_name().empty());
     // With no name known, name_or_id() falls back to the id rather than an empty string.
-    CHECK(c->conversation(convo, wait)->name_or_id() == convo.to_string());
+    CHECK(c->conversation(convo, block)->name_or_id() == convo.to_string());
 
     deliver(*c, sender, "two", from_epoch_ms(2000), "h2", "Padmé");
-    CHECK(c->conversation(convo, wait)->display_name() == "Padmé");
-    CHECK(c->conversation(convo, wait)->name_or_id() == "Padmé");
+    CHECK(c->conversation(convo, block)->display_name() == "Padmé");
+    CHECK(c->conversation(convo, block)->name_or_id() == "Padmé");
 
     // A message with no profile does not erase the name we already have.
     deliver(*c, sender, "three", from_epoch_ms(3000), "h3");
-    CHECK(c->conversation(convo, wait)->display_name() == "Padmé");
+    CHECK(c->conversation(convo, block)->display_name() == "Padmé");
 }
 
 TEST_CASE("Client: non-conversation content does not create a conversation", "[client][receive]") {
@@ -273,7 +273,7 @@ TEST_CASE("Client: non-conversation content does not create a conversation", "[c
     bodyless.mutable_datamessage()->mutable_profile()->set_displayname("Ghost");
     deliver_content(bodyless, "bodyless");
 
-    CHECK(c->conversations(wait).empty());
+    CHECK(c->conversations(block).empty());
 }
 
 // ── Ordering, unread, drafts ────────────────────────────────────────────────────────────────────
@@ -287,14 +287,14 @@ TEST_CASE("Client: conversations are ordered by most recent activity", "[client]
     deliver(*c, alice, "first", from_epoch_ms(1000), "a1");
     deliver(*c, bob, "second", from_epoch_ms(2000), "b1");
 
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 2);
     CHECK(convos[0].id() == ConversationId::dm(bob.session_id));
     CHECK(convos[1].id() == ConversationId::dm(alice.session_id));
 
     // Alice speaking again moves her back to the top.
     deliver(*c, alice, "third", from_epoch_ms(3000), "a2");
-    convos = c->conversations(wait);
+    convos = c->conversations(block);
     CHECK(convos[0].id() == ConversationId::dm(alice.session_id));
     CHECK(preview_body(convos[0]) == "third");
 }
@@ -307,34 +307,34 @@ TEST_CASE("Client: unread counting and the read watermark", "[client][unread]") 
     deliver(*c, sender, "one", from_epoch_ms(1000), "h1");
     deliver(*c, sender, "two", from_epoch_ms(2000), "h2");
     deliver(*c, sender, "three", from_epoch_ms(3000), "h3");
-    CHECK(c->conversation(convo, wait)->unread() == 3);
+    CHECK(c->conversation(convo, block)->unread() == 3);
 
-    c->conversation(convo, wait)->mark_read(from_epoch_ms(2000), wait);
-    CHECK(c->conversation(convo, wait)->unread() == 1);
+    c->conversation(convo, block)->mark_read(from_epoch_ms(2000), block);
+    CHECK(c->conversation(convo, block)->unread() == 1);
 
     // The watermark never moves backwards.
-    c->conversation(convo, wait)->mark_read(from_epoch_ms(1000), wait);
-    CHECK(c->conversation(convo, wait)->unread() == 1);
+    c->conversation(convo, block)->mark_read(from_epoch_ms(1000), block);
+    CHECK(c->conversation(convo, block)->unread() == 1);
 
-    c->conversation(convo, wait)->mark_read(wait);
-    CHECK(c->conversation(convo, wait)->unread() == 0);
+    c->conversation(convo, block)->mark_read(block);
+    CHECK(c->conversation(convo, block)->unread() == 0);
 
     // A new arrival after a full read is unread again: "read everything" must not mean "read
     // everything that will ever arrive".
     deliver(*c, sender, "four", from_epoch_ms(4000), "h4");
-    CHECK(c->conversation(convo, wait)->unread() == 1);
+    CHECK(c->conversation(convo, block)->unread() == 1);
 
     // Even one that arrives late, bearing a timestamp older than what we already read to.
-    c->conversation(convo, wait)->mark_read(wait);
+    c->conversation(convo, block)->mark_read(block);
     deliver(*c, sender, "late", from_epoch_ms(3500), "h5");
-    CHECK(c->conversation(convo, wait)->unread() ==
+    CHECK(c->conversation(convo, block)->unread() ==
           0);  // known limitation of a timestamp watermark
 
     // Marking read on a conversation with nothing to read is a no-op, not an error.
     auto empty = ConversationId::dm(
             "05fe94b7ad4b7f1cc1bb92671f1f0d243f226e115b33770465e82b503fc3e96e1f"_hex_b);
-    CHECK_NOTHROW(c->open_dm(empty, wait).mark_read(wait));
-    CHECK(c->conversation(empty, wait)->unread() == 0);
+    CHECK_NOTHROW(c->open_dm(empty, block).mark_read(block));
+    CHECK(c->conversation(empty, block)->unread() == 0);
 }
 
 TEST_CASE("Client: cached counts stay in step with the messages table", "[client][convos]") {
@@ -372,11 +372,11 @@ TEST_CASE("Client: cached counts stay in step with the messages table", "[client
         CHECK(unread == actual_unread);
         CHECK(n == 3);
         CHECK(unread == 3);
-        CHECK(c->conversation(convo, wait)->unread() == 3);
+        CHECK(c->conversation(convo, block)->unread() == 3);
     }
 
     SECTION("marking read moves unread without touching the total") {
-        c->conversation(convo, wait)->mark_read(from_epoch_ms(2000), wait);
+        c->conversation(convo, block)->mark_read(from_epoch_ms(2000), block);
         auto [n, unread, actual_n, actual_unread] = counts(alice.session_id);
         CHECK(n == actual_n);
         CHECK(unread == actual_unread);
@@ -385,7 +385,7 @@ TEST_CASE("Client: cached counts stay in step with the messages table", "[client
     }
 
     SECTION("count tracks deletes made behind the application's back") {
-        auto id = c->conversation(convo, wait)->messages(wait).front().id;
+        auto id = c->conversation(convo, block)->messages(block).front().id;
         conn.prepared_exec("DELETE FROM messages WHERE id = ?", id);
 
         auto [n, unread, actual_n, actual_unread] = counts(alice.session_id);
@@ -397,7 +397,7 @@ TEST_CASE("Client: cached counts stay in step with the messages table", "[client
         CHECK(unread == 3);
         CHECK(actual_unread == 2);
 
-        c->conversation(convo, wait)->mark_read(from_epoch_ms(1000), wait);
+        c->conversation(convo, block)->mark_read(from_epoch_ms(1000), block);
         auto [n2, unread2, actual_n2, actual_unread2] = counts(alice.session_id);
         CHECK(unread2 == actual_unread2);
     }
@@ -407,7 +407,7 @@ TEST_CASE("Client: cached counts stay in step with the messages table", "[client
                 "SELECT c.id FROM conversations c JOIN accounts a ON a.id = c.dm"
                 " WHERE a.session_id = ?",
                 bob.session_id);
-        auto id = c->conversation(convo, wait)->messages(wait).front().id;
+        auto id = c->conversation(convo, block)->messages(block).front().id;
         conn.prepared_exec("UPDATE messages SET conversation = ? WHERE id = ?", convo_row, id);
 
         auto [n, unread, actual_n, actual_unread] = counts(alice.session_id);
@@ -425,19 +425,19 @@ TEST_CASE("Client: explicit conversation creation", "[client][convos]") {
     constexpr auto sid = "05fe94b7ad4b7f1cc1bb92671f1f0d243f226e115b33770465e82b503fc3e96e1f"_hex_b;
     auto convo = ConversationId::dm(sid);
 
-    CHECK_FALSE(c->conversation(convo, wait).has_value());
+    CHECK_FALSE(c->conversation(convo, block).has_value());
 
-    auto created = c->open_dm(convo, wait);
+    auto created = c->open_dm(convo, block);
     CHECK(created.id == convo);
     CHECK(created.unread == 0);
     // Nothing to preview at all, which is a different answer from an empty body.
     CHECK(!created.last_preview);
-    CHECK(c->conversations(wait).size() == 1);
+    CHECK(c->conversations(block).size() == 1);
 
     // Opening one that already exists is not an error and does not duplicate it -- which is why
     // this is `open` and not `create`.
-    c->open_dm(convo, wait);
-    CHECK(c->conversations(wait).size() == 1);
+    c->open_dm(convo, block);
+    CHECK(c->conversations(block).size() == 1);
 }
 
 // ── Paging ──────────────────────────────────────────────────────────────────────────────────────
@@ -450,22 +450,22 @@ TEST_CASE("Client: message history pages backwards by cursor", "[client][message
     for (int i = 1; i <= 10; i++)
         deliver(*c, sender, "msg{}"_format(i), from_epoch_ms(i * 1000), "h{}"_format(i));
 
-    auto page1 = c->conversation(convo, wait)->messages(4, wait);
+    auto page1 = c->conversation(convo, block)->messages(4, block);
     REQUIRE(page1.size() == 4);
     CHECK(page1[0].body == "msg10");
     CHECK(page1[3].body == "msg7");
 
-    auto page2 = c->conversation(convo, wait)->messages(4, page1.back().cursor(), wait);
+    auto page2 = c->conversation(convo, block)->messages(4, page1.back().cursor(), block);
     REQUIRE(page2.size() == 4);
     CHECK(page2[0].body == "msg6");
     CHECK(page2[3].body == "msg3");
 
-    auto page3 = c->conversation(convo, wait)->messages(4, page2.back().cursor(), wait);
+    auto page3 = c->conversation(convo, block)->messages(4, page2.back().cursor(), block);
     REQUIRE(page3.size() == 2);
     CHECK(page3[0].body == "msg2");
     CHECK(page3[1].body == "msg1");
 
-    CHECK(c->conversation(convo, wait)->messages(4, page3.back().cursor(), wait).empty());
+    CHECK(c->conversation(convo, block)->messages(4, page3.back().cursor(), block).empty());
 }
 
 TEST_CASE("Client: paging is stable across equal timestamps", "[client][messages]") {
@@ -481,7 +481,7 @@ TEST_CASE("Client: paging is stable across equal timestamps", "[client][messages
     std::vector<std::string> seen;
     std::optional<MessageCursor> cursor;
     while (true) {
-        auto page = c->conversation(convo, wait)->messages(1, cursor, wait);
+        auto page = c->conversation(convo, block)->messages(1, cursor, block);
         if (page.empty())
             break;
         seen.push_back(page[0].body);
@@ -512,10 +512,10 @@ TEST_CASE("Client: a message can be shown as it was on the wire", "[client][mess
             },
             77);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 1);
 
-    auto dump = c->message_debug(msgs[0].id, wait);
+    auto dump = c->message_debug(msgs[0].id, block);
     REQUIRE(dump);
     INFO("dump:\n" << *dump);
 
@@ -540,7 +540,7 @@ TEST_CASE("Client: a message can be shown as it was on the wire", "[client][mess
 
     // A message with no stored wire form, and one that does not exist, are both "nothing to show"
     // rather than errors.
-    CHECK_FALSE(c->message_debug(msgs[0].id + 1000, wait).has_value());
+    CHECK_FALSE(c->message_debug(msgs[0].id + 1000, block).has_value());
 }
 
 TEST_CASE(
@@ -552,24 +552,24 @@ TEST_CASE(
     deliver(*c, sender, "one", from_epoch_ms(1000), "h1");
     deliver(*c, sender, "two", from_epoch_ms(2000), "h2");
     deliver(*c, sender, "three", from_epoch_ms(3000), "h3");
-    REQUIRE(c->conversation(convo, wait)->unread() == 3);
+    REQUIRE(c->conversation(convo, block)->unread() == 3);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 3);
     auto middle = msgs[1];  // "two"
     REQUIRE(middle.body == "two");
     REQUIRE(middle.hash == "h2");
 
-    CHECK(c->delete_message(middle.id, wait));
+    CHECK(c->delete_message(middle.id, block));
 
     // Hidden by default...
-    auto visible = c->conversation(convo, wait)->messages(wait);
+    auto visible = c->conversation(convo, block)->messages(block);
     REQUIRE(visible.size() == 2);
     CHECK(visible[0].body == "three");
     CHECK(visible[1].body == "one");
 
     // ...and in its original place when asked for, saying who and when but nothing else.
-    auto all = c->conversation(convo, wait)->messages(50, std::nullopt, true, wait);
+    auto all = c->conversation(convo, block)->messages(50, std::nullopt, true, block);
     REQUIRE(all.size() == 3);
     CHECK(all[1].id == middle.id);
     CHECK(all[1].deleted == Deletion::here);
@@ -580,17 +580,17 @@ TEST_CASE(
     CHECK(all[1].hash == "h2");
 
     // Nothing left to read, so it stops being unread.
-    CHECK(c->conversation(convo, wait)->unread() == 2);
+    CHECK(c->conversation(convo, block)->unread() == 2);
 
     // The stored wire form goes with it, which is where the body actually survived.
-    CHECK_FALSE(c->message_debug(middle.id, wait).has_value());
+    CHECK_FALSE(c->message_debug(middle.id, block).has_value());
 
     // A redelivery under the same hash is still recognised as one we have seen.
     deliver(*c, sender, "two", from_epoch_ms(2000), "h2");
-    CHECK(c->conversation(convo, wait)->messages(50, std::nullopt, true, wait).size() == 3);
+    CHECK(c->conversation(convo, block)->messages(50, std::nullopt, true, block).size() == 3);
 
     // Deleting a message that does not exist is false, not an error.
-    CHECK_FALSE(c->delete_message(middle.id + 10000, wait));
+    CHECK_FALSE(c->delete_message(middle.id + 10000, block));
 }
 
 TEST_CASE("Client: the list preview skips a deleted last message", "[client][convos][delete]") {
@@ -602,14 +602,14 @@ TEST_CASE("Client: the list preview skips a deleted last message", "[client][con
     deliver(*c, sender, "older", from_epoch_ms(1000), "h1");
     deliver(*c, sender, "newest", from_epoch_ms(2000), "h2");
 
-    auto newest = c->conversation(convo, wait)->messages(wait).front();
+    auto newest = c->conversation(convo, block)->messages(block).front();
     REQUIRE(newest.body == "newest");
-    REQUIRE(preview_body(*c->conversation(convo, wait)) == "newest");
+    REQUIRE(preview_body(*c->conversation(convo, block)) == "newest");
 
-    c->delete_message(newest.id, wait);
+    c->delete_message(newest.id, block);
 
     // The list says what was last actually said, rather than going blank.
-    CHECK(preview_body(*c->conversation(convo, wait)) == "older");
+    CHECK(preview_body(*c->conversation(convo, block)) == "older");
 }
 
 TEST_CASE("Client: purging removes what a deletion left", "[client][messages][delete]") {
@@ -621,37 +621,37 @@ TEST_CASE("Client: purging removes what a deletion left", "[client][messages][de
     deliver(*c, sender, "two", from_epoch_ms(2000), "h2");
     deliver(*c, sender, "three", from_epoch_ms(3000), "h3");
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     auto live = msgs[0].id;  // "three"
-    c->delete_message(msgs[1].id, wait);
-    c->delete_message(msgs[2].id, wait);
+    c->delete_message(msgs[1].id, block);
+    c->delete_message(msgs[2].id, block);
 
     SECTION("one at a time, and only what was deleted") {
         // A live message is refused: this is the one call that destroys history outright.
-        CHECK_FALSE(c->purge_deleted_message(live, wait));
-        CHECK(c->conversation(convo, wait)->messages(wait).size() == 1);
+        CHECK_FALSE(c->purge_deleted_message(live, block));
+        CHECK(c->conversation(convo, block)->messages(block).size() == 1);
 
-        CHECK(c->purge_deleted_message(msgs[1].id, wait));
-        CHECK(c->conversation(convo, wait)->messages(50, std::nullopt, true, wait).size() == 2);
+        CHECK(c->purge_deleted_message(msgs[1].id, block));
+        CHECK(c->conversation(convo, block)->messages(50, std::nullopt, true, block).size() == 2);
 
         // Purging the same row twice is false the second time rather than an error.
-        CHECK_FALSE(c->purge_deleted_message(msgs[1].id, wait));
+        CHECK_FALSE(c->purge_deleted_message(msgs[1].id, block));
     }
 
     SECTION("all of them at once") {
-        CHECK(c->conversation(convo, wait)->purge_deleted(wait) == 2);
+        CHECK(c->conversation(convo, block)->purge_deleted(block) == 2);
 
-        auto left = c->conversation(convo, wait)->messages(50, std::nullopt, true, wait);
+        auto left = c->conversation(convo, block)->messages(50, std::nullopt, true, block);
         REQUIRE(left.size() == 1);
         CHECK(left[0].body == "three");
 
         // Nothing left to purge.
-        CHECK(c->conversation(convo, wait)->purge_deleted(wait) == 0);
+        CHECK(c->conversation(convo, block)->purge_deleted(block) == 0);
 
         // And having forgotten it, a redelivery is a new message again -- the cost the header warns
         // about, asserted here so it is a decision rather than a surprise.
         deliver(*c, sender, "two", from_epoch_ms(2000), "h2");
-        CHECK(c->conversation(convo, wait)->messages(wait).size() == 2);
+        CHECK(c->conversation(convo, block)->messages(block).size() == 2);
     }
 }
 
@@ -661,20 +661,20 @@ TEST_CASE("Client: deleting for everyone is only for what we sent", "[client][me
     auto convo = ConversationId::dm(sender.session_id);
 
     deliver(*c, sender, "theirs", from_epoch_ms(1000), "h1");
-    auto theirs = c->conversation(convo, wait)->messages(wait).front();
+    auto theirs = c->conversation(convo, block)->messages(block).front();
 
     // Their message, in their swarm as well as ours: an unsend request from us would be ignored at
     // the other end, so we do not pretend to offer it.
-    CHECK_FALSE(c->delete_message_everywhere(theirs.id, wait));
-    CHECK_FALSE(c->message(theirs.id, wait)->deleted.has_value());
-    CHECK(c->message(theirs.id, wait)->body == "theirs");
+    CHECK_FALSE(c->delete_message_everywhere(theirs.id, block));
+    CHECK_FALSE(c->message(theirs.id, block)->deleted.has_value());
+    CHECK(c->message(theirs.id, block)->body == "theirs");
 
     // Deleting it for ourselves is what that caller wanted, and still works.
-    CHECK(c->delete_message(theirs.id, wait));
-    CHECK(c->message(theirs.id, wait)->deleted == Deletion::here);
+    CHECK(c->delete_message(theirs.id, block));
+    CHECK(c->message(theirs.id, block)->deleted == Deletion::here);
 
     // A message that does not exist is false either way, not an error.
-    CHECK_FALSE(c->delete_message_everywhere(theirs.id + 10000, wait));
+    CHECK_FALSE(c->delete_message_everywhere(theirs.id + 10000, block));
 }
 
 TEST_CASE("Client: an unsend request from the author deletes the message", "[client][delete]") {
@@ -710,7 +710,7 @@ TEST_CASE("Client: an unsend request from the author deletes the message", "[cli
     };
 
     deliver(*c, sender, "regrettable", from_epoch_ms(1000), "h1", "", std::nullopt, nullptr, 42);
-    auto msg = c->conversation(convo, wait)->messages(wait).front();
+    auto msg = c->conversation(convo, block)->messages(block).front();
     REQUIRE(msg.body == "regrettable");
 
     SECTION("naming someone else's message, ignored") {
@@ -719,24 +719,24 @@ TEST_CASE("Client: an unsend request from the author deletes the message", "[cli
         // is a different test -- it would be honoured, and rightly.
         SenderKeys stranger;
         unsend(stranger, sender.session_id, 1000, 42, "u2");
-        CHECK(c->message(msg.id, wait)->body == "regrettable");
-        CHECK_FALSE(c->message(msg.id, wait)->deleted.has_value());
+        CHECK(c->message(msg.id, block)->body == "regrettable");
+        CHECK_FALSE(c->message(msg.id, block)->deleted.has_value());
     }
 
     SECTION("from the author, honoured") {
         unsend(sender, sender.session_id, 1000, 42, "u3");
-        auto after = c->message(msg.id, wait);
+        auto after = c->message(msg.id, block);
         REQUIRE(after);
         CHECK(after->deleted == Deletion::everywhere);
         CHECK(after->body.empty());
         // The row stays, so a redelivery cannot resurrect it.
         CHECK(after->hash == "h1");
-        CHECK(c->conversation(convo, wait)->unread() == 0);
+        CHECK(c->conversation(convo, block)->unread() == 0);
     }
 
     SECTION("matching nothing, ignored") {
         unsend(sender, sender.session_id, 5555, 42, "u4");
-        CHECK(c->message(msg.id, wait)->body == "regrettable");
+        CHECK(c->message(msg.id, block)->body == "regrettable");
     }
 
     SECTION("ambiguous, refused rather than guessed") {
@@ -744,11 +744,11 @@ TEST_CASE("Client: an unsend request from the author deletes the message", "[cli
         // case the id exists for, and the case a sender most often unsends.
         deliver(*c, sender, "one", from_epoch_ms(7000), "amb1");
         deliver(*c, sender, "two", from_epoch_ms(7000), "amb2");
-        REQUIRE(c->conversation(convo, wait)->messages(wait).size() == 3);
+        REQUIRE(c->conversation(convo, block)->messages(block).size() == 3);
 
         unsend(sender, sender.session_id, 7000, std::nullopt, "u5");
 
-        auto left = c->conversation(convo, wait)->messages(wait);
+        auto left = c->conversation(convo, block)->messages(block);
         CHECK(left.size() == 3);
         for (const auto& m : left)
             CHECK_FALSE(m.deleted.has_value());
@@ -787,10 +787,10 @@ TEST_CASE("Client: a sender's picture arrives with their message", "[client][rec
             std::nullopt,
             with_profile("Padmé", "http://fs.example/file/7#pubkey=aa", key, 500));
 
-    auto pic = c->conversation(convo, wait)->picture();
+    auto pic = c->conversation(convo, block)->picture();
     CHECK(pic.url == "http://fs.example/file/7#pubkey=aa");
     CHECK(pic.key == key);
-    CHECK(c->conversation(convo, wait)->display_name() == "Padmé");
+    CHECK(c->conversation(convo, block)->display_name() == "Padmé");
 
     SECTION("a newer profile replaces it") {
         std::vector<std::byte> key2(32, std::byte{0x9});
@@ -803,8 +803,8 @@ TEST_CASE("Client: a sender's picture arrives with their message", "[client][rec
                 std::nullopt,
                 with_profile("Padme", "http://fs.example/file/8", key2, 900));
 
-        CHECK(c->conversation(convo, wait)->picture().url == "http://fs.example/file/8");
-        CHECK(c->conversation(convo, wait)->picture().key == key2);
+        CHECK(c->conversation(convo, block)->picture().url == "http://fs.example/file/8");
+        CHECK(c->conversation(convo, block)->picture().key == key2);
     }
 
     SECTION("a message that took a week to arrive does not undo a newer change") {
@@ -819,8 +819,8 @@ TEST_CASE("Client: a sender's picture arrives with their message", "[client][rec
                 std::nullopt,
                 with_profile("Old Name", "http://fs.example/file/old", stale, 100));
 
-        CHECK(c->conversation(convo, wait)->picture().url == "http://fs.example/file/7#pubkey=aa");
-        CHECK(c->conversation(convo, wait)->display_name() == "Padmé");
+        CHECK(c->conversation(convo, block)->picture().url == "http://fs.example/file/7#pubkey=aa");
+        CHECK(c->conversation(convo, block)->display_name() == "Padmé");
     }
 
     SECTION("a url with no key is not stored, since it could only fail to open") {
@@ -833,13 +833,13 @@ TEST_CASE("Client: a sender's picture arrives with their message", "[client][rec
                 std::nullopt,
                 with_profile("", "http://fs.example/file/nokey", std::nullopt, 900));
 
-        CHECK(c->conversation(convo, wait)->picture().url == "http://fs.example/file/7#pubkey=aa");
+        CHECK(c->conversation(convo, block)->picture().url == "http://fs.example/file/7#pubkey=aa");
     }
 
     SECTION("a message carrying no profile leaves it alone") {
         deliver(*c, sender, "plain", from_epoch_ms(5000), "h5");
-        CHECK(c->conversation(convo, wait)->picture().url == "http://fs.example/file/7#pubkey=aa");
-        CHECK(c->conversation(convo, wait)->display_name() == "Padmé");
+        CHECK(c->conversation(convo, block)->picture().url == "http://fs.example/file/7#pubkey=aa");
+        CHECK(c->conversation(convo, block)->display_name() == "Padmé");
     }
 
     SECTION("and it reaches the config, so our other devices learn it too") {

--- a/tests/test_client/replies.cpp
+++ b/tests/test_client/replies.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Client: a reply names what it answers", "[client][replies]") {
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2);
     // Newest first.
     const auto& answer = msgs[0];
@@ -65,7 +65,7 @@ TEST_CASE(
             quoting(peer.session_id, missing, 4242));
     sync(*c);
 
-    auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
+    auto msgs = c->conversation(ConversationId::dm(peer.session_id), block)->messages(block);
     REQUIRE(msgs.size() == 1);
     REQUIRE(msgs[0].reply);
     // Unresolved, but the author and timestamp came off the wire, so a client can still say who
@@ -93,7 +93,7 @@ TEST_CASE("Client: a reply resolves once its target arrives", "[client][replies]
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 1);
     REQUIRE(msgs[0].reply);
     REQUIRE_FALSE(msgs[0].reply->message_id.has_value());
@@ -101,7 +101,7 @@ TEST_CASE("Client: a reply resolves once its target arrives", "[client][replies]
     deliver(*c, peer, "the original", first, "h1", "", std::nullopt, nullptr, 7777);
     sync(*c);
 
-    msgs = c->conversation(convo, wait)->messages(wait);
+    msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2);
     REQUIRE(msgs[0].reply);
     REQUIRE(msgs[0].reply->message_id.has_value());
@@ -127,7 +127,7 @@ TEST_CASE("Client: msgid disambiguates a same-millisecond target", "[client][rep
             quoting(peer.session_id, same, 222));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 3);
 
     int64_t second_id = 0;
@@ -161,13 +161,13 @@ TEST_CASE("Client: an ambiguous target resolves stably", "[client][replies]") {
             quoting(peer.session_id, same));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 3);
     REQUIRE(msgs[0].reply);
     REQUIRE(msgs[0].reply->message_id.has_value());
     auto picked = *msgs[0].reply->message_id;
 
-    auto again = c->conversation(convo, wait)->messages(wait);
+    auto again = c->conversation(convo, block)->messages(block);
     REQUIRE(again[0].reply->message_id == picked);
 
     // And it is one of the two candidates, not something else.
@@ -204,7 +204,7 @@ TEST_CASE("Client: a quote with an unusable author is dropped", "[client][replie
             quoting(peer.session_id, target, 999));
     sync(*c);
 
-    auto msgs = c->conversation(ConversationId::dm(peer.session_id), wait)->messages(wait);
+    auto msgs = c->conversation(ConversationId::dm(peer.session_id), block)->messages(block);
     REQUIRE(msgs.size() == 3);
 
     auto by_body = [&](std::string_view b) -> const Message& {
@@ -270,13 +270,13 @@ TEST_CASE("Client: deleting a target re-reports the replies to it", "[client][re
             quoting(peer.session_id, target_ts, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2);
     auto reply_id = msgs[0].id;
     auto target_id = msgs[1].id;
     rec.msg_updated.clear();
 
-    c->delete_message(target_id, wait);
+    c->delete_message(target_id, block);
     sync(*c);
 
     // The target itself is reported, and so is the reply that points at it: what it should draw
@@ -304,7 +304,7 @@ TEST_CASE("Client: a reply carries the message it answers", "[client][replies]")
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2);
     REQUIRE(msgs[0].reply);
     REQUIRE(msgs[0].reply->message);
@@ -352,7 +352,7 @@ TEST_CASE("Client: a quoted attachment-only message arrives whole", "[client][re
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2);
     REQUIRE(msgs[0].reply);
     REQUIRE(msgs[0].reply->message);
@@ -385,7 +385,7 @@ TEST_CASE("Client: reply loading stops one level down", "[client][replies]") {
             quoting(peer.session_id, b_ts, 222));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 3);
     const auto& cmsg = msgs[0];
 
@@ -428,7 +428,7 @@ TEST_CASE("Client: several replies to one message share one copy", "[client][rep
             quoting(peer.session_id, first, 7777));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 3);
     REQUIRE(msgs[0].reply);
     REQUIRE(msgs[1].reply);
@@ -471,7 +471,7 @@ TEST_CASE("Client: many distinct reply targets load correctly", "[client][replie
                 quoting(peer.session_id, stamps[i], 100 + i));
     sync(*c);
 
-    auto msgs = c->conversation(convo, wait)->messages(wait);
+    auto msgs = c->conversation(convo, block)->messages(block);
     REQUIRE(msgs.size() == 2 * n);
 
     // Every answer resolved, and each to its *own* target rather than all to one of them -- which
@@ -495,11 +495,11 @@ TEST_CASE("Client: a sent reply names what it answers", "[client][replies][send]
     TestHelper::seed_pfs_nak(c->core, me);
     auto convo = ConversationId::dm(me);
 
-    auto first = c->send_message(convo, {.body = "the original"}, wait);
-    auto second = c->send_message(convo, {.body = "answering", .reply_to = first}, wait);
+    auto first = c->send_message(convo, {.body = "the original"}, block);
+    auto second = c->send_message(convo, {.body = "answering", .reply_to = first}, block);
     sync(*c);
 
-    auto msg = c->message(second, wait);
+    auto msg = c->message(second, block);
     REQUIRE(msg);
     REQUIRE(msg->reply);
     CHECK(msg->reply->author == me);
@@ -518,12 +518,12 @@ TEST_CASE("Client: a sent reply puts a quote on the wire", "[client][replies][se
     TestHelper::seed_pfs_nak(c->core, me);
     auto convo = ConversationId::dm(me);
 
-    auto first = c->send_message(convo, {.body = "the original"}, wait);
-    auto second = c->send_message(convo, {.body = "answering", .reply_to = first}, wait);
+    auto first = c->send_message(convo, {.body = "the original"}, block);
+    auto second = c->send_message(convo, {.body = "answering", .reply_to = first}, block);
     sync(*c);
 
     // What was stored is what goes out, so the wire form is checkable from the raw content.
-    auto dump = c->message_debug(second, wait);
+    auto dump = c->message_debug(second, block);
     REQUIRE(dump);
     CHECK(dump->find("quote") != std::string::npos);
     CHECK(dump->find("msgTimestamp") != std::string::npos);
@@ -538,18 +538,18 @@ TEST_CASE("Client: reply_to must name a message in this conversation", "[client]
     auto me = own_sid(*c);
     TestHelper::seed_pfs_nak(c->core, me);
 
-    auto mine = c->send_message(ConversationId::dm(me), {.body = "a note"}, wait);
+    auto mine = c->send_message(ConversationId::dm(me), {.body = "a note"}, block);
 
     // Nonexistent, and in another conversation: both are caller error, and both are refused on the
     // calling thread rather than accepted and then silently dropped.
     CHECK_THROWS_AS(
-            c->send_message(ConversationId::dm(me), {.body = "x", .reply_to = 999999}, wait),
+            c->send_message(ConversationId::dm(me), {.body = "x", .reply_to = 999999}, block),
             std::invalid_argument);
 
-    c->open_dm(ConversationId::dm(peer.session_id), wait);
+    c->open_dm(ConversationId::dm(peer.session_id), block);
     TestHelper::seed_pfs_nak(c->core, peer.session_id);
     CHECK_THROWS_AS(
             c->send_message(
-                    ConversationId::dm(peer.session_id), {.body = "x", .reply_to = mine}, wait),
+                    ConversationId::dm(peer.session_id), {.body = "x", .reply_to = mine}, block),
             std::invalid_argument);
 }

--- a/tests/test_client/requests.cpp
+++ b/tests/test_client/requests.cpp
@@ -9,8 +9,8 @@ TEST_CASE("Client: a stranger's message is a request, not a conversation", "[cli
     deliver(*c, sender, "hi, remember me?", from_epoch_ms(5000), "h1", "Jar Jar");
     sync(*c);
 
-    CHECK(c->conversations(wait).empty());
-    auto requests = c->message_requests(wait);
+    CHECK(c->conversations(block).empty());
+    auto requests = c->message_requests(block);
     REQUIRE(requests.size() == 1);
     CHECK(requests[0].id() == id);
     CHECK(requests[0].dm()->request);
@@ -21,9 +21,9 @@ TEST_CASE("Client: a stranger's message is a request, not a conversation", "[cli
     // which list it belongs to, and `request` is what says so.
     REQUIRE(r.added.size() == 1);
     CHECK(r.added[0].dm()->request);
-    REQUIRE(c->conversation(id, wait));
-    CHECK(c->conversation(id, wait)->dm()->request);
-    CHECK(c->conversation(id, wait)->messages(wait).size() == 1);
+    REQUIRE(c->conversation(id, block));
+    CHECK(c->conversation(id, block)->dm()->request);
+    CHECK(c->conversation(id, block)->messages(block).size() == 1);
 
     // And it is synced, so a request answered on one device is not still waiting on another.  Their
     // writing to us is what says they approved us; nothing yet says we approved them.
@@ -41,16 +41,16 @@ TEST_CASE("Client: answering a request accepts it", "[client][requests]") {
 
     deliver(*c, sender, "hello?", from_epoch_ms(5000), "h1");
     sync(*c);
-    REQUIRE(c->message_requests(wait).size() == 1);
+    REQUIRE(c->message_requests(block).size() == 1);
     r.order.clear();
 
     // There is no separate accept: writing to someone is what approving them is.
-    c->send_message(id, {.body = "hello yourself"}, wait);
+    c->send_message(id, {.body = "hello yourself"}, block);
     sync(*c);
 
-    CHECK(c->message_requests(wait).empty());
-    REQUIRE(c->conversations(wait).size() == 1);
-    CHECK_FALSE(c->conversations(wait)[0].dm()->request);
+    CHECK(c->message_requests(block).empty());
+    REQUIRE(c->conversations(block).size() == 1);
+    CHECK_FALSE(c->conversations(block)[0].dm()->request);
     CHECK(c->core.configs.contacts().get(oxenc::to_hex(sender.session_id))->approved);
 
     // It left one list and joined the other, which is neither an addition nor a removal to either,
@@ -65,7 +65,7 @@ TEST_CASE("Client: a linked device's answer accepts the request", "[client][requ
     auto id = ConversationId::dm(sender.session_id);
 
     deliver(*c, sender, "hello?", from_epoch_ms(5000), "h1");
-    REQUIRE(c->message_requests(wait).size() == 1);
+    REQUIRE(c->message_requests(block).size() == 1);
 
     // Our own message coming back off our own swarm because another device sent it.  syncTarget
     // says who it was addressed to, and sending to them is what approved them.
@@ -77,9 +77,9 @@ TEST_CASE("Client: a linked device's answer accepts the request", "[client][requ
             "",
             sender.session_id);
 
-    CHECK(c->message_requests(wait).empty());
-    REQUIRE(c->conversations(wait).size() == 1);
-    CHECK(c->conversations(wait)[0].id() == id);
+    CHECK(c->message_requests(block).empty());
+    REQUIRE(c->conversations(block).size() == 1);
+    CHECK(c->conversations(block)[0].id() == id);
 }
 
 TEST_CASE("Client: writing first leaves us awaiting their approval", "[client][requests]") {
@@ -87,37 +87,37 @@ TEST_CASE("Client: writing first leaves us awaiting their approval", "[client][r
     SenderKeys them;
     auto id = ConversationId::dm(them.session_id);
 
-    c->send_message(id, {.body = "are you there?"}, wait);
+    c->send_message(id, {.body = "are you there?"}, block);
     sync(*c);
 
     // The mirror of a request: we are in *their* requests list, and nothing they could be sent
     // says so -- only a message back from them clears it.  Meanwhile it is an ordinary conversation
     // of ours, since we chose to start it.
-    REQUIRE(c->conversations(wait).size() == 1);
-    CHECK(c->conversations(wait)[0].dm()->awaiting_approval);
-    CHECK_FALSE(c->conversations(wait)[0].dm()->request);
-    CHECK(c->message_requests(wait).empty());
+    REQUIRE(c->conversations(block).size() == 1);
+    CHECK(c->conversations(block)[0].dm()->awaiting_approval);
+    CHECK_FALSE(c->conversations(block)[0].dm()->request);
+    CHECK(c->message_requests(block).empty());
 
     deliver(*c, them, "here", from_epoch_ms(9000), "h1");
 
-    REQUIRE(c->conversation(id, wait));
-    CHECK_FALSE(c->conversation(id, wait)->dm()->awaiting_approval);
-    CHECK_FALSE(c->conversation(id, wait)->dm()->request);
+    REQUIRE(c->conversation(id, block));
+    CHECK_FALSE(c->conversation(id, block)->dm()->awaiting_approval);
+    CHECK_FALSE(c->conversation(id, block)->dm()->request);
 }
 
 TEST_CASE("Client: note to self is never a message request", "[client][requests]") {
     TempClient c;
     auto me = self_convo(*c.client);
 
-    c->send_message(me, {.body = "a note"}, wait);
+    c->send_message(me, {.body = "a note"}, block);
     sync(*c);
 
-    CHECK(c->message_requests(wait).empty());
-    REQUIRE(c->conversation(me, wait));
-    CHECK_FALSE(c->conversation(me, wait)->dm()->request);
+    CHECK(c->message_requests(block).empty());
+    REQUIRE(c->conversation(me, block));
+    CHECK_FALSE(c->conversation(me, block)->dm()->request);
 
     // Nor awaiting anything: there is nobody at the other end to accept.
-    CHECK_FALSE(c->conversation(me, wait)->dm()->awaiting_approval);
+    CHECK_FALSE(c->conversation(me, block)->dm()->awaiting_approval);
 }
 
 TEST_CASE("Client: a blocked account's messages are refused", "[client][requests]") {
@@ -126,17 +126,17 @@ TEST_CASE("Client: a blocked account's messages are refused", "[client][requests
     auto id = ConversationId::dm(sender.session_id);
 
     deliver(*c, sender, "first", from_epoch_ms(5000), "h1");
-    REQUIRE(c->conversation(id, wait)->messages(wait).size() == 1);
+    REQUIRE(c->conversation(id, block)->messages(block).size() == 1);
 
-    c->dm(id, wait)->set_blocked(true, wait);
+    c->dm(id, block)->set_blocked(true, block);
     deliver(*c, sender, "and again", from_epoch_ms(6000), "h2");
 
     // Refused on arrival rather than hidden when drawing, so nothing they send becomes history or
     // an unread count.
-    CHECK(c->conversation(id, wait)->messages(wait).size() == 1);
-    CHECK(c->conversation(id, wait)->unread() == 1);
+    CHECK(c->conversation(id, block)->messages(block).size() == 1);
+    CHECK(c->conversation(id, block)->unread() == 1);
 
-    c->dm(id, wait)->set_blocked(false, wait);
+    c->dm(id, block)->set_blocked(false, block);
     deliver(*c, sender, "still there?", from_epoch_ms(7000), "h3");
-    CHECK(c->conversation(id, wait)->messages(wait).size() == 2);
+    CHECK(c->conversation(id, block)->messages(block).size() == 2);
 }

--- a/tests/test_client/sending.cpp
+++ b/tests/test_client/sending.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Client: send_message stores, dispatches and reaches sent", "[client][
     TestHelper::seed_pfs_nak(c->core, peer);
     TestHelper::seed_pfs_nak(c->core, own_sid(*c));
 
-    auto id = c->send_message(convo, {.body = "general kenobi"}, wait);
+    auto id = c->send_message(convo, {.body = "general kenobi"}, block);
 
     // A store to the recipient's swarm and one to our own, both into the default namespace, with
     // something in them.
@@ -28,7 +28,7 @@ TEST_CASE("Client: send_message stores, dispatches and reaches sent", "[client][
     }
     CHECK(accept_stores(*net) == 2);
 
-    auto msg = c->message(id, wait);
+    auto msg = c->message(id, block);
     REQUIRE(msg.has_value());
     CHECK(msg->body == "general kenobi");
     CHECK(msg->outgoing);
@@ -40,7 +40,7 @@ TEST_CASE("Client: send_message stores, dispatches and reaches sent", "[client][
     CHECK(msg->hash == store_hash_for(oxenc::to_hex(own_sid(*c))));
 
     // The conversation was created by the send and shows the outgoing message as its preview.
-    auto convos = c->conversations(wait);
+    auto convos = c->conversations(block);
     REQUIRE(convos.size() == 1);
     CHECK(preview_body(convos[0]) == "general kenobi");
     // Ours, which is what lets a row prefix "You: ".
@@ -59,7 +59,7 @@ TEST_CASE("Client: a failed send is recorded as failed", "[client][send]") {
     TestHelper::seed_pfs_nak(c->core, peer);
     TestHelper::seed_pfs_nak(c->core, own_sid(*c));
 
-    auto id = c->send_message(ConversationId::dm(peer), {.body = "into the void"}, wait);
+    auto id = c->send_message(ConversationId::dm(peer), {.body = "into the void"}, block);
 
     // The swarm refusing the store is what a failure is, rather than us declining to attempt one.
     auto sent = stores(*net);
@@ -67,14 +67,14 @@ TEST_CASE("Client: a failed send is recorded as failed", "[client][send]") {
     for (auto* r : sent)
         r->callback(false, false, 500, {}, "nope");
 
-    CHECK(c->message(id, wait)->send_state == SendState::failed);
+    CHECK(c->message(id, block)->send_state == SendState::failed);
 }
 
 TEST_CASE("Client: sending to a non-DM conversation is rejected", "[client][send]") {
     TempClient c;
     constexpr auto gid = "03fe94b7ad4b7f1cc1bb92671f1f0d243f226e115b33770465e82b503fc3e96e1f"_hex_b;
     CHECK_THROWS_AS(
-            c->send_message(ConversationId::group(gid), {.body = "hi"}, wait),
+            c->send_message(ConversationId::group(gid), {.body = "hi"}, block),
             std::invalid_argument);
 }
 
@@ -89,14 +89,14 @@ TEST_CASE("Client: an in-flight send becomes interrupted after a restart", "[cli
     TestHelper::seed_pfs_nak(c->core, peer);
     TestHelper::seed_pfs_nak(c->core, own_sid(*c));
 
-    auto id = c->send_message(ConversationId::dm(peer), {.body = "did this land?"}, wait);
-    CHECK(c->message(id, wait)->send_state == SendState::sending);
+    auto id = c->send_message(ConversationId::dm(peer), {.body = "did this land?"}, block);
+    CHECK(c->message(id, block)->send_state == SendState::sending);
 
     c.reopen();
 
     // Not "failed": we genuinely do not know whether the swarm stored it.
-    CHECK(c->message(id, wait)->send_state == SendState::interrupted);
-    CHECK(c->message(id, wait)->body == "did this land?");
+    CHECK(c->message(id, block)->send_state == SendState::interrupted);
+    CHECK(c->message(id, block)->body == "did this land?");
 }
 
 // ── Signals ─────────────────────────────────────────────────────────────────────────────────────
@@ -182,7 +182,7 @@ TEST_CASE("Client: state is committed before the handler fires", "[client][signa
 
     TempClient c{callbacks{.message_added = [&](const ConversationId&, const Message& m) {
         // Waiting from inside a handler: the loop runs it inline, since it is already this thread.
-        body_seen_from_handler = self->message(m.id, wait)->body;
+        body_seen_from_handler = self->message(m.id, block)->body;
     }}};
     self = &*c;
 
@@ -199,7 +199,8 @@ TEST_CASE("Client: a throwing handler is contained", "[client][signals]") {
     // The exception is caught and logged rather than escaping into Core's event loop, and the
     // message is stored regardless: a broken listener must not cost us data.
     CHECK_NOTHROW(deliver(*c, sender, "still fine", from_epoch_ms(1000), "h1"));
-    CHECK(c->conversation(ConversationId::dm(sender.session_id), wait)->messages(wait).size() == 1);
+    CHECK(c->conversation(ConversationId::dm(sender.session_id), block)->messages(block).size() ==
+          1);
 }
 
 TEST_CASE("Client: send status changes are reported as message_updated", "[client][signals]") {
@@ -215,7 +216,7 @@ TEST_CASE("Client: send status changes are reported as message_updated", "[clien
     // for `send_state` rather than for the sync copy's.
     TestHelper::seed_pfs_nak(c->core, peer);
 
-    auto id = c->send_message(ConversationId::dm(peer), {.body = "hello"}, wait);
+    auto id = c->send_message(ConversationId::dm(peer), {.body = "hello"}, block);
     sync(*c);
     r.order.clear();
     r.msg_updated.clear();
@@ -250,37 +251,37 @@ TEST_CASE("Client: priority orders the list and hides", "[client][convos]") {
 
     auto ids = [&] {
         std::vector<ConversationId> out;
-        for (const auto& convo : c->conversations(wait))
+        for (const auto& convo : c->conversations(block))
             out.push_back(convo.id());
         return out;
     };
     CHECK(ids() == std::vector{idd, idb, ida});
 
     // Higher priority sorts first, regardless of recency.
-    c->conversation(ida, wait)->set_priority(1, wait);
+    c->conversation(ida, block)->set_priority(1, block);
     CHECK(ids() == std::vector{ida, idd, idb});
-    CHECK(c->conversation(ida, wait)->priority() == 1);
+    CHECK(c->conversation(ida, block)->priority() == 1);
 
     // A bigger number outranks a smaller one.
-    c->conversation(idb, wait)->set_priority(5, wait);
+    c->conversation(idb, block)->set_priority(5, block);
     CHECK(ids() == std::vector{idb, ida, idd});
 
     // Equal priorities form a block that sorts among itself by recency: b is pinned alongside a but
     // is the more recently active of the two, so it leads.  d stays below both, unpinned.
-    c->conversation(ida, wait)->set_priority(5, wait);
+    c->conversation(ida, block)->set_priority(5, block);
     CHECK(ids() == std::vector{idb, ida, idd});
 
     // Negative is hidden: gone from the list entirely rather than sorted last.
-    c->conversation(idb, wait)->set_priority(-1, wait);
+    c->conversation(idb, block)->set_priority(-1, block);
     CHECK(ids() == std::vector{ida, idd});
 
     // Still reachable by name, though: hidden is a statement about the list, and this is the only
     // way back to one.
-    REQUIRE(c->conversation(idb, wait).has_value());
-    CHECK(c->conversation(idb, wait)->priority() == -1);
+    REQUIRE(c->conversation(idb, block).has_value());
+    CHECK(c->conversation(idb, block)->priority() == -1);
 
     // ...and unhiding brings it back where its priority says.
-    c->conversation(idb, wait)->set_priority(0, wait);
+    c->conversation(idb, block)->set_priority(0, block);
     CHECK(ids() == std::vector{ida, idd, idb});
 }
 
@@ -296,7 +297,7 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     sync(*c);
     r.order.clear();
 
-    c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(3, wait);
+    c->conversation(ConversationId::dm(a.session_id), block)->set_priority(3, block);
 
     // Reported as a replacement, not as an update to the one conversation whose priority changed:
     // what moved is the list.  Both lists are replaced together, because hiding takes a
@@ -310,7 +311,7 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
     // Hiding removes it from the replacement list, which is how a subscriber learns it is gone.
     r.order.clear();
     r.replaced.clear();
-    c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
+    c->conversation(ConversationId::dm(a.session_id), block)->set_priority(-1, block);
     CHECK(r.order == std::vector<std::string>{"replaced", "requests"});
     REQUIRE(r.replaced.size() == 1);
     REQUIRE(r.replaced[0].size() == 1);
@@ -318,7 +319,7 @@ TEST_CASE("Client: a priority change replaces the whole list", "[client][signals
 
     // Setting the same value again changes nothing, so it says nothing.
     r.order.clear();
-    c->conversation(ConversationId::dm(a.session_id), wait)->set_priority(-1, wait);
+    c->conversation(ConversationId::dm(a.session_id), block)->set_priority(-1, block);
     CHECK(r.order.empty());
 }
 
@@ -331,7 +332,7 @@ TEST_CASE("Client: the two copies of a send report separately", "[client][send]"
     TestHelper::seed_pfs_nak(c->core, peer);
     TestHelper::seed_pfs_nak(c->core, own_sid(*c));
 
-    auto id = c->send_message(ConversationId::dm(peer), {.body = "two ways"}, wait);
+    auto id = c->send_message(ConversationId::dm(peer), {.body = "two ways"}, block);
 
     // Which swarm a store is bound for is the pubkey it names, so the two copies can be answered
     // independently and in either order.
@@ -349,13 +350,13 @@ TEST_CASE("Client: the two copies of a send report separately", "[client][send]"
 
     // The recipient's copy lands; our own swarm has not answered yet.
     (*to_peer)->callback(true, false, 200, {}, "{}");
-    CHECK(c->message(id, wait)->send_state == SendState::sent);
-    CHECK(c->message(id, wait)->sync_send_state == SendState::sending);
+    CHECK(c->message(id, block)->send_state == SendState::sent);
+    CHECK(c->message(id, block)->sync_send_state == SendState::sending);
 
     // The sync copy fails, which says nothing about whether the message arrived.
     (*to_self)->callback(false, false, 500, {}, "nope");
-    CHECK(c->message(id, wait)->send_state == SendState::sent);
-    CHECK(c->message(id, wait)->sync_send_state == SendState::failed);
+    CHECK(c->message(id, block)->send_state == SendState::sent);
+    CHECK(c->message(id, block)->sync_send_state == SendState::failed);
 }
 
 TEST_CASE("Client: sending to ourselves stores once", "[client][send]") {
@@ -366,30 +367,30 @@ TEST_CASE("Client: sending to ourselves stores once", "[client][send]") {
     TestHelper::seed_pfs_nak(c->core, me);
 
     // Mirrors opening the conversation first, as a UI does, before sending into it.
-    auto convo = c->open_dm(ConversationId::dm(me), wait);
+    auto convo = c->open_dm(ConversationId::dm(me), block);
     CHECK(convo.id == ConversationId::dm(me));
 
-    auto id = c->send_message(ConversationId::dm(me), {.body = "note to self"}, wait);
-    CHECK(c->message(id, wait)->body == "note to self");
-    CHECK(preview_body(*c->conversation(ConversationId::dm(me), wait)) == "note to self");
+    auto id = c->send_message(ConversationId::dm(me), {.body = "note to self"}, block);
+    CHECK(c->message(id, block)->body == "note to self");
+    CHECK(preview_body(*c->conversation(ConversationId::dm(me), block)) == "note to self");
 
     // One store reaching the swarm, not two: our own swarm is the recipient's, so the sync copy
     // would be the same store twice.
     CHECK(accept_stores(*net) == 1);
 
     // One swarm, so one send: there is no separate sync copy to have a state for.
-    CHECK(c->message(id, wait)->send_state.has_value());
-    CHECK_FALSE(c->message(id, wait)->sync_send_state.has_value());
+    CHECK(c->message(id, block)->send_state.has_value());
+    CHECK_FALSE(c->message(id, block)->sync_send_state.has_value());
 
     // That single store went to our own swarm, so its hash is one worth keeping.
-    CHECK(c->message(id, wait)->hash == store_hash_for(oxenc::to_hex(me)));
-    CHECK(c->conversation(ConversationId::dm(me), wait)->messages(wait).size() == 1);
+    CHECK(c->message(id, block)->hash == store_hash_for(oxenc::to_hex(me)));
+    CHECK(c->conversation(ConversationId::dm(me), block)->messages(block).size() == 1);
 
     // ...and when our own swarm hands it straight back on the next poll, which is what note to self
     // does, it must recognise its own message rather than storing a second copy.  What makes that
     // work is the msgid: the copy coming back carries the one we generated when sending, which is
     // exactly what a hash of the two copies could not do.
-    auto ts = c->message(id, wait)->timestamp;
+    auto ts = c->message(id, block)->timestamp;
     auto msgid = c->core.loop().call_get([&] {
         return c->core.database().conn().prepared_get<int64_t>(
                 "SELECT msgid FROM messages WHERE id = ?", id);
@@ -409,5 +410,5 @@ TEST_CASE("Client: sending to ourselves stores once", "[client][send]") {
         return 0;
     });
 
-    CHECK(c->conversation(ConversationId::dm(me), wait)->messages(wait).size() == 1);
+    CHECK(c->conversation(ConversationId::dm(me), block)->messages(block).size() == 1);
 }

--- a/tests/test_client/volatile.cpp
+++ b/tests/test_client/volatile.cpp
@@ -16,11 +16,11 @@ TEST_CASE("Client: reading a conversation publishes the watermark", "[client][vo
     auto newest = recently(2s);
     deliver(*c, them, "one", recently(3s), "h1");
     deliver(*c, them, "two", newest, "h2");
-    REQUIRE(c->conversation(id, wait)->unread() == 2);
+    REQUIRE(c->conversation(id, block)->unread() == 2);
 
-    c->conversation(id, wait)->mark_read(wait);
+    c->conversation(id, block)->mark_read(block);
 
-    CHECK(c->conversation(id, wait)->unread() == 0);
+    CHECK(c->conversation(id, block)->unread() == 0);
     auto entry = c->core.configs.convo_info_volatile().get_1to1(hex);
     REQUIRE(entry);
     CHECK(entry->last_read == newest.time_since_epoch().count());
@@ -36,7 +36,7 @@ TEST_CASE("Client: a watermark from another device applies", "[client][volatile]
     auto older = recently(30s);
     deliver(*c, them, "one", older, "h1");
     deliver(*c, them, "two", recently(10s), "h2");
-    REQUIRE(c->conversation(id, wait)->unread() == 2);
+    REQUIRE(c->conversation(id, block)->unread() == 2);
 
     // Read up to the first message on another device.
     auto read = volatile_from_another_device(*c.client, [&](config::ConvoInfoVolatile& theirs) {
@@ -46,7 +46,7 @@ TEST_CASE("Client: a watermark from another device applies", "[client][volatile]
     });
     merge_volatile(*c.client, read);
 
-    CHECK(c->conversation(id, wait)->unread() == 1);
+    CHECK(c->conversation(id, block)->unread() == 1);
 }
 
 TEST_CASE("Client: a stale watermark cannot unread what we have read", "[client][volatile]") {
@@ -60,8 +60,8 @@ TEST_CASE("Client: a stale watermark cannot unread what we have read", "[client]
     auto newest = recently(10s);
     deliver(*c, them, "one", older, "h1");
     deliver(*c, them, "two", newest, "h2");
-    c->conversation(id, wait)->mark_read(wait);
-    REQUIRE(c->conversation(id, wait)->unread() == 0);
+    c->conversation(id, block)->mark_read(block);
+    REQUIRE(c->conversation(id, block)->unread() == 0);
 
     // The config permits a value to be written backwards on purpose, and a same-seqno conflict
     // resolves by a tie-break that knows nothing about which value is newer -- so an older one
@@ -73,7 +73,7 @@ TEST_CASE("Client: a stale watermark cannot unread what we have read", "[client]
     });
     merge_volatile(*c.client, stale);
 
-    CHECK(c->conversation(id, wait)->unread() == 0);
+    CHECK(c->conversation(id, block)->unread() == 0);
 
     // ...and we do not publish the stale value back out, either.
     TestHelper::sync_convo_volatile(*c.client, id);
@@ -90,18 +90,18 @@ TEST_CASE("Client: marking unread syncs, and reading clears it", "[client][volat
     approve(*c, them.session_id);
 
     deliver(*c, them, "one", recently(5s), "h1");
-    c->conversation(id, wait)->mark_read(wait);
-    REQUIRE(c->conversation(id, wait)->unread() == 0);
+    c->conversation(id, block)->mark_read(block);
+    REQUIRE(c->conversation(id, block)->unread() == 0);
 
-    c->conversation(id, wait)->set_marked_unread(true, wait);
+    c->conversation(id, block)->set_marked_unread(true, block);
 
     // Survives having read everything, which is the whole point of it.
-    CHECK(c->conversation(id, wait)->marked_unread());
-    CHECK(c->conversation(id, wait)->unread() == 0);
+    CHECK(c->conversation(id, block)->marked_unread());
+    CHECK(c->conversation(id, block)->unread() == 0);
     CHECK(c->core.configs.convo_info_volatile().get_1to1(hex)->unread);
 
-    c->conversation(id, wait)->mark_read(wait);
-    CHECK_FALSE(c->conversation(id, wait)->marked_unread());
+    c->conversation(id, block)->mark_read(block);
+    CHECK_FALSE(c->conversation(id, block)->marked_unread());
     CHECK_FALSE(c->core.configs.convo_info_volatile().get_1to1(hex)->unread);
 }
 
@@ -120,6 +120,6 @@ TEST_CASE("Client: read state for a conversation we do not have is ignored", "[c
     });
     merge_volatile(*c.client, orphan);
 
-    CHECK_FALSE(c->conversation(id, wait));
-    CHECK(c->conversations(wait).empty());
+    CHECK_FALSE(c->conversation(id, block));
+    CHECK(c->conversations(block).empty());
 }


### PR DESCRIPTION
POSIX declares `::wait` in <sys/wait.h>, so a translation unit that does `using namespace session::client;` and pulls in that header -- which macOS and glibc both make easy -- finds two `wait`s and can use neither:

    error: reference to 'wait' is ambiguous
    note: candidate found by name lookup is 'wait'
    note: candidate found by name lookup is 'session::client::wait'

There is no fix for that at namespace scope.  A using-declaration next to the using-directive is rejected outright ("target of using declaration conflicts with declaration already in scope"), and a using-directive in an inner namespace does not help, since it injects the name into the nearest namespace enclosing both -- the global one, where `::wait` already is. What is left is a block-scope using-declaration in every function that wants it, or qualifying every call site, and neither is something to ask of a client.

So the tag becomes `block_t`/`block`, and its doc block says why, so that the next reader does not rename it back.  The reason it is not a variable problem in the first place is that `wait` is an object: a function of that name would merge into an overload set with `::wait(int*)` and resolve by arity.