### PR TITLE
Fix pro-backend tests: Take the proof's version from the endpoint, not the response

### DIFF
--- a/include/session/session_protocol.hpp
+++ b/include/session/session_protocol.hpp
@@ -103,7 +103,10 @@ enum class ProStatus {
 
 class ProProof {
   public:
-    /// Version of the proof set by the Session Pro Backend
+    /// Format version of the proof.  It does not travel with the proof over the backend wire (the
+    /// endpoint that issued it fixes the format, and the domain prefix binds it into `sig`); it is
+    /// carried by the protobuf envelope a client attaches the proof to, which is where an offline
+    /// peer -- the only party that has to discover it -- can read it.
     std::uint8_t version;
 
     /// Opaque revocation tag identifying this proof (from the Session Pro backend)

--- a/src/pro_backend.cpp
+++ b/src/pro_backend.cpp
@@ -182,7 +182,12 @@ namespace {
     // Fills the common proof payload (add-payment and generate-proof both reply with exactly a
     // proof) from the already-extracted `result` object.
     void fill_proof(const nlohmann::json::object_t& result_obj, GenerateProProofResponse& result) {
-        result.proof.version = json::require<uint8_t>(result_obj, "version");
+        // Not on the wire (pro-wire-protocol.md §2): the proof's format version is bound into the
+        // signature by the domain prefix, and the endpoint we called picks the format -- a future
+        // proof version is served from a new endpoint, so a `version` we parsed back could only
+        // ever repeat what the request already decided. The offline peer that genuinely has to
+        // discover a version reads it from the protobuf envelope, not from here.
+        result.proof.version = ProProofVersion_v0;
         result.proof.expiry_at = json::require<std::chrono::sys_seconds>(result_obj, "expiry_ts");
         json::require_binary(result_obj, "revocation_tag", result.proof.revocation_tag);
         json::require_binary(result_obj, "rotating_pkey", result.proof.rotating_pubkey);

--- a/tests/test_pro_backend.cpp
+++ b/tests/test_pro_backend.cpp
@@ -144,7 +144,6 @@ TEST_CASE("Pro Backend C API", "[pro_backend]") {
             nlohmann::json j;
             j["status"] = "ok";
             j["result"] = {
-                    {"version", 0},
                     {"expiry_ts", unix_ts},
                     {"revocation_tag", oxenc::to_hex(fake_revocation_tag)},
                     {"rotating_pkey", oxenc::to_hex(rotating_pubkey.data)},


### PR DESCRIPTION
The backend stopped sending `"version": 0` on the proof response (session-pro-backend 2ce104a, on the dev branch our [pro_live] job tracks), and `fill_proof` required the key, so every proof fetch threw `Key 'version' is missing`. That is one line failing three CI cases: the full-flow case at both provider SECTIONs, and get_pro_revocations in its setup, which redeems a payment before it has a revocation to look at.

The field was telling us something we chose. A proof's format is fixed by the endpoint that issued it -- a future version is served from a new one -- and bound into `sig` by the domain prefix, so a version read back out of the response could only ever repeat what the request already decided. The party that must genuinely discover a version is an offline peer verifier, which never made this request and reads it from the protobuf envelope instead; session_protocol.cpp already checks it there.

So the version comes from ProProofVersion_v0, the way config/pro.cpp has always set it for the stored credential, and for the same reason.

ProProof::version stays: the envelope path is a real reader. Its doc comment claimed the backend set it, which was the thing that stopped being true.