### PR TITLE
Let a logger be taken back off

### DIFF
--- a/include/session/logging.hpp
+++ b/include/session/logging.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -10,6 +11,10 @@
 namespace spdlog::level {
 enum level_enum : int;
 }
+
+namespace oxen::log {
+class formatted_callback_sink;
+}  // namespace oxen::log
 
 namespace session {
 
@@ -45,6 +50,11 @@ inline const LogLevel LogLevel::warn{LOG_LEVEL_WARN};
 inline const LogLevel LogLevel::error{LOG_LEVEL_ERROR};
 inline const LogLevel LogLevel::critical{LOG_LEVEL_CRITICAL};
 
+/// A registered logger, as returned by `add_logger` and accepted by `remove_logger`.  The sink is
+/// only forward-declared, so spdlog stays out of this header: hold the handle, don't dereference
+/// it.
+using LoggerHandle = std::shared_ptr<oxen::log::formatted_callback_sink>;
+
 /// API: add_logger
 ///
 /// Adds a logger callback for oxen-logging log messages (such as from the network object).
@@ -56,9 +66,25 @@ inline const LogLevel LogLevel::critical{LOG_LEVEL_CRITICAL};
 ///     callback(std::string_view msg)
 ///     callback(std::string_view msg, std::string_view log_cat, LogLevel level)
 ///
-void add_logger(std::function<void(std::string_view msg)> cb);
-void add_logger(
+/// Outputs:
+/// - a handle naming this logger, for `remove_logger`.  Ignoring it is fine if the logger is
+///   meant to last as long as the process.
+LoggerHandle add_logger(std::function<void(std::string_view msg)> cb);
+LoggerHandle add_logger(
         std::function<void(std::string_view msg, std::string_view category, LogLevel level)> cb);
+
+/// API: session/remove_logger
+///
+/// Removes a logger added by `add_logger`.  Removing one that is not registered does nothing.
+///
+/// Logging is serialised against this, so once it returns the callback is neither running nor
+/// reachable, and whatever it captured can be destroyed.  That is the difference from
+/// `clear_loggers`, which drops every logger in the process including ones this caller does not
+/// own.
+///
+/// Inputs:
+/// - `logger` -- [in] the handle returned by `add_logger`.
+void remove_logger(const LoggerHandle& logger);
 
 /// API: session/logger_reset_level
 ///

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -24,12 +24,21 @@ std::string_view LogLevel::to_string() const {
     return log::to_string(spdlog_level());
 }
 
-void add_logger(std::function<void(std::string_view msg)> cb) {
-    log::add_sink(std::make_shared<log::formatted_callback_sink>(std::move(cb)));
+LoggerHandle add_logger(std::function<void(std::string_view msg)> cb) {
+    auto sink = std::make_shared<log::formatted_callback_sink>(std::move(cb));
+    log::add_sink(sink);
+    return sink;
 }
-void add_logger(
+LoggerHandle add_logger(
         std::function<void(std::string_view msg, std::string_view category, LogLevel level)> cb) {
-    log::add_sink(std::make_shared<log::formatted_callback_sink>(std::move(cb)));
+    auto sink = std::make_shared<log::formatted_callback_sink>(std::move(cb));
+    log::add_sink(sink);
+    return sink;
+}
+
+void remove_logger(const LoggerHandle& logger) {
+    if (logger)
+        log::remove_sink(logger);
 }
 
 void manual_log(std::string_view msg) {


### PR DESCRIPTION
Depends on session-foundation/liblogging#1, which adds the `oxen::log::remove_sink` this calls.

## The problem

`add_logger` builds a `formatted_callback_sink` around the caller's callback, hands it to
`add_sink`, and throws away the only reference to it:

```cpp
void add_logger(std::function<void(std::string_view msg)> cb) {
    log::add_sink(std::make_shared<log::formatted_callback_sink>(std::move(cb)));
}
```

So the callback can never be retired. `clear_loggers` is the only way out and it drops every logger
in the process, including ones this caller does not own.

A consumer whose callback captures anything shorter-lived than the process is then left with a
registered callback pointing at freed memory. That is concrete rather than hypothetical: session-app
has a bridge that can be closed and reopened, and libsession logs from network threads its teardown
cannot join. It ended up holding the bridge through a `weak_ptr` purely so that a log line arriving
after close finds a dead pointer it can check rather than freed memory it cannot.

## The change

```cpp
LoggerHandle add_logger(std::function<void(std::string_view msg)> cb);
void remove_logger(const LoggerHandle& logger);
```

- `LoggerHandle` is `std::shared_ptr<oxen::log::formatted_callback_sink>` with the sink only
  forward-declared: the type has to be complete to dereference it, not to hold it. So spdlog stays
  out of the public header - which today keeps it out with a forward declaration of
  `spdlog::level::level_enum` - and the handle still names one type, so an unrelated `shared_ptr`
  cannot be handed to `remove_logger`.
- Removal is serialised against logging by the master sink, so once `remove_logger` returns the
  callback is neither running nor reachable and what it captured can be destroyed. That is the
  property a caller needs, and the reason this is worth having over "stop calling us".

## ABI

`add_logger`'s return type changes from `void`. Source-compatible - callers that ignore it still
compile - but the mangled symbol is unchanged while the calling convention is not, so a consumer
linking a prebuilt library against an old header would be wrong in a way the linker will not catch.
Everything I know of vendors libsession as a submodule and builds it with the application, so this
should have no victim, but it is the reviewer's call and I am happy to add a separately named
function instead.

The C API is untouched. It never exposed removal, and adding it needs an opaque handle of its own.

## Verified

Built against liblogging's `remove-sink` branch: 245/246 targets, no warnings from these files, and
`testLogging` passes. The one target that does not link, `static-bundle-test`, does not link before
this change either - its link line is missing SQLiteCpp.

Targeted `client` rather than `dev` because `client` is 434 commits ahead and `dev` has nothing it
lacks.
